### PR TITLE
Add ArtifactRunDate to FMS Insight Jobs

### DIFF
--- a/client/insight/src/cell-status/__snapshots__/jobs.test.ts.snap
+++ b/client/insight/src/cell-status/__snapshots__/jobs.test.ts.snap
@@ -5,6 +5,7 @@ Map {
   "xxx-3offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -112,6 +113,7 @@ Map {
   "xxx-3offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -215,6 +217,7 @@ Map {
   "aaa-0offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -454,6 +457,7 @@ Map {
   "zzz-5offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -561,6 +565,7 @@ Map {
   "ccc-2offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -792,6 +797,7 @@ Map {
   "zzz-5offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -908,6 +914,7 @@ Map {
   "xxx-3offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -1016,6 +1023,7 @@ Map {
   "ccc-2offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -1239,6 +1247,7 @@ Map {
   "bbb-1offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -1536,6 +1545,7 @@ Map {
   "bbb-1offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -1776,6 +1786,7 @@ Map {
   "xxx-3offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -1874,6 +1885,7 @@ Map {
   "ccc-2offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -2097,6 +2109,7 @@ Map {
   "aaa-0offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -2336,6 +2349,7 @@ Map {
   "ccc-2offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -2568,6 +2582,7 @@ Map {
   "yyy-4offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -2675,6 +2690,7 @@ Map {
   "yyy-4offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -2790,6 +2806,7 @@ Map {
   "bbb-1offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -3071,6 +3088,7 @@ Map {
   "aaa-0offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -3349,6 +3367,7 @@ Map {
   "zzz-5offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -3458,6 +3477,7 @@ Map {
   "zzz-5offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -3570,6 +3590,7 @@ Map {
   "xxx-3offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -3669,6 +3690,7 @@ Map {
   "zzz-5offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -3777,6 +3799,7 @@ Map {
   "ccc-2offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -3991,6 +4014,7 @@ Map {
   "yyy-4offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -4099,6 +4123,7 @@ Map {
   "yyy-4offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -4207,6 +4232,7 @@ Map {
   "yyy-4offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -4317,6 +4343,7 @@ Map {
   "yyy-4offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -4424,6 +4451,7 @@ Map {
   "yyy-4offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -4530,6 +4558,7 @@ Map {
   "bbb-1offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -4812,6 +4841,7 @@ Map {
   "bbb-1offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -5102,6 +5132,7 @@ Map {
   "zzz-5offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -5210,6 +5241,7 @@ Map {
   "aaa-0offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -5473,6 +5505,7 @@ Map {
   "ccc-2offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -5703,6 +5736,7 @@ Map {
   "xxx-3offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -5802,6 +5836,7 @@ Map {
   "ccc-2offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -6017,6 +6052,7 @@ Map {
   "xxx-3offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -6129,6 +6165,7 @@ Map {
   "xxx-3offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -6236,6 +6273,7 @@ Map {
   "zzz-5offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -6348,6 +6386,7 @@ Map {
   "yyy-4offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -6458,6 +6497,7 @@ Map {
   "xxx-3offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -6580,6 +6620,7 @@ Map {
   "aaa-0offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -6842,6 +6883,7 @@ Map {
   "ccc-2offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -7072,6 +7114,7 @@ Map {
   "zzz-5offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -7181,6 +7224,7 @@ Map {
   "ccc-2offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -7397,6 +7441,7 @@ Map {
   "xxx-3offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -7543,6 +7588,7 @@ Map {
   "yyy-4offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -7650,6 +7696,7 @@ Map {
   "zzz-5offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -7761,6 +7808,7 @@ Map {
   "ccc-2offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -7984,6 +8032,7 @@ Map {
   "zzz-5offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -8075,6 +8124,7 @@ Map {
   "yyy-4offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -27029,6 +27079,7 @@ Map {
   "yyy-4offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -27140,6 +27191,7 @@ Map {
   "bbb-1offline-2018-01-24" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-14",
       "ccc-11",
@@ -27411,6 +27463,7 @@ Map {
   "yyy-4offline-2018-01-18" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-10",
       "bbb-10",
@@ -27517,6 +27570,7 @@ Map {
   "aaa-0offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -27763,6 +27817,7 @@ Map {
   "aaa-0offline-2018-01-25" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-14",
       "aaa-15",
@@ -28058,6 +28113,7 @@ Map {
   "zzz-5offline-2018-01-20" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-11",
       "ccc-9",
@@ -28166,6 +28222,7 @@ Map {
   "bbb-1offline-2018-01-28" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-17",
       "bbb-18",
@@ -28462,6 +28519,7 @@ Map {
   "zzz-5offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -28573,6 +28631,7 @@ Map {
   "zzz-5offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -28672,6 +28731,7 @@ Map {
   "xxx-3offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -28783,6 +28843,7 @@ Map {
   "xxx-3offline-2018-01-18" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-10",
       "bbb-10",
@@ -28945,6 +29006,7 @@ Map {
   "aaa-0offline-2018-01-18" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-10",
       "bbb-10",
@@ -29167,6 +29229,7 @@ Map {
   "ccc-2offline-2018-01-26" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-16",
       "bbb-16",
@@ -29452,6 +29515,7 @@ Map {
   "ccc-2offline-2018-01-23" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-13",
       "bbb-15",
@@ -29714,6 +29778,7 @@ Map {
   "ccc-2offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -29944,6 +30009,7 @@ Map {
   "aaa-0offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -30151,6 +30217,7 @@ Map {
   "ccc-2offline-2018-01-21" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-12",
       "xxx-16",
@@ -30371,6 +30438,7 @@ Map {
   "zzz-4offline-2018-01-24" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-14",
       "ccc-11",
@@ -30469,6 +30537,7 @@ Map {
   "zzz-4offline-2018-01-29" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-19",
       "ccc-21",
@@ -30574,6 +30643,7 @@ Map {
   "bbb-1offline-2018-01-22" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-12",
       "aaa-13",
@@ -30719,6 +30789,7 @@ Map {
   "ccc-2offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -30941,6 +31012,7 @@ Map {
   "xxx-3offline-2018-01-24" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-14",
       "ccc-11",
@@ -31082,6 +31154,7 @@ Map {
   "xxx-3offline-2018-01-29" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-19",
       "ccc-21",
@@ -31218,6 +31291,7 @@ Map {
   "aaa-0offline-2018-01-27" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-17",
       "ccc-17",
@@ -31399,6 +31473,7 @@ Map {
   "aaa-0offline-2018-01-30" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-19",
       "bbb-26",
@@ -31604,6 +31679,7 @@ Map {
   "zzz-5offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -31716,6 +31792,7 @@ Map {
   "ccc-2offline-2018-01-24" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-14",
       "ccc-11",
@@ -31969,6 +32046,7 @@ Map {
   "yyy-4offline-2018-01-20" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-11",
       "ccc-9",
@@ -32076,6 +32154,7 @@ Map {
   "bbb-1offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -32356,6 +32435,7 @@ Map {
   "zzz-5offline-2018-01-17" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-18",
       "aaa-9",
@@ -32448,6 +32528,7 @@ Map {
   "bbb-1offline-2018-01-18" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-10",
       "bbb-10",
@@ -32624,6 +32705,7 @@ Map {
   "ccc-2offline-2018-01-25" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-14",
       "aaa-15",
@@ -32895,6 +32977,7 @@ Map {
   "zzz-4offline-2018-01-25" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-14",
       "aaa-15",
@@ -32995,6 +33078,7 @@ Map {
   "bbb-1offline-2018-01-26" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-16",
       "bbb-16",
@@ -33218,6 +33302,7 @@ Map {
   "bbb-1offline-2018-01-23" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-13",
       "bbb-15",
@@ -33546,6 +33631,7 @@ Map {
   "xxx-3offline-2018-01-20" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-11",
       "ccc-9",
@@ -33661,6 +33747,7 @@ Map {
   "xxx-3offline-2018-01-25" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-14",
       "aaa-15",
@@ -33804,6 +33891,7 @@ Map {
   "ccc-2offline-2018-01-28" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-17",
       "bbb-18",
@@ -34074,6 +34162,7 @@ Map {
   "bbb-1offline-2018-01-21" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-12",
       "xxx-16",
@@ -34288,6 +34377,7 @@ Map {
   "ccc-2offline-2018-01-17" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-18",
       "aaa-9",
@@ -34519,6 +34609,7 @@ Map {
   "zzz-5offline-2018-01-22" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-12",
       "aaa-13",
@@ -34631,6 +34722,7 @@ Map {
   "xxx-3offline-2018-01-27" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-17",
       "ccc-17",
@@ -34732,6 +34824,7 @@ Map {
   "bbb-1offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -34964,6 +35057,7 @@ Map {
   "xxx-3offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -35114,6 +35208,7 @@ Map {
   "ccc-2offline-2018-01-30" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-19",
       "bbb-26",
@@ -35375,6 +35470,7 @@ Map {
   "yyy-4offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -35477,6 +35573,7 @@ Map {
   "zzz-4offline-2018-01-27" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-17",
       "ccc-17",
@@ -35587,6 +35684,7 @@ Map {
   "aaa-0offline-2018-01-29" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-19",
       "ccc-21",
@@ -35743,6 +35841,7 @@ Map {
   "xxx-3offline-2018-01-22" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-12",
       "aaa-13",
@@ -35862,6 +35961,7 @@ Map {
   "yyy-4offline-2018-01-22" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-12",
       "aaa-13",
@@ -35937,6 +36037,7 @@ Map {
   "ccc-2offline-2018-01-19" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-11",
       "ccc-7",
@@ -36167,6 +36268,7 @@ Map {
   "zzz-5offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -36282,6 +36384,7 @@ Map {
   "aaa-0offline-2018-01-19" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-11",
       "ccc-7",
@@ -36552,6 +36655,7 @@ Map {
   "zzz-4offline-2018-01-23" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-13",
       "bbb-15",
@@ -36647,6 +36751,7 @@ Map {
   "aaa-0offline-2018-01-17" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-18",
       "aaa-9",
@@ -36942,6 +37047,7 @@ Map {
   "zzz-4offline-2018-01-28" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-17",
       "bbb-18",
@@ -37037,6 +37143,7 @@ Map {
   "ccc-2offline-2018-01-18" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-10",
       "bbb-10",
@@ -37267,6 +37374,7 @@ Map {
   "bbb-1offline-2018-01-25" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-14",
       "aaa-15",
@@ -37428,6 +37536,7 @@ Map {
   "ccc-2offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -37651,6 +37760,7 @@ Map {
   "xxx-3offline-2018-01-23" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-13",
       "bbb-15",
@@ -37805,6 +37915,7 @@ Map {
   "xxx-3offline-2018-01-28" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-17",
       "bbb-18",
@@ -37959,6 +38070,7 @@ Map {
   "bbb-1offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -38175,6 +38287,7 @@ Map {
   "aaa-0offline-2018-01-26" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-16",
       "bbb-16",
@@ -38396,6 +38509,7 @@ Map {
   "ccc-2offline-2018-01-20" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-11",
       "ccc-9",
@@ -38619,6 +38733,7 @@ Map {
   "zzz-5offline-2018-01-18" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-10",
       "bbb-10",
@@ -38710,6 +38825,7 @@ Map {
   "bbb-1offline-2018-01-30" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-19",
       "bbb-26",
@@ -38941,6 +39057,7 @@ Map {
   "zzz-5offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -39048,6 +39165,7 @@ Map {
   "xxx-3offline-2018-01-30" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-19",
       "bbb-26",
@@ -39149,6 +39267,7 @@ Map {
   "xxx-3offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -39247,6 +39366,7 @@ Map {
   "xxx-3offline-2018-01-19" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-11",
       "ccc-7",
@@ -39397,6 +39517,7 @@ Map {
   "ccc-2offline-2018-01-27" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-17",
       "ccc-17",
@@ -39650,6 +39771,7 @@ Map {
   "yyy-4offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -39760,6 +39882,7 @@ Map {
   "yyy-4offline-2018-01-19" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-11",
       "ccc-7",
@@ -39866,6 +39989,7 @@ Map {
   "aaa-0offline-2018-01-21" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-12",
       "xxx-16",
@@ -40046,6 +40170,7 @@ Map {
   "ccc-2offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -40268,6 +40393,7 @@ Map {
   "zzz-5offline-2018-01-21" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-12",
       "xxx-16",
@@ -40357,6 +40483,7 @@ Map {
   "bbb-1offline-2018-01-29" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-19",
       "ccc-21",
@@ -40619,6 +40746,7 @@ Map {
   "ccc-2offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -40841,6 +40969,7 @@ Map {
   "yyy-4offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -40947,6 +41076,7 @@ Map {
   "aaa-0offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -41153,6 +41283,7 @@ Map {
   "aaa-0offline-2018-01-28" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-17",
       "bbb-18",
@@ -41327,6 +41458,7 @@ Map {
   "zzz-4offline-2018-01-30" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-19",
       "bbb-26",
@@ -41441,6 +41573,7 @@ Map {
   "aaa-0offline-2018-01-22" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-12",
       "aaa-13",
@@ -41736,6 +41869,7 @@ Map {
   "bbb-1offline-2018-01-20" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-11",
       "ccc-9",
@@ -42009,6 +42143,7 @@ Map {
   "bbb-1offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -42170,6 +42305,7 @@ Map {
   "zzz-5offline-2018-01-19" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-11",
       "ccc-7",
@@ -42261,6 +42397,7 @@ Map {
   "bbb-1offline-2018-01-19" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-11",
       "ccc-7",
@@ -42429,6 +42566,7 @@ Map {
   "xxx-3offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -42535,6 +42673,7 @@ Map {
   "zzz-4offline-2018-01-26" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-16",
       "bbb-16",
@@ -42641,6 +42780,7 @@ Map {
   "xxx-3offline-2018-01-26" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-16",
       "bbb-16",
@@ -42746,6 +42886,7 @@ Map {
   "ccc-2offline-2018-01-29" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-19",
       "ccc-21",
@@ -42998,6 +43139,7 @@ Map {
   "ccc-2offline-2018-01-22" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-12",
       "aaa-13",
@@ -43261,6 +43403,7 @@ Map {
   "bbb-1offline-2018-01-27" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-17",
       "ccc-17",
@@ -43524,6 +43667,7 @@ Map {
   "yyy-4offline-2018-01-17" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-18",
       "aaa-9",
@@ -43631,6 +43775,7 @@ Map {
   "xxx-3offline-2018-01-21" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-12",
       "xxx-16",
@@ -43795,6 +43940,7 @@ Map {
   "yyy-4offline-2018-01-21" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-12",
       "xxx-16",
@@ -43899,6 +44045,7 @@ Map {
   "aaa-0offline-2018-01-24" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-14",
       "ccc-11",
@@ -44064,6 +44211,7 @@ Map {
   "bbb-1offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -44216,6 +44364,7 @@ Map {
   "xxx-3offline-2018-01-17" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-18",
       "aaa-9",
@@ -44367,6 +44516,7 @@ Map {
   "yyy-4offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -44477,6 +44627,7 @@ Map {
   "xxx-3offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -84114,6 +84265,7 @@ Map {
   "yyy-4offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -84225,6 +84377,7 @@ Map {
   "aaa-0offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -84471,6 +84624,7 @@ Map {
   "xxx-3offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -84578,6 +84732,7 @@ Map {
   "xxx-3offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -84681,6 +84836,7 @@ Map {
   "aaa-0offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -84920,6 +85076,7 @@ Map {
   "zzz-5offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -85027,6 +85184,7 @@ Map {
   "zzz-5offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -85138,6 +85296,7 @@ Map {
   "ccc-2offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -85369,6 +85528,7 @@ Map {
   "zzz-5offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -85468,6 +85628,7 @@ Map {
   "xxx-3offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -85579,6 +85740,7 @@ Map {
   "ccc-2offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -85809,6 +85971,7 @@ Map {
   "aaa-0offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -86016,6 +86179,7 @@ Map {
   "ccc-2offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -86238,6 +86402,7 @@ Map {
   "zzz-5offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -86354,6 +86519,7 @@ Map {
   "xxx-3offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -86462,6 +86628,7 @@ Map {
   "ccc-2offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -86685,6 +86852,7 @@ Map {
   "zzz-5offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -86797,6 +86965,7 @@ Map {
   "bbb-1offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -87094,6 +87263,7 @@ Map {
   "bbb-1offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -87334,6 +87504,7 @@ Map {
   "xxx-3offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -87432,6 +87603,7 @@ Map {
   "ccc-2offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -87655,6 +87827,7 @@ Map {
   "aaa-0offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -87894,6 +88067,7 @@ Map {
   "bbb-1offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -88174,6 +88348,7 @@ Map {
   "ccc-2offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -88406,6 +88581,7 @@ Map {
   "yyy-4offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -88513,6 +88689,7 @@ Map {
   "yyy-4offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -88628,6 +88805,7 @@ Map {
   "bbb-1offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -88909,6 +89087,7 @@ Map {
   "aaa-0offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -89187,6 +89366,7 @@ Map {
   "zzz-5offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -89296,6 +89476,7 @@ Map {
   "zzz-5offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -89408,6 +89589,7 @@ Map {
   "xxx-3offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -89507,6 +89689,7 @@ Map {
   "zzz-5offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -89615,6 +89798,7 @@ Map {
   "ccc-2offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -89829,6 +90013,7 @@ Map {
   "bbb-1offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -90061,6 +90246,7 @@ Map {
   "xxx-3offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -90211,6 +90397,7 @@ Map {
   "yyy-4offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -90319,6 +90506,7 @@ Map {
   "yyy-4offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -90427,6 +90615,7 @@ Map {
   "yyy-4offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -90529,6 +90718,7 @@ Map {
   "yyy-4offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -90639,6 +90829,7 @@ Map {
   "zzz-5offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -90754,6 +90945,7 @@ Map {
   "yyy-4offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -90861,6 +91053,7 @@ Map {
   "yyy-4offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -90967,6 +91160,7 @@ Map {
   "bbb-1offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -91249,6 +91443,7 @@ Map {
   "bbb-1offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -91539,6 +91734,7 @@ Map {
   "ccc-2offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -91762,6 +91958,7 @@ Map {
   "zzz-5offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -91870,6 +92067,7 @@ Map {
   "bbb-1offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -92086,6 +92284,7 @@ Map {
   "aaa-0offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -92349,6 +92548,7 @@ Map {
   "ccc-2offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -92579,6 +92779,7 @@ Map {
   "xxx-3offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -92678,6 +92879,7 @@ Map {
   "ccc-2offline-2018-01-01" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-1",
       "aaa-7",
@@ -92893,6 +93095,7 @@ Map {
   "zzz-5offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -93000,6 +93203,7 @@ Map {
   "xxx-3offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -93098,6 +93302,7 @@ Map {
   "yyy-4offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -93208,6 +93413,7 @@ Map {
   "xxx-3offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -93320,6 +93526,7 @@ Map {
   "xxx-3offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -93427,6 +93634,7 @@ Map {
   "ccc-2offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -93649,6 +93857,7 @@ Map {
   "zzz-5offline-2018-01-07" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-3",
       "ccc-6",
@@ -93761,6 +93970,7 @@ Map {
   "ccc-2offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -93983,6 +94193,7 @@ Map {
   "yyy-4offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -94093,6 +94304,7 @@ Map {
   "yyy-4offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -94199,6 +94411,7 @@ Map {
   "aaa-0offline-2018-01-11" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-5",
       "ccc-29",
@@ -94405,6 +94618,7 @@ Map {
   "xxx-3offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -94527,6 +94741,7 @@ Map {
   "aaa-0offline-2018-01-06" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-2",
       "ccc-22",
@@ -94789,6 +95004,7 @@ Map {
   "ccc-2offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -95019,6 +95235,7 @@ Map {
   "zzz-5offline-2018-01-03" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-0",
       "bbb-24",
@@ -95128,6 +95345,7 @@ Map {
   "ccc-2offline-2018-01-08" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-3",
       "bbb-5",
@@ -95344,6 +95562,7 @@ Map {
   "bbb-1offline-2018-01-13" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-6",
       "bbb-7",
@@ -95505,6 +95724,7 @@ Map {
   "xxx-3offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -95651,6 +95871,7 @@ Map {
   "xxx-3offline-2018-01-15" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-8",
       "ccc-2",
@@ -95757,6 +95978,7 @@ Map {
   "yyy-4offline-2018-01-02" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-0",
       "ccc-16",
@@ -95864,6 +96086,7 @@ Map {
   "zzz-5offline-2018-01-09" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-4",
       "ccc-25",
@@ -95975,6 +96198,7 @@ Map {
   "bbb-1offline-2018-01-14" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-8",
       "ccc-1",
@@ -96127,6 +96351,7 @@ Map {
   "ccc-2offline-2018-01-04" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-1",
       "ccc-19",
@@ -96350,6 +96575,7 @@ Map {
   "zzz-5offline-2018-01-10" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "aaa-4",
       "ccc-12",
@@ -96441,6 +96667,7 @@ Map {
   "yyy-4offline-2018-01-05" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-2",
       "ccc-0",
@@ -96548,6 +96775,7 @@ Map {
   "yyy-4offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",
@@ -96658,6 +96886,7 @@ Map {
   "xxx-3offline-2018-01-12" => {
     "allocationAlgorithm": undefined,
     "archived": false,
+    "artifactRunDate": undefined,
     "bookings": [
       "bbb-6",
       "ccc-27",

--- a/client/insight/src/network/api.ts
+++ b/client/insight/src/network/api.ts
@@ -2990,6 +2990,7 @@ export class Job implements IJob {
     allocationAlgorithm?: string | undefined;
     bookings?: string[] | undefined;
     provisionalWorkorderId?: string | undefined;
+    artifactRunDate?: Date | undefined;
     manuallyCreated?: boolean;
     holdEntireJob?: HoldPattern | undefined;
     cycles!: number;
@@ -3022,6 +3023,7 @@ export class Job implements IJob {
                     this.bookings!.push(item);
             }
             this.provisionalWorkorderId = _data["ProvisionalWorkorderId"];
+            this.artifactRunDate = _data["ArtifactRunDate"] ? new Date(_data["ArtifactRunDate"].toString()) : undefined as any;
             this.manuallyCreated = _data["ManuallyCreated"];
             this.holdEntireJob = _data["HoldEntireJob"] ? HoldPattern.fromJS(_data["HoldEntireJob"]) : undefined as any;
             this.cycles = _data["Cycles"];
@@ -3055,6 +3057,7 @@ export class Job implements IJob {
                 data["Bookings"].push(item);
         }
         data["ProvisionalWorkorderId"] = this.provisionalWorkorderId;
+        data["ArtifactRunDate"] = this.artifactRunDate ? formatDate(this.artifactRunDate) : undefined as any;
         data["ManuallyCreated"] = this.manuallyCreated;
         data["HoldEntireJob"] = this.holdEntireJob ? this.holdEntireJob.toJSON() : undefined as any;
         data["Cycles"] = this.cycles;
@@ -3077,6 +3080,7 @@ export interface IJob {
     allocationAlgorithm?: string | undefined;
     bookings?: string[] | undefined;
     provisionalWorkorderId?: string | undefined;
+    artifactRunDate?: Date | undefined;
     manuallyCreated?: boolean;
     holdEntireJob?: HoldPattern | undefined;
     cycles: number;
@@ -5481,6 +5485,7 @@ export class MostRecentSchedule implements IMostRecentSchedule {
     latestScheduleId!: string;
     jobs!: HistoricJob[];
     extraParts!: { [key: string]: number; };
+    recentArtifactRuns?: ScheduledArtifactRun[] | undefined;
     unscheduledRebookings?: Rebooking[] | undefined;
 
     constructor(data?: IMostRecentSchedule) {
@@ -5510,6 +5515,11 @@ export class MostRecentSchedule implements IMostRecentSchedule {
                     if (_data["ExtraParts"].hasOwnProperty(key))
                         (this.extraParts as any)![key] = _data["ExtraParts"][key];
                 }
+            }
+            if (Array.isArray(_data["RecentArtifactRuns"])) {
+                this.recentArtifactRuns = [] as any;
+                for (let item of _data["RecentArtifactRuns"])
+                    this.recentArtifactRuns!.push(ScheduledArtifactRun.fromJS(item));
             }
             if (Array.isArray(_data["UnscheduledRebookings"])) {
                 this.unscheduledRebookings = [] as any;
@@ -5541,6 +5551,11 @@ export class MostRecentSchedule implements IMostRecentSchedule {
                     (data["ExtraParts"] as any)[key] = (this.extraParts as any)[key];
             }
         }
+        if (Array.isArray(this.recentArtifactRuns)) {
+            data["RecentArtifactRuns"] = [];
+            for (let item of this.recentArtifactRuns)
+                data["RecentArtifactRuns"].push(item ? item.toJSON() : undefined as any);
+        }
         if (Array.isArray(this.unscheduledRebookings)) {
             data["UnscheduledRebookings"] = [];
             for (let item of this.unscheduledRebookings)
@@ -5554,7 +5569,52 @@ export interface IMostRecentSchedule {
     latestScheduleId: string;
     jobs: HistoricJob[];
     extraParts: { [key: string]: number; };
+    recentArtifactRuns?: ScheduledArtifactRun[] | undefined;
     unscheduledRebookings?: Rebooking[] | undefined;
+}
+
+export class ScheduledArtifactRun implements IScheduledArtifactRun {
+    jobUnique!: string;
+    partName!: string;
+    artifactRunDate!: Date;
+
+    constructor(data?: IScheduledArtifactRun) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (this as any)[property] = (data as any)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.jobUnique = _data["JobUnique"];
+            this.partName = _data["PartName"];
+            this.artifactRunDate = _data["ArtifactRunDate"] ? new Date(_data["ArtifactRunDate"].toString()) : undefined as any;
+        }
+    }
+
+    static fromJS(data: any): ScheduledArtifactRun {
+        data = typeof data === 'object' ? data : {};
+        let result = new ScheduledArtifactRun();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["JobUnique"] = this.jobUnique;
+        data["PartName"] = this.partName;
+        data["ArtifactRunDate"] = this.artifactRunDate ? formatDate(this.artifactRunDate) : undefined as any;
+        return data;
+    }
+}
+
+export interface IScheduledArtifactRun {
+    jobUnique: string;
+    partName: string;
+    artifactRunDate: Date;
 }
 
 export class Rebooking implements IRebooking {

--- a/server/fms-insight-api.json
+++ b/server/fms-insight-api.json
@@ -2783,6 +2783,11 @@
             "type": "string",
             "nullable": true
           },
+          "ArtifactRunDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
           "ManuallyCreated": {
             "type": "boolean"
           },
@@ -4376,12 +4381,43 @@
               "format": "int32"
             }
           },
+          "RecentArtifactRuns": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ScheduledArtifactRun"
+            }
+          },
           "UnscheduledRebookings": {
             "type": "array",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Rebooking"
             }
+          }
+        }
+      },
+      "ScheduledArtifactRun": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "JobUnique",
+          "PartName",
+          "ArtifactRunDate",
+          "JobUnique",
+          "PartName",
+          "ArtifactRunDate"
+        ],
+        "properties": {
+          "JobUnique": {
+            "type": "string"
+          },
+          "PartName": {
+            "type": "string"
+          },
+          "ArtifactRunDate": {
+            "type": "string",
+            "format": "date"
           }
         }
       },

--- a/server/lib/BlackMaple.MachineFramework/api/CellStatus.cs
+++ b/server/lib/BlackMaple.MachineFramework/api/CellStatus.cs
@@ -135,6 +135,15 @@ namespace BlackMaple.MachineFramework
     public ImmutableList<SimulatedDayUsage>? MostRecentSimDayUsage { get; init; }
   }
 
+  public record ScheduledArtifactRun
+  {
+    public required string JobUnique { get; init; }
+
+    public required string PartName { get; init; }
+
+    public required DateOnly ArtifactRunDate { get; init; }
+  }
+
   public record MostRecentSchedule
   {
     public required string LatestScheduleId { get; init; }
@@ -142,6 +151,8 @@ namespace BlackMaple.MachineFramework
     public required ImmutableList<MachineFramework.HistoricJob> Jobs { get; init; }
 
     public required ImmutableDictionary<string, int> ExtraParts { get; init; }
+
+    public ImmutableList<ScheduledArtifactRun>? RecentArtifactRuns { get; init; }
 
     public ImmutableList<Rebooking>? UnscheduledRebookings { get; init; }
   }

--- a/server/lib/BlackMaple.MachineFramework/api/JobPlan.cs
+++ b/server/lib/BlackMaple.MachineFramework/api/JobPlan.cs
@@ -254,6 +254,8 @@ namespace BlackMaple.MachineFramework
 
     public string? ProvisionalWorkorderId { get; init; }
 
+    public DateOnly? ArtifactRunDate { get; init; }
+
     public bool ManuallyCreated { get; init; }
 
     [JsonPropertyName("HoldEntireJob")]

--- a/server/lib/BlackMaple.MachineFramework/db/JobDB.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/JobDB.cs
@@ -146,6 +146,9 @@ namespace BlackMaple.MachineFramework
         ImmutableList.CreateBuilder<SimulatedStationPart>();
     }
 
+    private const string JobProjection =
+      "UniqueStr, Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId, ArtifactRunDate";
+
     private JobDetails LoadJobData(string uniq, IDbTransaction trans)
     {
       using (var cmd = _connection.CreateCommand())
@@ -605,6 +608,7 @@ namespace BlackMaple.MachineFramework
               Processes = details.Procs,
               BookingIds = details.Bookings,
               ProvisionalWorkorderId = reader.IsDBNull(11) ? null : reader.GetString(11),
+              ArtifactRunDate = reader.IsDBNull(12) ? null : DateOnly.FromDayNumber(reader.GetInt32(12)),
               HoldJob = details.Hold?.ToHoldPattern(),
               Decrements = LoadDecrementsForJob(trans, unique),
             }
@@ -613,6 +617,33 @@ namespace BlackMaple.MachineFramework
       }
 
       return ret.ToImmutable();
+    }
+
+    private ImmutableList<ScheduledArtifactRun> LoadRecentArtifactRuns(IDbTransaction trans)
+    {
+      using var cmd = _connection.CreateCommand();
+      ((IDbCommand)cmd).Transaction = trans;
+      cmd.CommandText =
+        "SELECT UniqueStr, Part, ArtifactRunDate FROM jobs WHERE ArtifactRunDate IS NOT NULL AND ArtifactRunDate >= $start ORDER BY ArtifactRunDate, UniqueStr";
+      cmd.Parameters.Add("start", SqliteType.Integer).Value = DateOnly
+        .FromDateTime(DateTime.UtcNow.AddHours(-48))
+        .DayNumber;
+
+      var ret = ImmutableList.CreateBuilder<ScheduledArtifactRun>();
+      using var reader = cmd.ExecuteReader();
+      while (reader.Read())
+      {
+        ret.Add(
+          new ScheduledArtifactRun()
+          {
+            JobUnique = reader.GetString(0),
+            PartName = reader.GetString(1),
+            ArtifactRunDate = DateOnly.FromDayNumber(reader.GetInt32(2)),
+          }
+        );
+      }
+
+      return ret.Count == 0 ? null : ret.ToImmutable();
     }
 
     private ImmutableDictionary<string, int> LoadExtraParts(IDbTransaction trans, string schId)
@@ -877,10 +908,7 @@ namespace BlackMaple.MachineFramework
         using var jobCmd = _connection.CreateCommand();
         jobCmd.Transaction = trans;
         jobCmd.CommandText =
-          "SELECT UniqueStr, Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId"
-          + " FROM jobs WHERE ScheduleId IN ("
-          + scheduleIdSubquery
-          + ")";
+          "SELECT " + JobProjection + " FROM jobs WHERE ScheduleId IN (" + scheduleIdSubquery + ")";
         configureScheduleIdParameters(jobCmd);
 
         using var simCmd = _connection.CreateCommand();
@@ -921,8 +949,7 @@ namespace BlackMaple.MachineFramework
     {
       using (var cmd = _connection.CreateCommand())
       {
-        cmd.CommandText =
-          "SELECT UniqueStr, Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId FROM jobs WHERE Archived = 0";
+        cmd.CommandText = "SELECT " + JobProjection + " FROM jobs WHERE Archived = 0";
         using (var trans = _connection.BeginTransaction())
         {
           cmd.Transaction = trans;
@@ -938,7 +965,8 @@ namespace BlackMaple.MachineFramework
     )
     {
       var cmdTxt =
-        "SELECT UniqueStr, Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId"
+        "SELECT "
+        + JobProjection
         + " FROM jobs WHERE StartUTC <= $end AND EndUTC >= $start AND CopiedToSystem = 0";
       if (!includeDecremented)
       {
@@ -1082,9 +1110,7 @@ namespace BlackMaple.MachineFramework
     {
       using (var cmd = _connection.CreateCommand())
       {
-        cmd.CommandText =
-          "SELECT UniqueStr, Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId"
-          + " FROM jobs WHERE ScheduleId = $sid";
+        cmd.CommandText = "SELECT " + JobProjection + " FROM jobs WHERE ScheduleId = $sid";
 
         using (var trans = _connection.BeginTransaction())
         {
@@ -1096,6 +1122,7 @@ namespace BlackMaple.MachineFramework
             LatestScheduleId = latestSchId,
             Jobs = LoadJobsHelper(cmd, trans),
             ExtraParts = LoadExtraParts(trans, latestSchId),
+            RecentArtifactRuns = LoadRecentArtifactRuns(trans),
             UnscheduledRebookings = LoadUnscheduledRebookings(trans),
           };
         }
@@ -1171,9 +1198,7 @@ namespace BlackMaple.MachineFramework
     {
       using (var cmd = _connection.CreateCommand())
       {
-        cmd.CommandText =
-          "SELECT UniqueStr, Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId"
-          + " FROM jobs WHERE UniqueStr BETWEEN $start AND $end";
+        cmd.CommandText = "SELECT " + JobProjection + " FROM jobs WHERE UniqueStr BETWEEN $start AND $end";
 
         using (var trans = _connection.BeginTransaction())
         {
@@ -1192,7 +1217,7 @@ namespace BlackMaple.MachineFramework
       HistoricJob job = null;
 
       cmd.CommandText =
-        "SELECT Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId FROM jobs WHERE UniqueStr = $uniq";
+        "SELECT Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId, ArtifactRunDate FROM jobs WHERE UniqueStr = $uniq";
       cmd.Parameters.Add("uniq", SqliteType.Text).Value = UniqueStr;
 
       cmd.Transaction = trans;
@@ -1223,6 +1248,7 @@ namespace BlackMaple.MachineFramework
             Processes = details.Procs,
             BookingIds = details.Bookings,
             ProvisionalWorkorderId = reader.IsDBNull(10) ? null : reader.GetString(10),
+            ArtifactRunDate = reader.IsDBNull(11) ? null : DateOnly.FromDayNumber(reader.GetInt32(11)),
             HoldJob = details.Hold?.ToHoldPattern(),
             Decrements = LoadDecrementsForJob(trans, UniqueStr),
           };
@@ -1389,8 +1415,8 @@ namespace BlackMaple.MachineFramework
         ((IDbCommand)cmd).Transaction = trans;
 
         cmd.CommandText =
-          "INSERT INTO jobs(UniqueStr, Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId) "
-          + "VALUES($uniq,$part,$proc,$comment,$start,$end,$archived,$copied,$sid,$manual,$alg,$prov)";
+          "INSERT INTO jobs(UniqueStr, Part, NumProcess, Comment, StartUTC, EndUTC, Archived, CopiedToSystem, ScheduleId, Manual, AllocateAlg, ProvisionalWorkorderId, ArtifactRunDate) "
+          + "VALUES($uniq,$part,$proc,$comment,$start,$end,$archived,$copied,$sid,$manual,$alg,$prov,$artifact)";
 
         cmd.Parameters.Add("uniq", SqliteType.Text).Value = job.UniqueStr;
         cmd.Parameters.Add("part", SqliteType.Text).Value = job.PartName;
@@ -1414,6 +1440,9 @@ namespace BlackMaple.MachineFramework
         cmd.Parameters.Add("prov", SqliteType.Text).Value = string.IsNullOrEmpty(job.ProvisionalWorkorderId)
           ? DBNull.Value
           : job.ProvisionalWorkorderId;
+        cmd.Parameters.Add("artifact", SqliteType.Integer).Value = job.ArtifactRunDate.HasValue
+          ? job.ArtifactRunDate.Value.DayNumber
+          : DBNull.Value;
 
         cmd.ExecuteNonQuery();
 

--- a/server/lib/BlackMaple.MachineFramework/db/Schema.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/Schema.cs
@@ -41,7 +41,7 @@ namespace BlackMaple.MachineFramework
 {
   internal static class DatabaseSchema
   {
-    private const int Version = 39;
+    private const int Version = 40;
 
     #region Create
     public static void CreateTables(SqliteConnection connection, SerialSettings settings)
@@ -176,7 +176,7 @@ namespace BlackMaple.MachineFramework
         cmd.Transaction = transaction;
 
         cmd.CommandText =
-          "CREATE TABLE jobs(UniqueStr TEXT PRIMARY KEY, Part TEXT NOT NULL, NumProcess INTEGER NOT NULL, Comment TEXT, AllocateAlg TEXT, StartUTC INTEGER NOT NULL, EndUTC INTEGER NOT NULL, Archived INTEGER NOT NULL, CopiedToSystem INTEGER NOT NULL, ScheduleId TEXT, Manual INTEGER, ProvisionalWorkorderId TEXT)";
+          "CREATE TABLE jobs(UniqueStr TEXT PRIMARY KEY, Part TEXT NOT NULL, NumProcess INTEGER NOT NULL, Comment TEXT, AllocateAlg TEXT, StartUTC INTEGER NOT NULL, EndUTC INTEGER NOT NULL, Archived INTEGER NOT NULL, CopiedToSystem INTEGER NOT NULL, ScheduleId TEXT, Manual INTEGER, ProvisionalWorkorderId TEXT, ArtifactRunDate INTEGER)";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText = "CREATE INDEX jobs_time_idx ON jobs(EndUTC, StartUTC)";
@@ -186,6 +186,10 @@ namespace BlackMaple.MachineFramework
         cmd.ExecuteNonQuery();
 
         cmd.CommandText = "CREATE INDEX jobs_schedule_id ON jobs(ScheduleId) WHERE ScheduleId IS NOT NULL";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE INDEX jobs_artifact_run_date_idx ON jobs(ArtifactRunDate) WHERE ArtifactRunDate IS NOT NULL";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -495,6 +499,9 @@ namespace BlackMaple.MachineFramework
 
           if (curVersion < 39)
             Ver38ToVer39(trans, updateJobsTables);
+
+          if (curVersion < 40)
+            Ver39ToVer40(trans, updateJobsTables);
 
           //update the version in the database
           cmd.Transaction = trans;
@@ -1255,6 +1262,22 @@ namespace BlackMaple.MachineFramework
 
       cmd.CommandText =
         "CREATE TABLE basketloadunload(UniqueStr TEXT, Process INTEGER, StatNum INTEGER, Load INTEGER, PRIMARY KEY(UniqueStr,Process,StatNum,Load))";
+      cmd.ExecuteNonQuery();
+    }
+
+    private static void Ver39ToVer40(IDbTransaction trans, bool updateJobTables)
+    {
+      if (!updateJobTables)
+        return;
+
+      using var cmd = trans.Connection.CreateCommand();
+      cmd.Transaction = trans;
+
+      cmd.CommandText = "ALTER TABLE jobs ADD ArtifactRunDate INTEGER";
+      cmd.ExecuteNonQuery();
+
+      cmd.CommandText =
+        "CREATE INDEX jobs_artifact_run_date_idx ON jobs(ArtifactRunDate) WHERE ArtifactRunDate IS NOT NULL";
       cmd.ExecuteNonQuery();
     }
 

--- a/server/machines/makino/MakinoToJobMap.cs
+++ b/server/machines/makino/MakinoToJobMap.cs
@@ -235,6 +235,7 @@ namespace BlackMaple.FMSInsight.Makino
         ScheduleId = historic?.ScheduleId ?? null,
         BookingIds = historic?.BookingIds ?? null,
         ProvisionalWorkorderId = historic?.ProvisionalWorkorderId ?? null,
+        ArtifactRunDate = historic?.ArtifactRunDate,
         ManuallyCreated = historic?.ManuallyCreated ?? false,
         CopiedToSystem = historic?.CopiedToSystem ?? true,
         Decrements = db.LoadDecrementsForJob(order),

--- a/server/machines/mazak/sync/BuildCurrentStatus.cs
+++ b/server/machines/mazak/sync/BuildCurrentStatus.cs
@@ -472,6 +472,7 @@ namespace MazakMachineInterface
           Comment = job.DbJob?.Comment,
           ScheduleId = job.DbJob?.ScheduleId,
           BookingIds = job.DbJob?.BookingIds,
+          ArtifactRunDate = job.DbJob?.ArtifactRunDate,
           ManuallyCreated = job.DbJob?.ManuallyCreated ?? false,
           HoldJob = job.UserHold
             ? new BlackMaple.MachineFramework.HoldPattern()

--- a/server/test/JobAndQueueSpec.cs
+++ b/server/test/JobAndQueueSpec.cs
@@ -66,6 +66,8 @@ public sealed class JobAndQueueSpec : ISynchronizeCellState<JobAndQueueSpec.Mock
     _repo = RepositoryConfig.InitializeMemoryDB(null);
     _fixture = new Fixture();
     _fixture.Customizations.Add(new ImmutableSpecimenBuilder());
+    _fixture.Customizations.Add(new NullJobArtifactRunDateSpecimenBuilder());
+    _fixture.Customizations.Add(new DateOnlySpecimenBuilder());
 
     _settings = new FMSSettings() { };
     _settings.Queues.Add("q1", new QueueInfo());

--- a/server/test/JobDBSpec.cs
+++ b/server/test/JobDBSpec.cs
@@ -51,6 +51,7 @@ namespace BlackMaple.FMSInsight.Tests
       _repoCfg = RepositoryConfig.InitializeMemoryDB(null);
       _fixture = new Fixture();
       _fixture.Customizations.Add(new ImmutableSpecimenBuilder());
+      _fixture.Customizations.Add(new NullJobArtifactRunDateSpecimenBuilder());
       _fixture.Customizations.Add(new DateOnlySpecimenBuilder());
     }
 
@@ -412,6 +413,153 @@ namespace BlackMaple.FMSInsight.Tests
             Decrements = ImmutableList<DecrementQuantity>.Empty,
           }
         );
+    }
+
+    [Test]
+    public void PersistsArtifactRunDateAndLoadsRecentArtifactRuns()
+    {
+      using var _jobDB = _repoCfg.OpenConnection();
+      var recentDate = DateOnly.FromDateTime(DateTime.UtcNow);
+      var oldDate = DateOnly.FromDateTime(DateTime.UtcNow.AddHours(-48)).AddDays(-1);
+      var olderScheduleId = "artifact-older";
+      var latestScheduleId = "zz-latest";
+      var manualScheduleId = "zzzz-manual";
+
+      var olderArtifactJob = RandJob() with
+      {
+        UniqueStr = "artifact-old-sch",
+        PartName = "artifact-part",
+        ArtifactRunDate = recentDate,
+        ManuallyCreated = false,
+      };
+      var duplicateArtifactJob = RandJob() with
+      {
+        UniqueStr = "artifact-old-sch-duplicate",
+        PartName = olderArtifactJob.PartName,
+        ArtifactRunDate = recentDate,
+        ManuallyCreated = false,
+      };
+      var oldArtifactJob = RandJob() with
+      {
+        UniqueStr = "artifact-too-old",
+        PartName = "old-artifact-part",
+        ArtifactRunDate = oldDate,
+        ManuallyCreated = false,
+      };
+
+      _jobDB.AddJobs(
+        new NewJobs()
+        {
+          ScheduleId = olderScheduleId,
+          Jobs = [olderArtifactJob, duplicateArtifactJob, oldArtifactJob],
+        },
+        null,
+        addAsCopiedToSystem: true
+      );
+
+      var latestJob = RandJob() with
+      {
+        UniqueStr = "latest-job",
+        PartName = "latest-part",
+        ArtifactRunDate = null,
+        ManuallyCreated = false,
+      };
+
+      _jobDB.AddJobs(
+        new NewJobs() { ScheduleId = latestScheduleId, Jobs = [latestJob] },
+        olderScheduleId,
+        addAsCopiedToSystem: false
+      );
+
+      var archivedArtifactJob = RandJob() with
+      {
+        UniqueStr = "artifact-archived",
+        PartName = "archived-artifact-part",
+        ArtifactRunDate = recentDate,
+        ManuallyCreated = false,
+      };
+
+      _jobDB.AddJobs(
+        new NewJobs() { ScheduleId = "artifact-archived", Jobs = [archivedArtifactJob] },
+        latestScheduleId,
+        addAsCopiedToSystem: true
+      );
+      _jobDB.ArchiveJob(archivedArtifactJob.UniqueStr);
+
+      var manualArtifactJob = RandJob() with
+      {
+        UniqueStr = "artifact-manual",
+        PartName = "manual-artifact-part",
+        ArtifactRunDate = recentDate,
+        ManuallyCreated = true,
+      };
+
+      _jobDB.AddJobs(
+        new NewJobs() { ScheduleId = manualScheduleId, Jobs = [manualArtifactJob] },
+        latestScheduleId,
+        addAsCopiedToSystem: false
+      );
+
+      var olderArtifactHistory = olderArtifactJob.CloneToDerived<HistoricJob, Job>() with
+      {
+        ScheduleId = olderScheduleId,
+        CopiedToSystem = true,
+        Decrements = ImmutableList<DecrementQuantity>.Empty,
+      };
+      var duplicateArtifactHistory = duplicateArtifactJob.CloneToDerived<HistoricJob, Job>() with
+      {
+        ScheduleId = olderScheduleId,
+        CopiedToSystem = true,
+        Decrements = ImmutableList<DecrementQuantity>.Empty,
+      };
+      var latestHistory = latestJob.CloneToDerived<HistoricJob, Job>() with
+      {
+        ScheduleId = latestScheduleId,
+        CopiedToSystem = false,
+        Decrements = ImmutableList<DecrementQuantity>.Empty,
+      };
+
+      _jobDB.LoadJob(olderArtifactJob.UniqueStr).ShouldBeEquivalentTo(olderArtifactHistory);
+      _jobDB
+        .LoadJobHistory(olderArtifactJob.RouteStartUTC, olderArtifactJob.RouteEndUTC)
+        .Jobs[olderArtifactJob.UniqueStr]
+        .ShouldBeEquivalentTo(olderArtifactHistory);
+
+      _jobDB
+        .LoadJobsBetween(olderArtifactJob.UniqueStr, duplicateArtifactJob.UniqueStr)
+        .ShouldContain(j => j.UniqueStr == olderArtifactJob.UniqueStr && j.ArtifactRunDate == recentDate);
+
+      var mostRecent = _jobDB.LoadMostRecentSchedule();
+      mostRecent.Jobs.ShouldBeEquivalentTo(ImmutableList.Create(latestHistory));
+      mostRecent.RecentArtifactRuns.ShouldBeEquivalentTo(
+        ImmutableList.Create(
+          new ScheduledArtifactRun()
+          {
+            JobUnique = archivedArtifactJob.UniqueStr,
+            PartName = archivedArtifactJob.PartName,
+            ArtifactRunDate = recentDate,
+          },
+          new ScheduledArtifactRun()
+          {
+            JobUnique = manualArtifactJob.UniqueStr,
+            PartName = manualArtifactJob.PartName,
+            ArtifactRunDate = recentDate,
+          },
+          new ScheduledArtifactRun()
+          {
+            JobUnique = olderArtifactHistory.UniqueStr,
+            PartName = olderArtifactHistory.PartName,
+            ArtifactRunDate = recentDate,
+          },
+          new ScheduledArtifactRun()
+          {
+            JobUnique = duplicateArtifactHistory.UniqueStr,
+            PartName = duplicateArtifactHistory.PartName,
+            ArtifactRunDate = recentDate,
+          }
+        )
+      );
+      mostRecent.RecentArtifactRuns.ShouldNotContain(r => r.JobUnique == oldArtifactJob.UniqueStr);
     }
 
     [Test]
@@ -2669,6 +2817,7 @@ namespace BlackMaple.FMSInsight.Tests
       {
         RouteStartUTC = s,
         RouteEndUTC = s.AddHours(1),
+        ArtifactRunDate = null,
         Processes = job
           .Processes.Select(
             (proc, procIdx) =>

--- a/server/test/JobLogTest.cs
+++ b/server/test/JobLogTest.cs
@@ -98,6 +98,7 @@ namespace BlackMaple.FMSInsight.Tests
       _repoCfg = RepositoryConfig.InitializeMemoryDB(null);
       _fixture = new Fixture();
       _fixture.Customizations.Add(new ImmutableSpecimenBuilder());
+      _fixture.Customizations.Add(new NullJobArtifactRunDateSpecimenBuilder());
       _fixture.Customizations.Add(new InjectNullValuesForNullableTypesSpecimenBuilder());
       _fixture.Customizations.Add(new DateOnlySpecimenBuilder());
     }

--- a/server/test/RepositoryStressSpec.cs
+++ b/server/test/RepositoryStressSpec.cs
@@ -23,6 +23,7 @@ public sealed class RepositoryStressSpec : IDisposable
     _repo = RepositoryConfig.InitializeEventDatabase(null, _tempDbFile, pooling: false);
     _fixture = new Fixture();
     _fixture.Customizations.Add(new ImmutableSpecimenBuilder());
+    _fixture.Customizations.Add(new NullJobArtifactRunDateSpecimenBuilder());
     _fixture.Customizations.Add(new InjectNullValuesForNullableTypesSpecimenBuilder());
     _fixture.Customizations.Add(new DateOnlySpecimenBuilder());
   }

--- a/server/test/SpecimenBuilder.cs
+++ b/server/test/SpecimenBuilder.cs
@@ -135,6 +135,23 @@ namespace BlackMaple.FMSInsight.Tests
     }
   }
 
+  public class NullJobArtifactRunDateSpecimenBuilder : AutoFixture.Kernel.ISpecimenBuilder
+  {
+    public object Create(object request, AutoFixture.Kernel.ISpecimenContext context)
+    {
+      if (
+        request is System.Reflection.PropertyInfo prop
+        && prop.Name == nameof(BlackMaple.MachineFramework.Job.ArtifactRunDate)
+        && typeof(BlackMaple.MachineFramework.Job).IsAssignableFrom(prop.DeclaringType)
+      )
+      {
+        return null;
+      }
+
+      return new AutoFixture.Kernel.NoSpecimen();
+    }
+  }
+
   public class InjectNullValuesForNullableTypesSpecimenBuilder : AutoFixture.Kernel.ISpecimenBuilder
   {
     private Random random = new Random();

--- a/server/test/makino/SyncSpec.cs
+++ b/server/test/makino/SyncSpec.cs
@@ -65,6 +65,7 @@ public sealed class SyncSpec : IDisposable
     );
     fix = new AutoFixture.Fixture();
     fix.Customizations.Add(new ImmutableSpecimenBuilder());
+    fix.Customizations.Add(new NullJobArtifactRunDateSpecimenBuilder());
     fix.Customizations.Add(new DateOnlySpecimenBuilder());
 
     sync = new MakinoSync(

--- a/server/test/mazak/BuildMazakSchedulesSpec.cs
+++ b/server/test/mazak/BuildMazakSchedulesSpec.cs
@@ -722,6 +722,8 @@ namespace BlackMaple.FMSInsight.Mazak.Tests
 
       var fix = new Fixture();
       fix.Customizations.Add(new ImmutableSpecimenBuilder());
+      fix.Customizations.Add(new NullJobArtifactRunDateSpecimenBuilder());
+      fix.Customizations.Add(new DateOnlySpecimenBuilder());
 
       var job = fix.Build<Job>()
         .With(j => j.Cycles, 30)
@@ -773,6 +775,8 @@ namespace BlackMaple.FMSInsight.Mazak.Tests
     {
       var fix = new Fixture();
       fix.Customizations.Add(new ImmutableSpecimenBuilder());
+      fix.Customizations.Add(new NullJobArtifactRunDateSpecimenBuilder());
+      fix.Customizations.Add(new DateOnlySpecimenBuilder());
 
       static BlackMaple.MachineFramework.HoldPattern Hold() =>
         new()


### PR DESCRIPTION
Add a new field to FMS Insight Jobs to track if a job is an artifact and if so which date it is scheduled on.  Persist the field to the DB and provide it in MostRecentSchedule.