### PR TITLE
Switch ActiveWorkorder to be backwards compatible

### DIFF
--- a/client/csharp-api/api.cs
+++ b/client/csharp-api/api.cs
@@ -5694,9 +5694,8 @@ namespace BlackMaple.FMSInsight.API
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.IDictionary<string, System.TimeSpan> ActiveStationTime { get; set; } = new System.Collections.Generic.Dictionary<string, System.TimeSpan>();
 
-        [Newtonsoft.Json.JsonProperty("Serials", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.IDictionary<string, WorkorderSerialStatus> Serials { get; set; } = new System.Collections.Generic.Dictionary<string, WorkorderSerialStatus>();
+        [Newtonsoft.Json.JsonProperty("Material", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<WorkorderMaterial> Material { get; set; }
 
     }
 
@@ -5714,8 +5713,14 @@ namespace BlackMaple.FMSInsight.API
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class WorkorderSerialStatus
+    public partial class WorkorderMaterial
     {
+        [Newtonsoft.Json.JsonProperty("MaterialID", Required = Newtonsoft.Json.Required.Always)]
+        public long MaterialID { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("Serial", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Serial { get; set; }
+
         [Newtonsoft.Json.JsonProperty("Quarantined", Required = Newtonsoft.Json.Required.Always)]
         public bool Quarantined { get; set; }
 

--- a/client/insight/src/cell-status/material-details.ts
+++ b/client/insight/src/cell-status/material-details.ts
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { JobsBackend, LogBackend, OtherLogBackends, FmsServerBackend } from "../network/backend.js";
 import { LazySeq } from "@seedtactics/immutable-collections";
-import { MaterialSummary } from "./material-summary.js";
 import {
   IInProcessMaterial,
   ILogEntry,
@@ -52,9 +51,16 @@ import { atom, useSetAtom } from "jotai";
 import { loadable } from "jotai/utils";
 import { isLogEntryInvalidated } from "../components/LogEntry.js";
 
+export type MaterialToShowInfo = {
+  readonly materialID: number;
+  readonly partName: string;
+  readonly serial?: string;
+  readonly workorderId?: string;
+};
+
 export type MaterialToShow =
   | { readonly type: "InProcMat"; readonly inproc: Readonly<IInProcessMaterial> }
-  | { readonly type: "MatSummary"; readonly summary: Readonly<MaterialSummary> }
+  | { readonly type: "MatSummary"; readonly summary: MaterialToShowInfo }
   | { readonly type: "MatDetails"; readonly details: Readonly<IMaterialDetails> }
   | { readonly type: "LogMat"; readonly logMat: Readonly<ILogMaterial> }
   | { readonly type: "Barcode"; readonly barcode: string }
@@ -88,14 +94,6 @@ export const barcodeMaterialDetail = atom<Promise<Readonly<IScannedMaterial> | n
   }
 });
 
-export interface MaterialToShowInfo {
-  readonly materialID: number;
-  readonly jobUnique: string;
-  readonly partName: string;
-  readonly serial?: string;
-  readonly workorderId?: string;
-}
-
 export const materialInDialogInfo = atom<Promise<MaterialToShowInfo | null>>(async (get) => {
   const curMat = get(matToShow);
   if (curMat === null) return null;
@@ -105,14 +103,10 @@ export const materialInDialogInfo = atom<Promise<MaterialToShowInfo | null>>(asy
     case "MatSummary":
       return curMat.summary;
     case "MatDetails":
-      return {
-        ...curMat.details,
-        jobUnique: curMat.details.jobUnique ?? "",
-      };
+      return curMat.details;
     case "LogMat":
       return {
         materialID: curMat.logMat.id,
-        jobUnique: curMat.logMat.uniq,
         partName: curMat.logMat.part,
         serial: curMat.logMat.serial,
         workorderId: curMat.logMat.workorder,
@@ -120,15 +114,14 @@ export const materialInDialogInfo = atom<Promise<MaterialToShowInfo | null>>(asy
     case "Barcode": {
       const mat = await get(barcodeMaterialDetail);
       if (mat?.existingMaterial && mat.existingMaterial.materialID >= 0) {
-        return { ...mat.existingMaterial, jobUnique: mat.existingMaterial.jobUnique ?? "" };
+        return mat.existingMaterial;
       } else {
         return null;
       }
     }
     case "ManuallyEnteredSerial":
     case "AddMatWithEnteredSerial": {
-      const mat = (await LogBackend.materialForSerial(curMat.serial))?.[0] ?? null;
-      return mat ? { ...mat, jobUnique: mat.jobUnique ?? "" } : null;
+      return (await LogBackend.materialForSerial(curMat.serial))?.[0] ?? null;
     }
   }
 });
@@ -279,13 +272,7 @@ export const materialInDialogInspections = atom<MaterialToShowInspections>((get)
     return { signaledInspections: [], completedInspections: [] };
   }
 
-  const inspTypes = new Set<string>(
-    curMat.type === "MatSummary"
-      ? curMat.summary.signaledInspections
-      : curMat.type === "InProcMat"
-        ? curMat.inproc.signaledInspections
-        : [],
-  );
+  const inspTypes = new Set<string>(curMat.type === "InProcMat" ? curMat.inproc.signaledInspections : []);
   const completedTypes = new Set<string>();
 
   evts.forEach((e) => {
@@ -351,14 +338,7 @@ export function useForceInspection(): [(data: ForceInspectionData) => void, bool
   const callback = useCallback(
     (data: ForceInspectionData) => {
       setUpdating(true);
-      LogBackend.setInspectionDecision(
-        data.mat.materialID,
-        data.inspType,
-        1,
-        data.inspect,
-        data.mat.jobUnique,
-        data.mat.partName,
-      )
+      LogBackend.setInspectionDecision(data.mat.materialID, data.inspType, 1, data.inspect)
         .then((evt) => setExtraLogEvts((evts) => [...evts, evt]))
         .catch(console.log)
         .finally(() => setUpdating(false));
@@ -391,8 +371,6 @@ export function useCompleteInspection(): [(data: CompleteInspectionData) => void
         elapsed: "PT0S",
         extraData: data.operator ? { operator: data.operator } : undefined,
       }),
-      data.mat.jobUnique,
-      data.mat.partName,
     )
       .catch(console.log)
       .finally(() => setUpdating(false));
@@ -422,8 +400,6 @@ export function useCompleteCloseout(): [(d: CompleteCloseoutData) => void, boole
         extraData: d.operator ? { operator: d.operator } : undefined,
         failed: d.failed,
       }),
-      d.mat.jobUnique,
-      d.mat.partName,
     )
       .catch(console.log)
       .finally(() => setUpdating(false));
@@ -438,7 +414,7 @@ export function useAssignWorkorder(): [(mat: MaterialToShowInfo, workorder: stri
   const callback = useCallback(
     (mat: MaterialToShowInfo, workorder: string) => {
       setUpdating(true);
-      LogBackend.setWorkorder(mat.materialID, 1, workorder, mat.jobUnique, mat.partName)
+      LogBackend.setWorkorder(mat.materialID, 1, workorder)
         .then((evt) => setExtraLogEvts((evts) => [...evts, evt]))
         .catch(console.log)
         .finally(() => setUpdating(false));

--- a/client/insight/src/components/analysis/InspectionDataTable.tsx
+++ b/client/insight/src/components/analysis/InspectionDataTable.tsx
@@ -191,13 +191,9 @@ export default memo(function InspDataTable(props: InspectionDataTableProps) {
                               type: "MatSummary",
                               summary: {
                                 materialID: row.materialID,
-                                jobUnique: "",
                                 partName: row.partName,
-                                startedProcess1: true,
                                 serial: row.serial,
                                 workorderId: row.workorder,
-                                signaledInspections: [],
-                                quarantineAfterUnload: null,
                               },
                             })
                     }

--- a/client/insight/src/components/quality/RecentFailedInspections.tsx
+++ b/client/insight/src/components/quality/RecentFailedInspections.tsx
@@ -128,12 +128,8 @@ function RecentFailedTable(props: RecentFailedInspectionsProps) {
                     summary: {
                       materialID: row.materialID,
                       partName: row.part,
-                      jobUnique: "",
                       serial: row.serial,
                       workorderId: row.workorder,
-                      startedProcess1: true,
-                      signaledInspections: [],
-                      quarantineAfterUnload: null,
                     },
                   });
                 }

--- a/client/insight/src/components/station-monitor/JobDetails.tsx
+++ b/client/insight/src/components/station-monitor/JobDetails.tsx
@@ -225,16 +225,7 @@ function JobMaterial(props: JobMaterialProps) {
                   onClick={() =>
                     setMatToShow({
                       type: "MatSummary",
-                      summary: props.matsFromEvents.get(mat.materialID) ?? {
-                        materialID: mat.materialID,
-                        jobUnique: mat.jobUnique ?? "",
-                        partName: mat.partName ?? "",
-                        startedProcess1: false,
-                        serial: mat.serial,
-                        workorderId: mat.workorderId,
-                        signaledInspections: [],
-                        quarantineAfterUnload: null,
-                      },
+                      summary: mat,
                     })
                   }
                   size="large"

--- a/client/insight/src/data/queue-material.ts
+++ b/client/insight/src/data/queue-material.ts
@@ -137,7 +137,7 @@ function workorderDetailForCasting(
 
   if (!workorder) return null;
 
-  return `Started: ${LazySeq.ofObject(workorder.serials).length()}; Planned: ${workorder.plannedQuantity}`;
+  return `Started: ${workorder.material?.length ?? 0}; Planned: ${workorder.plannedQuantity}`;
 }
 
 function possibleCastings(

--- a/client/insight/src/network/backend-mock.ts
+++ b/client/insight/src/network/backend-mock.ts
@@ -160,6 +160,12 @@ async function loadEventsJson(
     );
 }
 
+function findMatById(evts: ReadonlyArray<api.ILogEntry>, matId: number): api.LogMaterial | undefined {
+  return LazySeq.of(evts)
+    .flatMap((e) => e.material)
+    .find((m) => m.id === matId);
+}
+
 export function registerMockBackend(
   offsetSeconds: number,
   mockD: Promise<MockData>,
@@ -238,7 +244,7 @@ export function registerMockBackend(
           dueDate: w.dueDate,
           priority: w.priority,
           completedQuantity: 0,
-          serials: {},
+          material: [],
           elapsedStationTime: {},
           activeStationTime: {},
         }));
@@ -343,25 +349,25 @@ export function registerMockBackend(
       ];
     },
 
-    setInspectionDecision(
+    async setInspectionDecision(
       materialID: number,
       inspType: string,
       process: number,
       inspect: boolean,
-      jobUnique?: string,
-      partName?: string,
     ): Promise<Readonly<api.ILogEntry>> {
-      const mat = new api.LogMaterial({
-        id: materialID,
-        uniq: jobUnique || "",
-        part: partName || "",
-        proc: process,
-        numproc: 1,
-        face: 1,
-      });
+      const evtMat =
+        findMatById(await events, materialID) ??
+        new api.LogMaterial({
+          id: materialID,
+          uniq: "",
+          part: "",
+          proc: process,
+          numproc: 1,
+          face: 1,
+        });
       const evt = {
         counter: 0,
-        material: [mat],
+        material: [evtMat],
         pal: 0,
         type: api.LogType.Inspection,
         startofcycle: false,
@@ -383,22 +389,20 @@ export function registerMockBackend(
         }),
       );
     },
-    recordInspectionCompleted(
-      insp: api.NewInspectionCompleted,
-      jobUnique?: string,
-      partName?: string,
-    ): Promise<Readonly<api.ILogEntry>> {
-      const mat = new api.LogMaterial({
-        id: insp.materialID,
-        uniq: jobUnique || "",
-        part: partName || "",
-        proc: insp.process,
-        numproc: 1,
-        face: 1,
-      });
+    async recordInspectionCompleted(insp: api.NewInspectionCompleted): Promise<Readonly<api.ILogEntry>> {
+      const evtMat =
+        findMatById(await events, insp.materialID) ??
+        new api.LogMaterial({
+          id: insp.materialID,
+          uniq: "",
+          part: "",
+          proc: insp.process,
+          numproc: 1,
+          face: 1,
+        });
       const evt: api.ILogEntry = {
         counter: 0,
-        material: [mat],
+        material: [evtMat],
         pal: 0,
         type: api.LogType.InspectionResult,
         startofcycle: false,
@@ -418,22 +422,20 @@ export function registerMockBackend(
         }),
       );
     },
-    recordCloseoutCompleted(
-      closeout: api.NewCloseout,
-      jobUnique?: string,
-      partName?: string,
-    ): Promise<Readonly<api.ILogEntry>> {
-      const mat = new api.LogMaterial({
-        id: closeout.materialID,
-        uniq: jobUnique || "",
-        part: partName || "",
-        proc: closeout.process,
-        numproc: 1,
-        face: 1,
-      });
+    async recordCloseoutCompleted(closeout: api.NewCloseout): Promise<Readonly<api.ILogEntry>> {
+      const evtMat =
+        findMatById(await events, closeout.materialID) ??
+        new api.LogMaterial({
+          id: closeout.materialID,
+          uniq: "",
+          part: "",
+          proc: closeout.process,
+          numproc: 1,
+          face: 1,
+        });
       const evt: api.ILogEntry = {
         counter: 0,
-        material: [mat],
+        material: [evtMat],
         pal: 0,
         type: api.LogType.CloseOut,
         startofcycle: false,
@@ -453,24 +455,24 @@ export function registerMockBackend(
         }),
       );
     },
-    setWorkorder(
+    async setWorkorder(
       materialID: number,
       process: number,
       workorder: string,
-      jobUnique?: string,
-      partName?: string,
     ): Promise<Readonly<api.ILogEntry>> {
-      const mat = new api.LogMaterial({
-        id: materialID,
-        uniq: jobUnique || "",
-        part: partName || "",
-        proc: process,
-        numproc: 1,
-        face: 1,
-      });
+      const evtMat =
+        findMatById(await events, materialID) ??
+        new api.LogMaterial({
+          id: materialID,
+          uniq: "",
+          part: "",
+          proc: process,
+          numproc: 1,
+          face: 1,
+        });
       const evt: api.ILogEntry = {
         counter: 0,
-        material: [mat],
+        material: [evtMat],
         pal: 0,
         type: api.LogType.OrderAssignment,
         startofcycle: false,

--- a/client/insight/src/network/backend.ts
+++ b/client/insight/src/network/backend.ts
@@ -110,26 +110,10 @@ export interface LogAPI {
     inspType: string,
     process: number,
     inspect: boolean,
-    jobUnique?: string,
-    partName?: string,
   ): Promise<Readonly<api.ILogEntry>>;
-  recordInspectionCompleted(
-    insp: api.NewInspectionCompleted,
-    jobUnique?: string,
-    partName?: string,
-  ): Promise<Readonly<api.ILogEntry>>;
-  recordCloseoutCompleted(
-    insp: api.NewCloseout,
-    jobUnique?: string,
-    partName?: string,
-  ): Promise<Readonly<api.ILogEntry>>;
-  setWorkorder(
-    materialID: number,
-    process: number,
-    workorder: string,
-    jobUnique?: string,
-    partName?: string,
-  ): Promise<Readonly<api.ILogEntry>>;
+  recordInspectionCompleted(insp: api.NewInspectionCompleted): Promise<Readonly<api.ILogEntry>>;
+  recordCloseoutCompleted(insp: api.NewCloseout): Promise<Readonly<api.ILogEntry>>;
+  setWorkorder(materialID: number, process: number, workorder: string): Promise<Readonly<api.ILogEntry>>;
   recordOperatorNotes(
     materialID: number,
     process: number,

--- a/server/debug-mock/sample-data/status-mock.json
+++ b/server/debug-mock/sample-data/status-mock.json
@@ -1344,18 +1344,22 @@
       "CompletedQuantity": 8,
       "SimulatedStartUTC": "2023-05-19T22:00:00Z",
       "SimulatedFilledUTC": "2023-05-27T03:00:00Z",
-      "Serials": {
-        "00000000aa": {
+      "Material": [
+        {
+          "MaterialID": 630,
+          "Serial": "00000000aa",
           "Quarantined": false,
           "InspectionFailed": true,
           "Closeout": "None"
         },
-        "00000000ab": {
+        {
+          "MaterialID": 631,
+          "Serial": "00000000ab",
           "Quarantined": true,
           "InspectionFailed": false,
           "Closeout": "None"
         }
-      },
+      ],
       "ElapsedStationTime": {
         "MC": "PT10M",
         "L/U": "PT8M"
@@ -1384,23 +1388,29 @@
       "CompletedQuantity": 4,
       "SimulatedStartUTC": "2023-05-19T22:00:00Z",
       "SimulatedFilledUTC": "2023-05-27T03:00:00Z",
-      "Serials": {
-        "00000000ccc": {
+      "Material": [
+        {
+          "MaterialID": 756,
+          "Serial": "00000000cc",
           "Quarantined": false,
           "InspectionFailed": true,
           "Closeout": "ClosedOut"
         },
-        "00000000dd": {
+        {
+          "MaterialID": 819,
+          "Serial": "00000000dd",
           "Quarantined": true,
           "InspectionFailed": false,
           "Closeout": "None"
         },
-        "00000000ee": {
+        {
+          "MaterialID": 882,
+          "Serial": "00000000ee",
           "Quarantined": false,
           "InspectionFailed": false,
           "Closeout": "CloseOutFailed"
         }
-      },
+      ],
       "ElapsedStationTime": {
         "MC": "PT10M",
         "L/U": "PT8M"
@@ -1419,18 +1429,21 @@
       "CompletedQuantity": 12,
       "SimulatedStartUTC": "2023-05-20T11:00:00Z",
       "SimulatedFilledUTC": "2023-06-02T14:00:00Z",
-      "Serials": {
-        "00000000bb": {
+      "Material": [
+        {
+          "MaterialID": 694,
+          "Serial": "00000000bc",
           "Quarantined": false,
           "InspectionFailed": false,
           "Closeout": "None"
         },
-        "00000000bc": {
+        {
+          "MaterialID": 695,
           "Quarantined": false,
           "InspectionFailed": true,
           "Closeout": "None"
         }
-      },
+      ],
       "ElapsedStationTime": {
         "MC": "PT4M",
         "L/U": "PT55M"

--- a/server/fms-insight-api.json
+++ b/server/fms-insight-api.json
@@ -3497,8 +3497,7 @@
           "Priority",
           "CompletedQuantity",
           "ElapsedStationTime",
-          "ActiveStationTime",
-          "Serials"
+          "ActiveStationTime"
         ],
         "properties": {
           "WorkorderId": {
@@ -3554,10 +3553,11 @@
               "format": "duration"
             }
           },
-          "Serials": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/WorkorderSerialStatus"
+          "Material": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/WorkorderMaterial"
             }
           }
         }
@@ -3579,15 +3579,24 @@
           }
         }
       },
-      "WorkorderSerialStatus": {
+      "WorkorderMaterial": {
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "MaterialID",
           "Quarantined",
           "InspectionFailed",
           "Closeout"
         ],
         "properties": {
+          "MaterialID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Serial": {
+            "type": "string",
+            "nullable": true
+          },
           "Quarantined": {
             "type": "boolean"
           },

--- a/server/lib/BlackMaple.MachineFramework/api/Workorders.cs
+++ b/server/lib/BlackMaple.MachineFramework/api/Workorders.cs
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System;
 using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 
 namespace BlackMaple.MachineFramework
 {
@@ -72,8 +73,10 @@ namespace BlackMaple.MachineFramework
     CloseOutFailed
   }
 
-  public record WorkorderSerialStatus
+  public record WorkorderMaterial
   {
+    public required long MaterialID { get; init; }
+    public string? Serial { get; init; }
     public required bool Quarantined { get; init; }
     public required bool InspectionFailed { get; init; }
     public required WorkorderSerialCloseout Closeout { get; init; }
@@ -106,6 +109,12 @@ namespace BlackMaple.MachineFramework
 
     public required ImmutableDictionary<string, TimeSpan> ActiveStationTime { get; init; }
 
-    public required ImmutableDictionary<string, WorkorderSerialStatus> Serials { get; init; }
+    public ImmutableList<WorkorderMaterial>? Material { get; init; }
+
+    [
+      Obsolete("Use Material instead, serials is written to the JSON for backwards compatibility"),
+      JsonInclude
+    ]
+    protected ImmutableList<object> Serials => [];
   }
 }

--- a/server/test/JobDBSpec.cs
+++ b/server/test/JobDBSpec.cs
@@ -1301,7 +1301,7 @@ namespace MachineWatchTest
               CompletedQuantity = 0,
               DueDate = initialWorks[0].DueDate,
               Priority = initialWorks[0].Priority,
-              Serials = ImmutableDictionary<string, WorkorderSerialStatus>.Empty,
+              Material = [],
               ElapsedStationTime = ImmutableDictionary<string, TimeSpan>.Empty,
               ActiveStationTime = ImmutableDictionary<string, TimeSpan>.Empty,
               SimulatedStart = initialWorks[0].SimulatedStart,

--- a/server/test/JobDBSpec.cs
+++ b/server/test/JobDBSpec.cs
@@ -1301,7 +1301,6 @@ namespace MachineWatchTest
               CompletedQuantity = 0,
               DueDate = initialWorks[0].DueDate,
               Priority = initialWorks[0].Priority,
-              Material = [],
               ElapsedStationTime = ImmutableDictionary<string, TimeSpan>.Empty,
               ActiveStationTime = ImmutableDictionary<string, TimeSpan>.Empty,
               SimulatedStart = initialWorks[0].SimulatedStart,

--- a/server/test/JobLogTest.cs
+++ b/server/test/JobLogTest.cs
@@ -1741,25 +1741,25 @@ namespace MachineWatchTest
           DueDate = work1part1.DueDate,
           Priority = work1part1.Priority,
           CompletedQuantity = 2, // mat1 and mat3
-          Serials = ImmutableDictionary<string, WorkorderSerialStatus>
-            .Empty.Add(
-              "serial1",
-              new WorkorderSerialStatus()
-              {
-                Quarantined = false,
-                InspectionFailed = false,
-                Closeout = WorkorderSerialCloseout.ClosedOut
-              }
-            )
-            .Add(
-              "serial3",
-              new WorkorderSerialStatus()
-              {
-                Quarantined = false,
-                InspectionFailed = true,
-                Closeout = WorkorderSerialCloseout.None
-              }
-            ),
+          Material =
+          [
+            new WorkorderMaterial()
+            {
+              MaterialID = mat1_proc2.MaterialID,
+              Serial = "serial1",
+              Quarantined = false,
+              InspectionFailed = false,
+              Closeout = WorkorderSerialCloseout.ClosedOut
+            },
+            new WorkorderMaterial()
+            {
+              MaterialID = mat3.MaterialID,
+              Serial = "serial3",
+              Quarantined = false,
+              InspectionFailed = true,
+              Closeout = WorkorderSerialCloseout.None
+            }
+          ],
           Comments = null,
           ElapsedStationTime = ImmutableDictionary<string, TimeSpan>
             .Empty.Add("MC", TimeSpan.FromMinutes(10 + 30 + 3 * 1 / c2Cnt)) //10 + 30 from mat1, 3*1/4 for mat3
@@ -1782,15 +1782,17 @@ namespace MachineWatchTest
           DueDate = work1part2.DueDate,
           Priority = work1part2.Priority,
           CompletedQuantity = 1,
-          Serials = ImmutableDictionary<string, WorkorderSerialStatus>.Empty.Add(
-            "serial4",
-            new WorkorderSerialStatus()
+          Material =
+          [
+            new WorkorderMaterial()
             {
+              MaterialID = mat4.MaterialID,
+              Serial = "serial4",
               Quarantined = false,
               InspectionFailed = false,
               Closeout = WorkorderSerialCloseout.None
             }
-          ),
+          ],
           Comments = null,
           ElapsedStationTime = ImmutableDictionary<string, TimeSpan>
             .Empty.Add("MC", TimeSpan.FromMinutes(3 * 1 / c2Cnt))
@@ -1809,25 +1811,25 @@ namespace MachineWatchTest
           DueDate = work2.DueDate,
           Priority = work2.Priority,
           CompletedQuantity = 2,
-          Serials = ImmutableDictionary<string, WorkorderSerialStatus>
-            .Empty.Add(
-              "serial5",
-              new WorkorderSerialStatus()
-              {
-                Quarantined = true,
-                InspectionFailed = false,
-                Closeout = WorkorderSerialCloseout.CloseOutFailed
-              }
-            )
-            .Add(
-              "serial6",
-              new WorkorderSerialStatus()
-              {
-                Quarantined = false,
-                InspectionFailed = false,
-                Closeout = WorkorderSerialCloseout.None
-              }
-            ),
+          Material =
+          [
+            new WorkorderMaterial()
+            {
+              MaterialID = mat5.MaterialID,
+              Serial = "serial5",
+              Quarantined = true,
+              InspectionFailed = false,
+              Closeout = WorkorderSerialCloseout.CloseOutFailed
+            },
+            new WorkorderMaterial()
+            {
+              MaterialID = mat6.MaterialID,
+              Serial = "serial6",
+              Quarantined = false,
+              InspectionFailed = false,
+              Closeout = WorkorderSerialCloseout.None
+            }
+          ],
           Comments = null,
           ElapsedStationTime = ImmutableDictionary<string, TimeSpan>
             .Empty.Add("MC", TimeSpan.FromMinutes(3 * 2 / c2Cnt))


### PR DESCRIPTION
The clients read CurrentStatus which includes ActiveWorkorder, so don't reuse serial, instead put it into a new property called Material