### PR TITLE
jobs: persist process extra fields

### DIFF
--- a/server/lib/BlackMaple.MachineFramework/api/JobPlan.cs
+++ b/server/lib/BlackMaple.MachineFramework/api/JobPlan.cs
@@ -179,6 +179,16 @@ namespace BlackMaple.MachineFramework
 
   public record ProcessInfo
   {
+    /// <summary>
+    /// Client-defined numeric process metadata which must travel with a downloaded job but has no
+    /// coherent meaning in the generic FMS model. Prefer a well-named, strongly typed property
+    /// whenever the concept can be defined consistently across systems. Adding a key here should
+    /// be a last resort after explicitly considering whether the value represents a reusable domain
+    /// concept; this dictionary must not become a convenient dumping ground for data that belongs
+    /// in the shared schema. Consumers own the meaning, validation, and compatibility of their keys.
+    /// </summary>
+    public ImmutableDictionary<string, double>? ExtraFields { get; init; }
+
     public ImmutableSortedSet<int>? BasketLoadStations { get; init; }
 
     public TimeSpan? ExpectedBasketLoadTime { get; init; }

--- a/server/lib/BlackMaple.MachineFramework/db/JobDB.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/JobDB.cs
@@ -118,6 +118,8 @@ namespace BlackMaple.MachineFramework
         ImmutableSortedSet.CreateBuilder<int>();
       public ImmutableSortedSet<int>.Builder BasketUnloads { get; } =
         ImmutableSortedSet.CreateBuilder<int>();
+      public ImmutableDictionary<string, double>.Builder ExtraFields { get; } =
+        ImmutableDictionary.CreateBuilder<string, double>();
     }
 
     private record JobDetails
@@ -285,6 +287,22 @@ namespace BlackMaple.MachineFramework
             {
               procData.BasketUnloads.Add(reader.GetInt32(1));
             }
+          }
+        }
+
+        cmd.CommandText =
+          "SELECT Process, Name, Value FROM process_extra_fields WHERE UniqueStr = $uniq";
+        using (var reader = cmd.ExecuteReader())
+        {
+          while (reader.Read())
+          {
+            var proc = reader.GetInt32(0);
+            if (!procDatRows.TryGetValue(proc, out var procData))
+            {
+              procData = new ProcDataRow() { Process = proc };
+              procDatRows.Add(proc, procData);
+            }
+            procData.ExtraFields.Add(reader.GetString(1), reader.GetDouble(2));
           }
         }
 
@@ -553,7 +571,12 @@ namespace BlackMaple.MachineFramework
             .Values.GroupBy(p => p.Process)
             .Select(proc => new ProcessInfo()
             {
-              BasketLoadStations = procDatRows.TryGetValue(proc.Key, out var procData)
+              ExtraFields =
+                procDatRows.TryGetValue(proc.Key, out var procData)
+                && procData.ExtraFields.Count > 0
+                  ? procData.ExtraFields.ToImmutable()
+                  : null,
+              BasketLoadStations = procDatRows.TryGetValue(proc.Key, out procData)
                 ? (procData.BasketLoads.Count == 0 ? null : procData.BasketLoads.ToImmutable())
                 : null,
               ExpectedBasketLoadTime = procDatRows.TryGetValue(proc.Key, out procData)
@@ -1696,6 +1719,27 @@ namespace BlackMaple.MachineFramework
             ? (object)proc.ExpectedBasketUnloadTime.Value.Ticks
             : DBNull.Value;
           cmd.ExecuteNonQuery();
+        }
+
+        cmd.CommandText =
+          "INSERT INTO process_extra_fields(UniqueStr, Process, Name, Value) VALUES ($uniq,$proc,$name,$value)";
+        cmd.Parameters.Clear();
+        cmd.Parameters.Add("uniq", SqliteType.Text).Value = job.UniqueStr;
+        cmd.Parameters.Add("proc", SqliteType.Integer);
+        cmd.Parameters.Add("name", SqliteType.Text);
+        cmd.Parameters.Add("value", SqliteType.Real);
+        for (int i = 1; i <= job.Processes.Count; i++)
+        {
+          var extraFields = job.Processes[i - 1].ExtraFields;
+          if (extraFields == null)
+            continue;
+          cmd.Parameters[1].Value = i;
+          foreach (var (name, value) in extraFields)
+          {
+            cmd.Parameters[2].Value = name;
+            cmd.Parameters[3].Value = value;
+            cmd.ExecuteNonQuery();
+          }
         }
 
         cmd.CommandText =

--- a/server/lib/BlackMaple.MachineFramework/db/Schema.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/Schema.cs
@@ -41,7 +41,7 @@ namespace BlackMaple.MachineFramework
 {
   internal static class DatabaseSchema
   {
-    private const int Version = 40;
+    private const int Version = 41;
 
     #region Create
     public static void CreateTables(SqliteConnection connection, SerialSettings settings)
@@ -204,6 +204,10 @@ namespace BlackMaple.MachineFramework
 
         cmd.CommandText =
           "CREATE TABLE procdata(UniqueStr TEXT, Process INTEGER, BasketLoadTime INTEGER, BasketUnloadTime INTEGER, PRIMARY KEY(UniqueStr,Process))";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE TABLE process_extra_fields(UniqueStr TEXT, Process INTEGER, Name TEXT, Value NUMERIC NOT NULL, PRIMARY KEY(UniqueStr,Process,Name))";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -505,6 +509,9 @@ namespace BlackMaple.MachineFramework
 
           if (curVersion < 40)
             Ver39ToVer40(trans, updateJobsTables);
+
+          if (curVersion < 41)
+            Ver40ToVer41(trans, updateJobsTables);
 
           //update the version in the database
           cmd.Transaction = trans;
@@ -1285,6 +1292,18 @@ namespace BlackMaple.MachineFramework
 
       cmd.CommandText =
         "CREATE INDEX jobs_artifact_run_date_idx ON jobs(ArtifactRunDate) WHERE ArtifactRunDate IS NOT NULL";
+      cmd.ExecuteNonQuery();
+    }
+
+    private static void Ver40ToVer41(IDbTransaction trans, bool updateJobTables)
+    {
+      if (!updateJobTables)
+        return;
+
+      using var cmd = trans.Connection.CreateCommand();
+      cmd.Transaction = trans;
+      cmd.CommandText =
+        "CREATE TABLE process_extra_fields(UniqueStr TEXT, Process INTEGER, Name TEXT, Value NUMERIC NOT NULL, PRIMARY KEY(UniqueStr,Process,Name))";
       cmd.ExecuteNonQuery();
     }
 

--- a/server/test/JobDBSpec.cs
+++ b/server/test/JobDBSpec.cs
@@ -415,6 +415,9 @@ namespace BlackMaple.FMSInsight.Tests
         [
           baseJob.Processes[0] with
           {
+            ExtraFields = ImmutableDictionary<string, double>
+              .Empty.Add("ClientSpecificCount", 7)
+              .Add("ClientSpecificRatio", 1.25),
             BasketLoadStations = [41, 42],
             ExpectedBasketLoadTime = TimeSpan.FromMinutes(9),
             BasketUnloadStations = [55],


### PR DESCRIPTION
Add a deliberately last-resort numeric metadata dictionary to job processes, with API documentation cautioning against using it instead of shared typed concepts. Persist values in a normalized table across repository round trips and schema upgrades.