### PR TITLE
events: add provisional pallet and basket identities

### DIFF
--- a/client/insight/src/components/LogEntry.tsx
+++ b/client/insight/src/components/LogEntry.tsx
@@ -111,10 +111,16 @@ function logType(entry: api.ILogEntry, fmsInfo: api.IFMSInfo): string {
 
     case api.LogType.BasketInLocation:
       if (entry.startofcycle) {
-        return "Depart";
-      } else {
         return "Arrive";
+      } else {
+        return "Depart";
       }
+
+    case api.LogType.BasketContentSnapshot:
+      return `${basketName} Contents`;
+
+    case api.LogType.ResolvedIdentity:
+      return `${basketName} Identity`;
 
     case api.LogType.MachineCycle:
       if (entry.startofcycle) {
@@ -262,21 +268,46 @@ function display(props: LogEntryProps, fmsInfo: api.IFMSInfo): ReactNode {
 
     case api.LogType.BasketInLocation: {
       const basketName = basketDisplayName(fmsInfo.basketName);
+      const basketIdentity = entry.provisionalPal
+        ? `unidentified ${basketName.toLowerCase()} ${entry.provisionalPal}`
+        : `${basketName} ${entry.pal}`;
       if (entry.startofcycle) {
         return (
           <span>
-            {basketName} {entry.pal} departed from {entry.loc}
+            {basketIdentity} arrived at {entry.loc}
             {entry.locnum > 0 ? ` position ${entry.locnum}` : ""}
           </span>
         );
       } else {
         return (
           <span>
-            {basketName} {entry.pal} arrived at {entry.loc}
+            {basketIdentity} departed from {entry.loc}
             {entry.locnum > 0 ? ` position ${entry.locnum}` : ""}
           </span>
         );
       }
+    }
+
+    case api.LogType.BasketContentSnapshot: {
+      const basketName = basketDisplayName(fmsInfo.basketName);
+      const basketIdentity = entry.provisionalPal
+        ? `unidentified ${basketName.toLowerCase()} ${entry.provisionalPal}`
+        : `${basketName} ${entry.pal}`;
+      return (
+        <span>
+          Recorded complete contents for {basketIdentity}: {displayMat(entry.material)}
+        </span>
+      );
+    }
+
+    case api.LogType.ResolvedIdentity: {
+      const basketName = basketDisplayName(fmsInfo.basketName);
+      return (
+        <span>
+          Unidentified pallet or {basketName.toLowerCase()} {entry.provisionalPal} resolved to
+          number {entry.pal}
+        </span>
+      );
     }
 
     case api.LogType.MachineCycle:

--- a/client/insight/src/components/LogEntry.tsx
+++ b/client/insight/src/components/LogEntry.tsx
@@ -120,7 +120,7 @@ function logType(entry: api.ILogEntry, fmsInfo: api.IFMSInfo): string {
       return `${basketName} Contents`;
 
     case api.LogType.ResolvedIdentity:
-      return `${basketName} Identity`;
+      return "Identity Resolution";
 
     case api.LogType.MachineCycle:
       if (entry.startofcycle) {

--- a/client/insight/src/network/api.ts
+++ b/client/insight/src/network/api.ts
@@ -3018,6 +3018,7 @@ export class LogEntry implements ILogEntry {
   loc!: string;
   locnum!: number;
   pal!: number;
+  provisionalPal?: string | undefined;
   program!: string;
   result!: string;
   elapsed!: string;
@@ -3049,6 +3050,7 @@ export class LogEntry implements ILogEntry {
       this.loc = _data["loc"];
       this.locnum = _data["locnum"];
       this.pal = _data["pal"];
+      this.provisionalPal = _data["provisionalPal"];
       this.program = _data["program"];
       this.result = _data["result"];
       this.elapsed = _data["elapsed"];
@@ -3088,6 +3090,7 @@ export class LogEntry implements ILogEntry {
     data["loc"] = this.loc;
     data["locnum"] = this.locnum;
     data["pal"] = this.pal;
+    data["provisionalPal"] = this.provisionalPal;
     data["program"] = this.program;
     data["result"] = this.result;
     data["elapsed"] = this.elapsed;
@@ -3117,6 +3120,7 @@ export interface ILogEntry {
   loc: string;
   locnum: number;
   pal: number;
+  provisionalPal?: string | undefined;
   program: string;
   result: string;
   elapsed: string;
@@ -3216,6 +3220,8 @@ export enum LogType {
   BasketLoadUnload = "BasketLoadUnload",
   BasketCycle = "BasketCycle",
   BasketInLocation = "BasketInLocation",
+  ResolvedIdentity = "ResolvedIdentity",
+  BasketContentSnapshot = "BasketContentSnapshot",
 }
 
 export class ToolUse implements IToolUse {
@@ -3725,6 +3731,7 @@ export interface IHoldPattern {
 }
 
 export class ProcessInfo implements IProcessInfo {
+  extraFields?: { [key: string]: number } | undefined;
   basketLoadStations?: number[] | undefined;
   expectedBasketLoadTime?: string | undefined;
   basketUnloadStations?: number[] | undefined;
@@ -3744,6 +3751,13 @@ export class ProcessInfo implements IProcessInfo {
 
   init(_data?: any) {
     if (_data) {
+      if (_data["ExtraFields"]) {
+        this.extraFields = {} as any;
+        for (let key in _data["ExtraFields"]) {
+          if (_data["ExtraFields"].hasOwnProperty(key))
+            (this.extraFields as any)![key] = _data["ExtraFields"][key];
+        }
+      }
       if (Array.isArray(_data["BasketLoadStations"])) {
         this.basketLoadStations = [] as any;
         for (let item of _data["BasketLoadStations"]) this.basketLoadStations!.push(item);
@@ -3770,6 +3784,13 @@ export class ProcessInfo implements IProcessInfo {
 
   toJSON(data?: any) {
     data = typeof data === "object" ? data : {};
+    if (this.extraFields) {
+      data["ExtraFields"] = {};
+      for (let key in this.extraFields) {
+        if (this.extraFields.hasOwnProperty(key))
+          (data["ExtraFields"] as any)[key] = (this.extraFields as any)[key];
+      }
+    }
     if (Array.isArray(this.basketLoadStations)) {
       data["BasketLoadStations"] = [];
       for (let item of this.basketLoadStations) data["BasketLoadStations"].push(item);
@@ -3789,6 +3810,7 @@ export class ProcessInfo implements IProcessInfo {
 }
 
 export interface IProcessInfo {
+  extraFields?: { [key: string]: number } | undefined;
   basketLoadStations?: number[] | undefined;
   expectedBasketLoadTime?: string | undefined;
   basketUnloadStations?: number[] | undefined;

--- a/server/fms-insight-api.json
+++ b/server/fms-insight-api.json
@@ -2269,6 +2269,11 @@
             "type": "integer",
             "format": "int32"
           },
+          "provisionalPal": {
+            "type": "string",
+            "format": "guid",
+            "nullable": true
+          },
           "program": {
             "type": "string"
           },
@@ -2380,7 +2385,9 @@
           "CancelRebooking",
           "BasketLoadUnload",
           "BasketCycle",
-          "BasketInLocation"
+          "BasketInLocation",
+          "ResolvedIdentity",
+          "BasketContentSnapshot"
         ],
         "enum": [
           "LoadUnloadCycle",
@@ -2405,7 +2412,9 @@
           "CancelRebooking",
           "BasketLoadUnload",
           "BasketCycle",
-          "BasketInLocation"
+          "BasketInLocation",
+          "ResolvedIdentity",
+          "BasketContentSnapshot"
         ]
       },
       "ToolUse": {
@@ -2729,6 +2738,14 @@
         "additionalProperties": false,
         "required": ["paths", "paths"],
         "properties": {
+          "ExtraFields": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "number",
+              "format": "double"
+            }
+          },
           "BasketLoadStations": {
             "type": "array",
             "nullable": true,

--- a/server/lib/BlackMaple.MachineFramework/api/LogData.cs
+++ b/server/lib/BlackMaple.MachineFramework/api/LogData.cs
@@ -112,7 +112,44 @@ namespace BlackMaple.MachineFramework
     BasketLoadUnload = 116,
     BasketCycle = 117,
     BasketInLocation = 118,
+    ResolvedIdentity = 119,
+    BasketContentSnapshot = 120,
     // when adding types, must also update the display in client/insight/src/components/LogEntry.tsx
+  }
+
+  /// <summary>
+  /// The pallet or basket identity recorded on an immutable log entry. The pallet terminology is
+  /// historical; depending on <see cref="LogEntry.LogType"/>, these values can identify either a
+  /// manufacturing pallet or a basket.
+  /// </summary>
+  public abstract record PalletIdentity
+  {
+    private PalletIdentity() { }
+
+    public sealed record None : PalletIdentity;
+
+    public sealed record Numbered : PalletIdentity
+    {
+      public required int Pallet { get; init; }
+    }
+
+    public sealed record Provisional : PalletIdentity
+    {
+      public required Guid ProvisionalPallet { get; init; }
+    }
+
+    public sealed record Resolution : PalletIdentity
+    {
+      public required Guid ProvisionalPallet { get; init; }
+      public required int Pallet { get; init; }
+    }
+  }
+
+  public record ResolvedPalletIdentity
+  {
+    public required Guid ProvisionalPallet { get; init; }
+    public required int Pallet { get; init; }
+    public required long ResolutionEventCounter { get; init; }
   }
 
   [KnownType(typeof(MaterialProcessActualPath))]
@@ -141,6 +178,33 @@ namespace BlackMaple.MachineFramework
 
     [JsonPropertyName("pal")]
     public required int Pallet { get; init; }
+
+    /// <summary>
+    /// A globally unique provisional pallet or basket identity. The pallet terminology is
+    /// historical; the log type determines whether this identifies a pallet or a basket.
+    /// </summary>
+    [JsonPropertyName("provisionalPal")]
+    public Guid? ProvisionalPallet { get; init; }
+
+    [JsonIgnore]
+    public PalletIdentity Identity =>
+      (Pallet, ProvisionalPallet, LogType) switch
+      {
+        (<= 0, null, _) => new PalletIdentity.None(),
+        (> 0, null, _) => new PalletIdentity.Numbered { Pallet = Pallet },
+        (-1, Guid provisional, _) => new PalletIdentity.Provisional
+        {
+          ProvisionalPallet = provisional,
+        },
+        (> 0, Guid provisional, LogType.ResolvedIdentity) => new PalletIdentity.Resolution
+        {
+          ProvisionalPallet = provisional,
+          Pallet = Pallet,
+        },
+        _ => throw new InvalidOperationException(
+          $"Invalid pallet identity on log entry {Counter}: pallet {Pallet}, provisional pallet {ProvisionalPallet}, log type {LogType}."
+        ),
+      };
 
     [JsonPropertyName("program")]
     public required string Program { get; init; }
@@ -181,6 +245,7 @@ namespace BlackMaple.MachineFramework
       Counter = cntr;
       Material = mat.ToImmutableList();
       Pallet = pal;
+      ProvisionalPallet = null;
       LogType = ty;
       LocationName = locName;
       LocationNum = locNum;

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -731,27 +731,31 @@ namespace BlackMaple.MachineFramework
             provisionalIdentity.ProvisionalPallet.ToString("D");
         cmd.Parameters.Add("resolutionType", SqliteType.Integer).Value = (int)
           LogType.ResolvedIdentity;
+        cmd.Parameters.Add("cycleResult", SqliteType.Text).Value = "BasketCycle";
+        cmd.CommandText =
+          "SELECT MAX(s.Counter) FROM stations s WHERE "
+          + identityCondition
+          + " AND s.Result = $cycleResult";
+        var lastCycleCounter = cmd.ExecuteScalar() as long?;
+
         cmd.CommandText =
           "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
           + " FROM stations s WHERE "
           + identityCondition
-          + " AND s.StationLoc != $resolutionType AND "
+          + " AND s.StationLoc != $resolutionType "
+          + (
+            lastCycleCounter.HasValue
+              ? "AND s.Counter " + (includeLastCycleEvt ? ">= " : "> ") + "$lastCycleCounter "
+              : ""
+          )
+          + "AND "
           + ignoreInvalidEventCondition
           + " ORDER BY Counter ASC";
+        if (lastCycleCounter.HasValue)
+          cmd.Parameters.Add("lastCycleCounter", SqliteType.Integer).Value = lastCycleCounter.Value;
         using (var reader = cmd.ExecuteReader())
         {
-          var logs = LoadLog(reader, trans).ToList();
-          var lastCycleCounter = logs.Where(entry => entry.LogType == LogType.BasketCycle)
-            .Select(entry => (long?)entry.Counter)
-            .Max();
-          return lastCycleCounter.HasValue
-            ? logs.Where(entry =>
-                includeLastCycleEvt
-                  ? entry.Counter >= lastCycleCounter.Value
-                  : entry.Counter > lastCycleCounter.Value
-              )
-              .ToList()
-            : logs;
+          return LoadLog(reader, trans).ToList();
         }
       }
     }
@@ -1556,12 +1560,21 @@ namespace BlackMaple.MachineFramework
       using var cmd = _connection.CreateCommand();
       ((IDbCommand)cmd).Transaction = trans;
       cmd.CommandText =
+        "SELECT ProvisionalPallet FROM resolved_identities "
+        + "WHERE Pallet = $pal AND ProvisionalPallet != $provisionalPal LIMIT 1";
+      cmd.Parameters.Add("provisionalPal", SqliteType.Text).Value = provisionalPallet.ToString("D");
+      cmd.Parameters.Add("pal", SqliteType.Integer).Value = pallet;
+      var conflictingProvisional = cmd.ExecuteScalar() as string;
+      if (conflictingProvisional is not null)
+        throw new ConflictRequestException(
+          $"Pallet or basket {pallet} is already resolved from provisional identity {conflictingProvisional}."
+        );
+
+      cmd.CommandText =
         "INSERT INTO resolved_identities(ProvisionalPallet, Pallet, ResolutionCounter) "
         + "VALUES($provisionalPal, $pal, $counter) "
         + "ON CONFLICT(ProvisionalPallet) DO UPDATE SET Pallet = excluded.Pallet, ResolutionCounter = excluded.ResolutionCounter "
         + "WHERE excluded.ResolutionCounter > resolved_identities.ResolutionCounter";
-      cmd.Parameters.Add("provisionalPal", SqliteType.Text).Value = provisionalPallet.ToString("D");
-      cmd.Parameters.Add("pal", SqliteType.Integer).Value = pallet;
       cmd.Parameters.Add("counter", SqliteType.Integer).Value = resolutionCounter;
       cmd.ExecuteNonQuery();
     }

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -99,6 +99,7 @@ namespace BlackMaple.MachineFramework
           string locName = null;
           if (!reader.IsDBNull(11))
             locName = reader.GetString(11);
+          Guid? provisionalPallet = reader.IsDBNull(12) ? null : Guid.Parse(reader.GetString(12));
 
           LogType ty;
           if (Enum.IsDefined(typeof(LogType), logType))
@@ -268,6 +269,7 @@ namespace BlackMaple.MachineFramework
             Counter = ctr,
             Material = matLst.ToImmutable(),
             Pallet = pal,
+            ProvisionalPallet = provisionalPallet,
             LogType = ty,
             LocationName = locName,
             LocationNum = locNum,
@@ -300,7 +302,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
           + " FROM stations WHERE TimeUTC >= $start AND TimeUTC <= $end ORDER BY Counter ASC";
 
         cmd.Parameters.Add("start", SqliteType.Integer).Value = startUTC.Ticks;
@@ -341,7 +343,7 @@ namespace BlackMaple.MachineFramework
         {
           cmd.Transaction = trans;
           cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
             + " FROM stations WHERE Counter > $cntr ORDER BY Counter ASC";
           cmd.Parameters.Add("cntr", SqliteType.Integer).Value = counter;
 
@@ -363,7 +365,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
           + " FROM stations WHERE ForeignID = $foreign ORDER BY Counter DESC LIMIT 1";
         cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignID;
 
@@ -381,7 +383,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
           + " FROM stations WHERE ForeignID <= $foreign ORDER BY ForeignID DESC, Counter DESC LIMIT 1";
         cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignID;
 
@@ -433,7 +435,7 @@ namespace BlackMaple.MachineFramework
       using var cmd = _connection.CreateCommand();
       cmd.Transaction = trans;
       cmd.CommandText =
-        "SELECT s.Counter, s.Pallet, s.StationLoc, s.StationNum, s.Program, s.Start, s.TimeUTC, s.Result, s.EndOfRoute, s.Elapsed, s.ActiveTime, s.StationName "
+        "SELECT s.Counter, s.Pallet, s.StationLoc, s.StationNum, s.Program, s.Start, s.TimeUTC, s.Result, s.EndOfRoute, s.Elapsed, s.ActiveTime, s.StationName, s.ProvisionalPallet "
         + " FROM stations s "
         + " WHERE s.Counter IN (SELECT m.Counter FROM stations_mat m WHERE m.MaterialID = $mat)"
         + (includeInvalidatedCycles ? "" : " AND " + ignoreInvalidEventCondition)
@@ -469,7 +471,7 @@ namespace BlackMaple.MachineFramework
       }
 
       cmd.CommandText =
-        "SELECT s.Counter, s.Pallet, s.StationLoc, s.StationNum, s.Program, s.Start, s.TimeUTC, s.Result, s.EndOfRoute, s.Elapsed, s.ActiveTime, s.StationName "
+        "SELECT s.Counter, s.Pallet, s.StationLoc, s.StationNum, s.Program, s.Start, s.TimeUTC, s.Result, s.EndOfRoute, s.Elapsed, s.ActiveTime, s.StationName, s.ProvisionalPallet "
         + " FROM stations s WHERE s.Counter IN "
         + "     (SELECT m.Counter FROM stations_mat m WHERE m.MaterialID IN "
         + "        (SELECT t.MaterialID FROM temp_mat_ids t))"
@@ -491,7 +493,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
           + " FROM stations WHERE Counter IN (SELECT stations_mat.Counter FROM matdetails INNER JOIN stations_mat ON stations_mat.MaterialID = matdetails.MaterialID WHERE matdetails.Serial = $ser) ORDER BY Counter ASC";
         cmd.Parameters.Add("ser", SqliteType.Text).Value = serial;
 
@@ -512,7 +514,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
           + " FROM stations WHERE Counter IN (SELECT stations_mat.Counter FROM matdetails INNER JOIN stations_mat ON stations_mat.MaterialID = matdetails.MaterialID WHERE matdetails.UniqueStr = $uniq) ORDER BY Counter ASC";
         cmd.Parameters.Add("uniq", SqliteType.Text).Value = jobUnique;
 
@@ -533,7 +535,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
           + " FROM stations "
           + " WHERE Counter IN (SELECT stations_mat.Counter FROM matdetails INNER JOIN stations_mat ON stations_mat.MaterialID = matdetails.MaterialID WHERE matdetails.Workorder = $work) "
           + "    OR (Pallet = 0 AND Result = $work AND StationLoc = $workloc) "
@@ -584,7 +586,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
           + " FROM stations WHERE Counter IN ("
           + searchCompleted
           + ") ORDER BY Counter ASC";
@@ -608,7 +610,7 @@ namespace BlackMaple.MachineFramework
       using var cmd = _connection.CreateCommand();
       cmd.Transaction = trans;
       cmd.CommandText =
-        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
         + " FROM stations WHERE Counter > $cntr AND StationLoc = $loadty AND Result = 'UNLOAD' AND Start = 0";
       cmd.Parameters.Add("cntr", SqliteType.Integer).Value = counter;
       cmd.Parameters.Add("loadty", SqliteType.Integer).Value = (int)LogType.LoadUnloadCycle;
@@ -649,7 +651,7 @@ namespace BlackMaple.MachineFramework
         if (counter == DBNull.Value)
         {
           cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
             + " FROM stations s "
             + " WHERE Pallet = $pal AND "
             + ignoreInvalidEventCondition
@@ -662,7 +664,7 @@ namespace BlackMaple.MachineFramework
         else
         {
           cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
             + " FROM stations s "
             + " WHERE Pallet = $pal AND Counter "
             + (includeLastPalletCycleEvt ? ">=" : ">")
@@ -681,16 +683,27 @@ namespace BlackMaple.MachineFramework
 
     public List<LogEntry> CurrentBasketLog(int basketId, bool includeLastCycleEvt = false)
     {
+      return CurrentBasketLog(
+        new PalletIdentity.Numbered { Pallet = basketId },
+        includeLastCycleEvt
+      );
+    }
+
+    public List<LogEntry> CurrentBasketLog(
+      PalletIdentity basketIdentity,
+      bool includeLastCycleEvt = false
+    )
+    {
       using (var trans = _connection.BeginTransaction())
       {
-        var ret = CurrentBasketLog(basketId, includeLastCycleEvt, trans);
+        var ret = CurrentBasketLog(basketIdentity, includeLastCycleEvt, trans);
         trans.Commit();
         return ret;
       }
     }
 
     private List<LogEntry> CurrentBasketLog(
-      int basketId,
+      PalletIdentity basketIdentity,
       bool includeLastCycleEvt,
       SqliteTransaction trans
     )
@@ -698,48 +711,164 @@ namespace BlackMaple.MachineFramework
       using (var cmd = _connection.CreateCommand())
       {
         cmd.Transaction = trans;
+        var identityCondition = basketIdentity switch
+        {
+          PalletIdentity.Numbered numbered when numbered.Pallet > 0 =>
+            "((s.Pallet = $basketId AND s.ProvisionalPallet IS NULL) OR "
+              + "s.ProvisionalPallet IN (SELECT ProvisionalPallet FROM resolved_identities WHERE Pallet = $basketId))",
+          PalletIdentity.Provisional provisional when provisional.ProvisionalPallet != Guid.Empty =>
+            "(s.ProvisionalPallet = $provisionalPal OR "
+              + "(s.ProvisionalPallet IS NULL AND s.Pallet = (SELECT Pallet FROM resolved_identities WHERE ProvisionalPallet = $provisionalPal)))",
+          _ => throw new ArgumentException(
+            "A current basket log requires a positive numbered or non-empty provisional identity.",
+            nameof(basketIdentity)
+          ),
+        };
+        if (basketIdentity is PalletIdentity.Numbered numberedIdentity)
+          cmd.Parameters.Add("basketId", SqliteType.Integer).Value = numberedIdentity.Pallet;
+        else if (basketIdentity is PalletIdentity.Provisional provisionalIdentity)
+          cmd.Parameters.Add("provisionalPal", SqliteType.Text).Value =
+            provisionalIdentity.ProvisionalPallet.ToString("D");
+        cmd.Parameters.Add("resolutionType", SqliteType.Integer).Value = (int)
+          LogType.ResolvedIdentity;
         cmd.CommandText =
-          "SELECT MAX(Counter) FROM stations WHERE Pallet = $basketId AND Result = 'BasketCycle'";
-        cmd.Parameters.Add("basketId", SqliteType.Integer).Value = basketId;
-
-        var counter = cmd.ExecuteScalar();
-
-        if (counter == DBNull.Value)
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ProvisionalPallet "
+          + " FROM stations s WHERE "
+          + identityCondition
+          + " AND s.StationLoc != $resolutionType AND "
+          + ignoreInvalidEventCondition
+          + " ORDER BY Counter ASC";
+        using (var reader = cmd.ExecuteReader())
         {
-          cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
-            + " FROM stations s "
-            + " WHERE Pallet = $basketId AND "
-            + ignoreInvalidEventCondition
-            + " ORDER BY Counter ASC";
-          cmd.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
-            LogType.BasketLoadUnload;
-          cmd.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)LogType.BasketCycle;
-          using (var reader = cmd.ExecuteReader())
-          {
-            return LoadLog(reader, trans).ToList();
-          }
+          var logs = LoadLog(reader, trans).ToList();
+          var lastCycleCounter = logs.Where(entry => entry.LogType == LogType.BasketCycle)
+            .Select(entry => (long?)entry.Counter)
+            .Max();
+          return lastCycleCounter.HasValue
+            ? logs.Where(entry =>
+                includeLastCycleEvt
+                  ? entry.Counter >= lastCycleCounter.Value
+                  : entry.Counter > lastCycleCounter.Value
+              )
+              .ToList()
+            : logs;
         }
-        else
-        {
-          cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
-            + " FROM stations s "
-            + " WHERE Pallet = $basketId AND Counter "
-            + (includeLastCycleEvt ? ">=" : ">")
-            + " $cntr AND "
-            + ignoreInvalidEventCondition
-            + " ORDER BY Counter ASC";
-          cmd.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
-            LogType.BasketLoadUnload;
-          cmd.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)LogType.BasketCycle;
-          cmd.Parameters.Add("cntr", SqliteType.Integer).Value = (long)counter;
+      }
+    }
 
-          using (var reader = cmd.ExecuteReader())
-          {
-            return LoadLog(reader, trans).ToList();
-          }
+    public ResolvedPalletIdentity GetResolvedPalletIdentity(Guid provisionalPallet)
+    {
+      return GetResolvedPalletIdentities([provisionalPallet]).GetValueOrDefault(provisionalPallet);
+    }
+
+    public ImmutableDictionary<Guid, ResolvedPalletIdentity> GetResolvedPalletIdentities(
+      IEnumerable<Guid> provisionalPallets
+    )
+    {
+      var identities = provisionalPallets.Distinct().ToImmutableList();
+      if (identities.Count == 0)
+        return ImmutableDictionary<Guid, ResolvedPalletIdentity>.Empty;
+      if (identities.Any(identity => identity == Guid.Empty))
+        throw new ArgumentException("Provisional pallet identities must not be empty.");
+
+      lock (_cfg)
+      {
+        using var cmd = _connection.CreateCommand();
+        var parameterNames = identities
+          .Select(
+            (identity, index) =>
+            {
+              var name = "provisional" + index.ToString();
+              cmd.Parameters.Add(name, SqliteType.Text).Value = identity.ToString("D");
+              return "$" + name;
+            }
+          )
+          .ToImmutableList();
+        cmd.CommandText =
+          "SELECT ProvisionalPallet, Pallet, ResolutionCounter FROM resolved_identities WHERE ProvisionalPallet IN ("
+          + string.Join(",", parameterNames)
+          + ")";
+        using var reader = cmd.ExecuteReader();
+        var resolutions = ImmutableDictionary.CreateBuilder<Guid, ResolvedPalletIdentity>();
+        while (reader.Read())
+        {
+          var provisional = Guid.Parse(reader.GetString(0));
+          resolutions.Add(
+            provisional,
+            new ResolvedPalletIdentity
+            {
+              ProvisionalPallet = provisional,
+              Pallet = reader.GetInt32(1),
+              ResolutionEventCounter = reader.GetInt64(2),
+            }
+          );
         }
+        return resolutions.ToImmutable();
+      }
+    }
+
+    public ImmutableList<Guid> GetUnresolvedProvisionalPallets()
+    {
+      lock (_cfg)
+      {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText =
+          "SELECT DISTINCT s.ProvisionalPallet FROM stations s "
+          + "LEFT JOIN resolved_identities r ON r.ProvisionalPallet = s.ProvisionalPallet "
+          + "WHERE s.ProvisionalPallet IS NOT NULL AND r.ProvisionalPallet IS NULL "
+          + "AND s.StationLoc != $resolutionType ORDER BY s.ProvisionalPallet";
+        cmd.Parameters.Add("resolutionType", SqliteType.Integer).Value = (int)
+          LogType.ResolvedIdentity;
+        using var reader = cmd.ExecuteReader();
+        var identities = ImmutableList.CreateBuilder<Guid>();
+        while (reader.Read())
+          identities.Add(Guid.Parse(reader.GetString(0)));
+        return identities.ToImmutable();
+      }
+    }
+
+    public PalletIdentity ResolvePalletIdentity(PalletIdentity recordedIdentity)
+    {
+      var provisional = recordedIdentity switch
+      {
+        PalletIdentity.Provisional identity => identity.ProvisionalPallet,
+        PalletIdentity.Resolution identity => identity.ProvisionalPallet,
+        _ => (Guid?)null,
+      };
+      if (!provisional.HasValue)
+        return recordedIdentity;
+      var resolution = GetResolvedPalletIdentity(provisional.Value);
+      return resolution is null
+        ? new PalletIdentity.Provisional { ProvisionalPallet = provisional.Value }
+        : new PalletIdentity.Numbered { Pallet = resolution.Pallet };
+    }
+
+    public ImmutableDictionary<Guid, ResolvedPalletIdentity> ReconstructResolvedPalletIdentities()
+    {
+      lock (_cfg)
+      {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText =
+          "SELECT ProvisionalPallet, Pallet, Counter FROM stations "
+          + "WHERE StationLoc = $resolutionType ORDER BY Counter";
+        cmd.Parameters.Add("resolutionType", SqliteType.Integer).Value = (int)
+          LogType.ResolvedIdentity;
+        using var reader = cmd.ExecuteReader();
+        var resolutions = ImmutableDictionary<Guid, ResolvedPalletIdentity>.Empty;
+        while (reader.Read())
+        {
+          var provisional = Guid.Parse(reader.GetString(0));
+          resolutions = resolutions.SetItem(
+            provisional,
+            new ResolvedPalletIdentity
+            {
+              ProvisionalPallet = provisional,
+              Pallet = reader.GetInt32(1),
+              ResolutionEventCounter = reader.GetInt64(2),
+            }
+          );
+        }
+        return resolutions;
       }
     }
 
@@ -1241,6 +1370,7 @@ namespace BlackMaple.MachineFramework
       public required string LocationName { get; init; }
       public required int LocationNum { get; init; }
       public required int Pallet { get; init; }
+      public Guid? ProvisionalPallet { get; init; }
       public required string Program { get; init; }
       public required string Result { get; init; }
       public TimeSpan ElapsedTime { get; init; } = TimeSpan.FromMinutes(-1); //time from cycle-start to cycle-stop
@@ -1286,6 +1416,7 @@ namespace BlackMaple.MachineFramework
           LocationName = this.LocationName,
           LocationNum = this.LocationNum,
           Pallet = this.Pallet,
+          ProvisionalPallet = this.ProvisionalPallet,
           Program = this.Program,
           Result = this.Result,
           ElapsedTime = this.ElapsedTime,
@@ -1304,6 +1435,7 @@ namespace BlackMaple.MachineFramework
         {
           Material = e.Material.Select(EventLogMaterial.FromLogMat),
           Pallet = e.Pallet,
+          ProvisionalPallet = e.ProvisionalPallet,
           LogType = e.LogType,
           LocationName = e.LocationName,
           LocationNum = e.LocationNum,
@@ -1333,15 +1465,19 @@ namespace BlackMaple.MachineFramework
       string origMessage
     )
     {
+      ValidateLogEntry(log);
       using (var cmd = _connection.CreateCommand())
       {
         ((IDbCommand)cmd).Transaction = trans;
 
         cmd.CommandText =
-          "INSERT INTO stations(Pallet, StationLoc, StationName, StationNum, Program, Start, TimeUTC, Result, Elapsed, ActiveTime, ForeignID,OriginalMessage)"
-          + "VALUES ($pal,$loc,$locname,$locnum,$prog,$start,$time,$result,$elapsed,$active,$foreign,$orig)";
+          "INSERT INTO stations(Pallet, ProvisionalPallet, StationLoc, StationName, StationNum, Program, Start, TimeUTC, Result, Elapsed, ActiveTime, ForeignID,OriginalMessage)"
+          + "VALUES ($pal,$provisionalPal,$loc,$locname,$locnum,$prog,$start,$time,$result,$elapsed,$active,$foreign,$orig)";
 
         cmd.Parameters.Add("pal", SqliteType.Integer).Value = log.Pallet;
+        cmd.Parameters.Add("provisionalPal", SqliteType.Text).Value = log.ProvisionalPallet.HasValue
+          ? log.ProvisionalPallet.Value.ToString("D")
+          : DBNull.Value;
         cmd.Parameters.Add("loc", SqliteType.Integer).Value = (int)log.LogType;
         cmd.Parameters.Add("locname", SqliteType.Text).Value = log.LocationName;
         cmd.Parameters.Add("locnum", SqliteType.Integer).Value = log.LocationNum;
@@ -1376,9 +1512,58 @@ namespace BlackMaple.MachineFramework
         AddProgramDetail(ctr, log.ProgramDetails, trans);
         AddToolUse(ctr, log.Tools, trans);
         AddToolSnapshots(ctr, log.ToolPockets, trans);
+        if (log.LogType == LogType.ResolvedIdentity)
+          UpdateResolvedIdentityCache(log.ProvisionalPallet.Value, log.Pallet, ctr, trans);
 
         return log.ToLogEntry(ctr, m => this.GetMaterialDetails(m, trans));
       }
+    }
+
+    private static void ValidateLogEntry(NewEventLogEntry log)
+    {
+      var validIdentity = (log.Pallet, log.ProvisionalPallet, log.LogType) switch
+      {
+        (0, null, _) => true,
+        (> 0, null, _) => true,
+        (-1, Guid provisional, _) => provisional != Guid.Empty,
+        (> 0, Guid provisional, LogType.ResolvedIdentity) => provisional != Guid.Empty,
+        _ => false,
+      };
+      if (!validIdentity)
+        throw new ArgumentException(
+          $"Invalid pallet identity: pallet {log.Pallet}, provisional pallet {log.ProvisionalPallet}, log type {log.LogType}."
+        );
+
+      if (
+        log.LogType == LogType.ResolvedIdentity
+        && (log.Pallet <= 0 || !log.ProvisionalPallet.HasValue)
+      )
+        throw new ArgumentException(
+          "ResolvedIdentity requires a provisional and numbered identity."
+        );
+
+      if (log.LogType == LogType.BasketContentSnapshot && log.Pallet == 0)
+        throw new ArgumentException("BasketContentSnapshot requires a basket identity.");
+    }
+
+    private void UpdateResolvedIdentityCache(
+      Guid provisionalPallet,
+      int pallet,
+      long resolutionCounter,
+      IDbTransaction trans
+    )
+    {
+      using var cmd = _connection.CreateCommand();
+      ((IDbCommand)cmd).Transaction = trans;
+      cmd.CommandText =
+        "INSERT INTO resolved_identities(ProvisionalPallet, Pallet, ResolutionCounter) "
+        + "VALUES($provisionalPal, $pal, $counter) "
+        + "ON CONFLICT(ProvisionalPallet) DO UPDATE SET Pallet = excluded.Pallet, ResolutionCounter = excluded.ResolutionCounter "
+        + "WHERE excluded.ResolutionCounter > resolved_identities.ResolutionCounter";
+      cmd.Parameters.Add("provisionalPal", SqliteType.Text).Value = provisionalPallet.ToString("D");
+      cmd.Parameters.Add("pal", SqliteType.Integer).Value = pallet;
+      cmd.Parameters.Add("counter", SqliteType.Integer).Value = resolutionCounter;
+      cmd.ExecuteNonQuery();
     }
 
     private void AddMaterial(long counter, IEnumerable<EventLogMaterial> mat, IDbTransaction trans)
@@ -1568,6 +1753,22 @@ namespace BlackMaple.MachineFramework
       foreach (var l in logs)
         _cfg.OnNewLogEntry(l, foreignId, this);
       return logs;
+    }
+
+    private ImmutableList<LogEntry> AddEntriesInTransaction(
+      Func<IDbTransaction, IReadOnlyList<(LogEntry Log, string ForeignId)>> f
+    )
+    {
+      IReadOnlyList<(LogEntry Log, string ForeignId)> logs;
+      lock (_cfg)
+      {
+        using var trans = _connection.BeginTransaction();
+        logs = f(trans);
+        trans.Commit();
+      }
+      foreach (var entry in logs)
+        _cfg.OnNewLogEntry(entry.Log, entry.ForeignId, this);
+      return logs.Select(entry => entry.Log).ToImmutableList();
     }
 
     public LogEntry RecordLoadStart(
@@ -3283,24 +3484,43 @@ namespace BlackMaple.MachineFramework
       string originalMessage = null
     )
     {
-      return AddEntryInTransaction(trans =>
-      {
-        var entry = new NewEventLogEntry()
+      return RecordBasketArriveLocation(
+        mats,
+        new PalletIdentity.Numbered { Pallet = basketId },
+        locationName,
+        locationPosition,
+        timeUTC,
+        foreignId,
+        originalMessage
+      );
+    }
+
+    public LogEntry RecordBasketArriveLocation(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      return AddEntryInTransaction(
+        trans =>
         {
-          Material = mats,
-          Pallet = basketId,
-          LogType = LogType.BasketInLocation,
-          LocationName = locationName,
-          LocationNum = locationPosition,
-          Program = "Arrive",
-          StartOfCycle = true,
-          EndTimeUTC = timeUTC,
-          Result = "",
-          ElapsedTime = TimeSpan.Zero,
-          ActiveOperationTime = TimeSpan.Zero,
-        };
-        return AddLogEntry(trans, entry, foreignId, originalMessage);
-      });
+          var entry = NewBasketLocationEntry(
+            mats,
+            basketIdentity,
+            locationName,
+            locationPosition,
+            timeUTC,
+            arrive: true,
+            TimeSpan.Zero
+          );
+          return AddLogEntry(trans, entry, foreignId, originalMessage);
+        },
+        foreignId
+      );
     }
 
     public LogEntry RecordBasketDepartLocation(
@@ -3314,24 +3534,229 @@ namespace BlackMaple.MachineFramework
       string originalMessage = null
     )
     {
-      return AddEntryInTransaction(trans =>
-      {
-        var entry = new NewEventLogEntry()
+      return AddEntryInTransaction(
+        trans =>
+          AddLogEntry(
+            trans,
+            NewBasketLocationEntry(
+              mats,
+              new PalletIdentity.Numbered { Pallet = basketId },
+              locationName,
+              locationPosition,
+              timeUTC,
+              arrive: false,
+              elapsed
+            ),
+            foreignId,
+            originalMessage
+          ),
+        foreignId
+      );
+    }
+
+    public LogEntry RecordBasketDepartLocation(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      return AddEntryInTransaction(
+        trans =>
         {
-          Material = mats,
-          Pallet = basketId,
-          LogType = LogType.BasketInLocation,
-          LocationName = locationName,
-          LocationNum = locationPosition,
-          Program = "Depart",
-          StartOfCycle = false,
-          EndTimeUTC = timeUTC,
-          Result = "",
-          ElapsedTime = elapsed,
-          ActiveOperationTime = TimeSpan.Zero,
-        };
-        return AddLogEntry(trans, entry, foreignId, originalMessage);
+          var latestLocationEvent = CurrentBasketLog(
+              basketIdentity,
+              includeLastCycleEvt: true,
+              (SqliteTransaction)trans
+            )
+            .Where(entry =>
+              entry.LogType == LogType.BasketInLocation
+              && entry.LocationName == locationName
+              && entry.LocationNum == locationPosition
+            )
+            .MaxBy(entry => entry.Counter);
+          if (latestLocationEvent is not { Program: "Arrive" })
+            throw new ConflictRequestException(
+              "Can not record basket departure without a current arrival at the same location."
+            );
+          var elapsed = timeUTC - latestLocationEvent.EndTimeUTC;
+          if (elapsed < TimeSpan.Zero)
+            throw new ArgumentException("Basket departure can not occur before its arrival.");
+          return AddLogEntry(
+            trans,
+            NewBasketLocationEntry(
+              mats,
+              basketIdentity,
+              locationName,
+              locationPosition,
+              timeUTC,
+              arrive: false,
+              elapsed
+            ),
+            foreignId,
+            originalMessage
+          );
+        },
+        foreignId
+      );
+    }
+
+    public LogEntry RecordBasketContentSnapshot(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      return AddEntryInTransaction(
+        trans =>
+          AddLogEntry(
+            trans,
+            NewBasketContentSnapshot(mats, basketIdentity, timeUTC),
+            foreignId,
+            originalMessage
+          ),
+        foreignId
+      );
+    }
+
+    public ImmutableList<LogEntry> RecordBasketArrivalAndContentSnapshot(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      string arrivalForeignId = null,
+      string snapshotForeignId = null,
+      string originalMessage = null
+    )
+    {
+      var material = mats.ToImmutableList();
+      return AddEntriesInTransaction(trans =>
+      {
+        var arrival = AddLogEntry(
+          trans,
+          NewBasketLocationEntry(
+            material,
+            basketIdentity,
+            locationName,
+            locationPosition,
+            timeUTC,
+            arrive: true,
+            TimeSpan.Zero
+          ),
+          arrivalForeignId,
+          originalMessage
+        );
+        var snapshot = AddLogEntry(
+          trans,
+          NewBasketContentSnapshot(material, basketIdentity, timeUTC),
+          snapshotForeignId,
+          originalMessage
+        );
+        return [(arrival, arrivalForeignId), (snapshot, snapshotForeignId)];
       });
+    }
+
+    public LogEntry RecordResolvedPalletIdentity(
+      Guid provisionalPallet,
+      int pallet,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      var log = new NewEventLogEntry
+      {
+        Material = [],
+        Pallet = pallet,
+        ProvisionalPallet = provisionalPallet,
+        LogType = LogType.ResolvedIdentity,
+        LocationName = "Identity",
+        LocationNum = 1,
+        Program = "Resolve",
+        StartOfCycle = false,
+        EndTimeUTC = timeUTC,
+        Result = "",
+      };
+      return AddEntryInTransaction(
+        trans => AddLogEntry(trans, log, foreignId, originalMessage),
+        foreignId
+      );
+    }
+
+    private static NewEventLogEntry NewBasketLocationEntry(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      bool arrive,
+      TimeSpan elapsed
+    )
+    {
+      var (pallet, provisionalPallet) = RecordedPalletIdentity(basketIdentity);
+      return new NewEventLogEntry
+      {
+        Material = mats,
+        Pallet = pallet,
+        ProvisionalPallet = provisionalPallet,
+        LogType = LogType.BasketInLocation,
+        LocationName = locationName,
+        LocationNum = locationPosition,
+        Program = arrive ? "Arrive" : "Depart",
+        StartOfCycle = arrive,
+        EndTimeUTC = timeUTC,
+        Result = "",
+        ElapsedTime = elapsed,
+        ActiveOperationTime = TimeSpan.Zero,
+      };
+    }
+
+    private static NewEventLogEntry NewBasketContentSnapshot(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      DateTime timeUTC
+    )
+    {
+      var (pallet, provisionalPallet) = RecordedPalletIdentity(basketIdentity);
+      return new NewEventLogEntry
+      {
+        Material = mats,
+        Pallet = pallet,
+        ProvisionalPallet = provisionalPallet,
+        LogType = LogType.BasketContentSnapshot,
+        LocationName = "Basket",
+        LocationNum = 1,
+        Program = "Snapshot",
+        StartOfCycle = false,
+        EndTimeUTC = timeUTC,
+        Result = "CompleteContent",
+        ElapsedTime = TimeSpan.Zero,
+        ActiveOperationTime = TimeSpan.Zero,
+      };
+    }
+
+    private static (int Pallet, Guid? ProvisionalPallet) RecordedPalletIdentity(
+      PalletIdentity identity
+    )
+    {
+      return identity switch
+      {
+        PalletIdentity.Numbered numbered when numbered.Pallet > 0 => (numbered.Pallet, null),
+        PalletIdentity.Provisional provisional when provisional.ProvisionalPallet != Guid.Empty => (
+          -1,
+          provisional.ProvisionalPallet
+        ),
+        _ => throw new ArgumentException(
+          "A basket event requires a positive numbered or non-empty provisional identity.",
+          nameof(identity)
+        ),
+      };
     }
 
     public LogEntry RecordSerialForMaterialID(

--- a/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
@@ -64,6 +64,17 @@ namespace BlackMaple.MachineFramework
     IEnumerable<LogEntry> GetLogForWorkorder(string workorder);
     List<LogEntry> CurrentPalletLog(int pallet, bool includeLastPalletCycleEvt = false);
     List<LogEntry> CurrentBasketLog(int basketId, bool includeLastCycleEvt = false);
+    List<LogEntry> CurrentBasketLog(
+      PalletIdentity basketIdentity,
+      bool includeLastCycleEvt = false
+    );
+    ResolvedPalletIdentity GetResolvedPalletIdentity(Guid provisionalPallet);
+    ImmutableDictionary<Guid, ResolvedPalletIdentity> GetResolvedPalletIdentities(
+      IEnumerable<Guid> provisionalPallets
+    );
+    ImmutableList<Guid> GetUnresolvedProvisionalPallets();
+    PalletIdentity ResolvePalletIdentity(PalletIdentity recordedIdentity);
+    ImmutableDictionary<Guid, ResolvedPalletIdentity> ReconstructResolvedPalletIdentities();
     IEnumerable<ToolSnapshot> ToolPocketSnapshotForCycle(long counter);
     bool CycleExists(DateTime endUTC, int pal, LogType logTy, string locName, int locNum);
     ImmutableList<ActiveWorkorder> GetActiveWorkorder(string workorder);
@@ -285,6 +296,15 @@ namespace BlackMaple.MachineFramework
       string foreignId = null,
       string originalMessage = null
     );
+    LogEntry RecordBasketArriveLocation(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    );
     LogEntry RecordBasketDepartLocation(
       IEnumerable<EventLogMaterial> mats,
       int basketId,
@@ -292,6 +312,39 @@ namespace BlackMaple.MachineFramework
       int locationPosition,
       DateTime timeUTC,
       TimeSpan elapsed,
+      string foreignId = null,
+      string originalMessage = null
+    );
+    LogEntry RecordBasketDepartLocation(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    );
+    LogEntry RecordBasketContentSnapshot(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    );
+    ImmutableList<LogEntry> RecordBasketArrivalAndContentSnapshot(
+      IEnumerable<EventLogMaterial> mats,
+      PalletIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      string arrivalForeignId = null,
+      string snapshotForeignId = null,
+      string originalMessage = null
+    );
+    LogEntry RecordResolvedPalletIdentity(
+      Guid provisionalPallet,
+      int pallet,
+      DateTime timeUTC,
       string foreignId = null,
       string originalMessage = null
     );

--- a/server/lib/BlackMaple.MachineFramework/db/Schema.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/Schema.cs
@@ -101,7 +101,7 @@ namespace BlackMaple.MachineFramework
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
-          "CREATE INDEX stations_provisional_pal ON stations(ProvisionalPallet) WHERE ProvisionalPallet IS NOT NULL";
+          "CREATE INDEX stations_provisional_pal ON stations(ProvisionalPallet, Result) WHERE ProvisionalPallet IS NOT NULL";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -141,6 +141,9 @@ namespace BlackMaple.MachineFramework
 
         cmd.CommandText =
           "CREATE TABLE resolved_identities(ProvisionalPallet TEXT PRIMARY KEY, Pallet INTEGER NOT NULL, ResolutionCounter INTEGER NOT NULL)";
+        cmd.ExecuteNonQuery();
+        cmd.CommandText =
+          "CREATE INDEX resolved_identities_pallet ON resolved_identities(Pallet, ProvisionalPallet)";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -1326,10 +1329,13 @@ namespace BlackMaple.MachineFramework
       cmd.CommandText = "ALTER TABLE stations ADD ProvisionalPallet TEXT";
       cmd.ExecuteNonQuery();
       cmd.CommandText =
-        "CREATE INDEX stations_provisional_pal ON stations(ProvisionalPallet) WHERE ProvisionalPallet IS NOT NULL";
+        "CREATE INDEX stations_provisional_pal ON stations(ProvisionalPallet, Result) WHERE ProvisionalPallet IS NOT NULL";
       cmd.ExecuteNonQuery();
       cmd.CommandText =
         "CREATE TABLE resolved_identities(ProvisionalPallet TEXT PRIMARY KEY, Pallet INTEGER NOT NULL, ResolutionCounter INTEGER NOT NULL)";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE INDEX resolved_identities_pallet ON resolved_identities(Pallet, ProvisionalPallet)";
       cmd.ExecuteNonQuery();
     }
 

--- a/server/lib/BlackMaple.MachineFramework/db/Schema.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/Schema.cs
@@ -41,7 +41,7 @@ namespace BlackMaple.MachineFramework
 {
   internal static class DatabaseSchema
   {
-    private const int Version = 41;
+    private const int Version = 42;
 
     #region Create
     public static void CreateTables(SqliteConnection connection, SerialSettings settings)
@@ -86,7 +86,7 @@ namespace BlackMaple.MachineFramework
         cmd.CommandText =
           "CREATE TABLE stations(Counter INTEGER PRIMARY KEY AUTOINCREMENT,  Pallet INTEGER,"
           + "StationLoc INTEGER, StationName TEXT, StationNum INTEGER, Program TEXT, Start INTEGER, TimeUTC INTEGER,"
-          + "Result TEXT, EndOfRoute INTEGER, Elapsed INTEGER, ActiveTime INTEGER, ForeignID TEXT, OriginalMessage TEXT)";
+          + "Result TEXT, EndOfRoute INTEGER, Elapsed INTEGER, ActiveTime INTEGER, ForeignID TEXT, OriginalMessage TEXT, ProvisionalPallet TEXT)";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -98,6 +98,10 @@ namespace BlackMaple.MachineFramework
         cmd.ExecuteNonQuery();
 
         cmd.CommandText = "CREATE INDEX stations_pal ON stations(Pallet, Result)";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE INDEX stations_provisional_pal ON stations(ProvisionalPallet) WHERE ProvisionalPallet IS NOT NULL";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -133,6 +137,10 @@ namespace BlackMaple.MachineFramework
         cmd.CommandText =
           "CREATE TABLE program_details(Counter INTEGER, Key TEXT, Value TEXT, "
           + "PRIMARY KEY(Counter, Key))";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE TABLE resolved_identities(ProvisionalPallet TEXT PRIMARY KEY, Pallet INTEGER NOT NULL, ResolutionCounter INTEGER NOT NULL)";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -512,6 +520,9 @@ namespace BlackMaple.MachineFramework
 
           if (curVersion < 41)
             Ver40ToVer41(trans, updateJobsTables);
+
+          if (curVersion < 42)
+            Ver41ToVer42(trans);
 
           //update the version in the database
           cmd.Transaction = trans;
@@ -1304,6 +1315,21 @@ namespace BlackMaple.MachineFramework
       cmd.Transaction = trans;
       cmd.CommandText =
         "CREATE TABLE process_extra_fields(UniqueStr TEXT, Process INTEGER, Name TEXT, Value NUMERIC NOT NULL, PRIMARY KEY(UniqueStr,Process,Name))";
+      cmd.ExecuteNonQuery();
+    }
+
+    private static void Ver41ToVer42(IDbTransaction trans)
+    {
+      using var cmd = trans.Connection.CreateCommand();
+      cmd.Transaction = trans;
+
+      cmd.CommandText = "ALTER TABLE stations ADD ProvisionalPallet TEXT";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE INDEX stations_provisional_pal ON stations(ProvisionalPallet) WHERE ProvisionalPallet IS NOT NULL";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE TABLE resolved_identities(ProvisionalPallet TEXT PRIMARY KEY, Pallet INTEGER NOT NULL, ResolutionCounter INTEGER NOT NULL)";
       cmd.ExecuteNonQuery();
     }
 

--- a/server/machines/mazak/sync/LogTranslation.cs
+++ b/server/machines/mazak/sync/LogTranslation.cs
@@ -241,7 +241,7 @@ namespace MazakMachineInterface
 
     private void HandleLoadEnd(IReadOnlyList<LogEntry> es)
     {
-      int pallet = mazakConfig.TranslatePalletNumber(es[0].Pallet);
+      int pallet = TranslatePalletOrNone(es[0].Pallet);
 
       var cycle = new List<MWI.LogEntry>();
       if (pallet >= 1)
@@ -270,7 +270,7 @@ namespace MazakMachineInterface
 
     private bool HandleNonLulEndEvent(LogEntry e)
     {
-      var translatedPallet = mazakConfig.TranslatePalletNumber(e.Pallet);
+      var translatedPallet = TranslatePalletOrNone(e.Pallet);
       var cycle = new List<MWI.LogEntry>();
       if (translatedPallet >= 1)
         cycle = repo.CurrentPalletLog(translatedPallet);
@@ -1006,6 +1006,9 @@ namespace MazakMachineInterface
         }
       }
     }
+
+    private int TranslatePalletOrNone(int pallet) =>
+      pallet > 0 ? mazakConfig.TranslatePalletNumber(pallet) : 0;
     #endregion
 
     #region Compare Status With Events

--- a/server/test/LogUpgradeSpec.cs
+++ b/server/test/LogUpgradeSpec.cs
@@ -92,7 +92,7 @@ namespace BlackMaple.FMSInsight.Tests
         }
         if (sql2.StartsWith("CREATE TABLE stations"))
         {
-          sql1 = sql1.Replace("Pallet TEXT", "Pallet INTEGER");
+          sql1 = sql1.Replace("  Pallet TEXT,", "  Pallet INTEGER,");
         }
 
         // Face was changed text to integer

--- a/server/test/ProvisionalIdentitySpec.cs
+++ b/server/test/ProvisionalIdentitySpec.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using BlackMaple.MachineFramework;
+using Microsoft.Data.Sqlite;
+
+namespace BlackMaple.FMSInsight.Tests;
+
+#pragma warning disable TUnit0018 // Restart coverage intentionally replaces the repository config.
+public sealed class ProvisionalIdentitySpec : IDisposable
+{
+  private readonly string _databaseFile = Path.Combine(
+    Path.GetTempPath(),
+    Guid.NewGuid().ToString("N") + ".db"
+  );
+  private RepositoryConfig _repositoryConfig;
+
+  public ProvisionalIdentitySpec()
+  {
+    _repositoryConfig = RepositoryConfig.InitializeEventDatabase(
+      null,
+      _databaseFile,
+      pooling: false
+    );
+  }
+
+  public void Dispose()
+  {
+    _repositoryConfig.Dispose();
+    if (File.Exists(_databaseFile))
+      File.Delete(_databaseFile);
+  }
+
+  [Test]
+  public async Task PersistsNumberedProvisionalAndResolutionIdentityShapes()
+  {
+    var provisional = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+
+    var noIdentity = repository.RecordGeneralMessage(
+      mats: [],
+      program: "NoIdentity",
+      result: "",
+      pallet: 0
+    );
+    var numbered = repository.RecordBasketContentSnapshot(
+      mats: [],
+      basketIdentity: new PalletIdentity.Numbered { Pallet = 7 },
+      timeUTC: DateTime.UtcNow
+    );
+    var provisionalSnapshot = repository.RecordBasketContentSnapshot(
+      mats: [],
+      basketIdentity: new PalletIdentity.Provisional { ProvisionalPallet = provisional },
+      timeUTC: DateTime.UtcNow
+    );
+    var resolution = repository.RecordResolvedPalletIdentity(
+      provisional,
+      pallet: 7,
+      timeUTC: DateTime.UtcNow
+    );
+
+    var loaded = repository.GetRecentLog(0).ToImmutableList();
+    await Assert
+      .That(loaded.Single(entry => entry.Counter == noIdentity.Counter).Identity)
+      .IsTypeOf<PalletIdentity.None>();
+    await Assert
+      .That(loaded.Single(entry => entry.Counter == numbered.Counter).Identity)
+      .IsEqualTo(new PalletIdentity.Numbered { Pallet = 7 });
+    await Assert
+      .That(loaded.Single(entry => entry.Counter == provisionalSnapshot.Counter).Identity)
+      .IsEqualTo(new PalletIdentity.Provisional { ProvisionalPallet = provisional });
+    await Assert
+      .That(loaded.Single(entry => entry.Counter == resolution.Counter).Identity)
+      .IsEqualTo(new PalletIdentity.Resolution { ProvisionalPallet = provisional, Pallet = 7 });
+    await Assert
+      .That(
+        new LogEntry(
+          cntr: -1,
+          mat: [],
+          pal: -1,
+          ty: LogType.GeneralMessage,
+          locName: "Legacy",
+          locNum: 1,
+          prog: "Legacy",
+          start: false,
+          endTime: DateTime.UtcNow,
+          result: ""
+        ).Identity
+      )
+      .IsTypeOf<PalletIdentity.None>();
+  }
+
+  [Test]
+  public async Task RejectsInvalidIdentityAndSnapshotShapes()
+  {
+    using var repository = _repositoryConfig.OpenConnection();
+    var now = DateTime.UtcNow;
+
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordBasketArriveLocation(
+        mats: [],
+        basketIdentity: new PalletIdentity.None(),
+        locationName: "Staging",
+        locationPosition: 1,
+        timeUTC: now
+      )
+    );
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordBasketArriveLocation(
+        mats: [],
+        basketIdentity: new PalletIdentity.Resolution
+        {
+          ProvisionalPallet = Guid.NewGuid(),
+          Pallet = 2,
+        },
+        locationName: "Staging",
+        locationPosition: 1,
+        timeUTC: now
+      )
+    );
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordResolvedPalletIdentity(Guid.Empty, pallet: 2, timeUTC: now)
+    );
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordResolvedPalletIdentity(Guid.NewGuid(), pallet: 0, timeUTC: now)
+    );
+    await Assert.That(repository.GetRecentLog(0)).IsEmpty();
+  }
+
+  [Test]
+  public async Task RoundTripsCompleteNumberedAndProvisionalBasketSnapshots()
+  {
+    var provisional = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 2);
+    var material = new EventLogMaterial
+    {
+      MaterialID = materialId,
+      Process = 1,
+      Face = 2,
+    };
+    var numbered = repository.RecordBasketContentSnapshot(
+      [material],
+      new PalletIdentity.Numbered { Pallet = 3 },
+      DateTime.UtcNow
+    );
+    var provisionalSnapshot = repository.RecordBasketContentSnapshot(
+      [material],
+      new PalletIdentity.Provisional { ProvisionalPallet = provisional },
+      DateTime.UtcNow
+    );
+
+    var loaded = repository.GetRecentLog(0).ToImmutableList();
+    foreach (var counter in new[] { numbered.Counter, provisionalSnapshot.Counter })
+    {
+      var snapshot = loaded.Single(entry => entry.Counter == counter);
+      await Assert.That(snapshot.LogType).IsEqualTo(LogType.BasketContentSnapshot);
+      await Assert.That(snapshot.Material.Single().MaterialID).IsEqualTo(materialId);
+      await Assert.That(snapshot.Material.Single().Face).IsEqualTo(2);
+    }
+  }
+
+  [Test]
+  public async Task ResolutionCacheUsesEventCounterAndSurvivesRestart()
+  {
+    var provisional = Guid.NewGuid();
+    var laterTime = DateTime.UtcNow;
+    using (var repository = _repositoryConfig.OpenConnection())
+    {
+      var first = repository.RecordResolvedPalletIdentity(provisional, 4, laterTime);
+      var correction = repository.RecordResolvedPalletIdentity(
+        provisional,
+        6,
+        laterTime.AddDays(-1)
+      );
+
+      var current = repository.GetResolvedPalletIdentity(provisional);
+      await Assert.That(current.Pallet).IsEqualTo(6);
+      await Assert.That(current.ResolutionEventCounter).IsEqualTo(correction.Counter);
+      await Assert.That(correction.Counter).IsGreaterThan(first.Counter);
+      await Assert
+        .That(repository.ReconstructResolvedPalletIdentities()[provisional])
+        .IsEqualTo(current);
+    }
+
+    _repositoryConfig.Dispose();
+    _repositoryConfig = RepositoryConfig.InitializeEventDatabase(
+      null,
+      _databaseFile,
+      pooling: false
+    );
+    using var restartedRepository = _repositoryConfig.OpenConnection();
+    await Assert
+      .That(restartedRepository.GetResolvedPalletIdentity(provisional).Pallet)
+      .IsEqualTo(6);
+    await Assert
+      .That(
+        restartedRepository.ResolvePalletIdentity(
+          new PalletIdentity.Provisional { ProvisionalPallet = provisional }
+        )
+      )
+      .IsEqualTo(new PalletIdentity.Numbered { Pallet = 6 });
+  }
+
+  [Test]
+  public async Task ResolutionAndCacheUpdateRollBackTogether()
+  {
+    var provisional = Guid.NewGuid();
+    using (var connection = new SqliteConnection("Data Source=" + _databaseFile))
+    {
+      connection.Open();
+      using var command = connection.CreateCommand();
+      command.CommandText =
+        "CREATE TRIGGER fail_resolution_cache BEFORE INSERT ON resolved_identities BEGIN SELECT RAISE(ABORT, 'test rollback'); END";
+      command.ExecuteNonQuery();
+    }
+
+    using var repository = _repositoryConfig.OpenConnection();
+    await AssertThrows<SqliteException>(() =>
+      repository.RecordResolvedPalletIdentity(provisional, 4, DateTime.UtcNow)
+    );
+    await Assert.That(repository.GetRecentLog(0)).IsEmpty();
+    await Assert.That(repository.GetResolvedPalletIdentity(provisional)).IsNull();
+  }
+
+  [Test]
+  public async Task ProvisionalArrivalPairsWithNumberedDepartureAfterResolution()
+  {
+    var provisional = Guid.NewGuid();
+    var start = DateTime.UtcNow.AddMinutes(-15);
+    using var repository = _repositoryConfig.OpenConnection();
+
+    var firstObservation = repository.RecordBasketArrivalAndContentSnapshot(
+      mats: [],
+      basketIdentity: new PalletIdentity.Provisional { ProvisionalPallet = provisional },
+      locationName: "Staging",
+      locationPosition: 1,
+      timeUTC: start
+    );
+    repository.RecordBasketContentSnapshot(
+      mats: [],
+      basketIdentity: new PalletIdentity.Provisional { ProvisionalPallet = provisional },
+      timeUTC: start.AddMinutes(5)
+    );
+    repository.RecordResolvedPalletIdentity(provisional, 4, start.AddMinutes(10));
+    var departure = repository.RecordBasketDepartLocation(
+      mats: [],
+      basketIdentity: new PalletIdentity.Numbered { Pallet = 4 },
+      locationName: "Staging",
+      locationPosition: 1,
+      timeUTC: start.AddMinutes(15)
+    );
+
+    var currentLog = repository.CurrentBasketLog(4);
+    await Assert
+      .That(firstObservation.Select(entry => entry.LogType))
+      .IsEquivalentTo([LogType.BasketInLocation, LogType.BasketContentSnapshot]);
+    await Assert
+      .That(
+        currentLog.Count(entry =>
+          entry.LogType == LogType.BasketInLocation && entry.Program == "Arrive"
+        )
+      )
+      .IsEqualTo(1);
+    await Assert
+      .That(currentLog.Single(entry => entry.Counter == departure.Counter).ElapsedTime)
+      .IsEqualTo(TimeSpan.FromMinutes(15));
+    await Assert.That(repository.GetUnresolvedProvisionalPallets()).IsEmpty();
+  }
+
+  private static async Task AssertThrows<TException>(Action action)
+    where TException : Exception
+  {
+    Exception exception = null;
+    try
+    {
+      action();
+    }
+    catch (Exception caught)
+    {
+      exception = caught;
+    }
+    await Assert.That(exception).IsTypeOf<TException>();
+  }
+}

--- a/server/test/ProvisionalIdentitySpec.cs
+++ b/server/test/ProvisionalIdentitySpec.cs
@@ -226,6 +226,76 @@ public sealed class ProvisionalIdentitySpec : IDisposable
   }
 
   [Test]
+  public async Task RejectsTwoProvisionalIdentitiesResolvedToTheSameNumber()
+  {
+    var firstProvisional = Guid.NewGuid();
+    var conflictingProvisional = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+
+    var firstResolution = repository.RecordResolvedPalletIdentity(
+      firstProvisional,
+      pallet: 4,
+      timeUTC: DateTime.UtcNow
+    );
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordResolvedPalletIdentity(
+        conflictingProvisional,
+        pallet: 4,
+        timeUTC: DateTime.UtcNow
+      )
+    );
+
+    await Assert
+      .That(repository.GetResolvedPalletIdentity(firstProvisional).ResolutionEventCounter)
+      .IsEqualTo(firstResolution.Counter);
+    await Assert.That(repository.GetResolvedPalletIdentity(conflictingProvisional)).IsNull();
+    await Assert.That(repository.GetRecentLog(0)).Count().IsEqualTo(1);
+  }
+
+  [Test]
+  public async Task CurrentBasketLogSearchesOnlyEventsAfterLatestResolvedCycle()
+  {
+    var provisional = Guid.NewGuid();
+    var start = DateTime.UtcNow.AddMinutes(-10);
+    using var repository = _repositoryConfig.OpenConnection();
+
+    var beforeCycle = repository.RecordBasketContentSnapshot(
+      mats: [],
+      basketIdentity: new PalletIdentity.Provisional { ProvisionalPallet = provisional },
+      timeUTC: start
+    );
+    repository.RecordResolvedPalletIdentity(provisional, pallet: 4, timeUTC: start.AddMinutes(1));
+    var cycle = repository.RecordEmptyBasket(4, start.AddMinutes(2)).Single();
+    var afterCycle = repository.RecordBasketContentSnapshot(
+      mats: [],
+      basketIdentity: new PalletIdentity.Provisional { ProvisionalPallet = provisional },
+      timeUTC: start.AddMinutes(3)
+    );
+
+    foreach (
+      var identity in new PalletIdentity[]
+      {
+        new PalletIdentity.Numbered { Pallet = 4 },
+        new PalletIdentity.Provisional { ProvisionalPallet = provisional },
+      }
+    )
+    {
+      await Assert
+        .That(repository.CurrentBasketLog(identity).Select(entry => entry.Counter))
+        .IsEquivalentTo([afterCycle.Counter]);
+      await Assert
+        .That(
+          repository
+            .CurrentBasketLog(identity, includeLastCycleEvt: true)
+            .Select(entry => entry.Counter)
+        )
+        .IsEquivalentTo([cycle.Counter, afterCycle.Counter]);
+    }
+
+    await Assert.That(beforeCycle.Counter).IsLessThan(cycle.Counter);
+  }
+
+  [Test]
   public async Task ProvisionalArrivalPairsWithNumberedDepartureAfterResolution()
   {
     var provisional = Guid.NewGuid();


### PR DESCRIPTION
Persist provisional UUIDs on log entries, append identity-resolution events with an atomic current cache, and add resolution-aware basket history/dwell APIs. Record complete basket-content snapshots using existing event material rows, with no separate slot-state persistence. Normalize Mazak events with omitted pallet fields to no identity.