### PR TITLE
events: finalize container UUID fragments

### DIFF
--- a/client/insight/src/components/LogEntry.test.ts
+++ b/client/insight/src/components/LogEntry.test.ts
@@ -32,8 +32,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 import { filterRemoveAddQueue } from "./log-entry-queue-filter.js";
+import { basketContainerName } from "./log-entry-container-name.js";
 import { fakeCycle, fakeAddToQueue, fakeRemoveFromQueue } from "../../test/events.fake.js";
 import { it, expect } from "vitest";
+
+it("displays the UUID fragment when a basket identity hint also has a number", () => {
+  expect(
+    basketContainerName({ pal: 5, containerId: "12345678-1234-1234-1234-123456789abc" }, "Basket"),
+  ).toBe("Basket fragment 12345678");
+});
 
 it("doesn't filter just a single add", () => {
   const cycles = [

--- a/client/insight/src/components/LogEntry.tsx
+++ b/client/insight/src/components/LogEntry.tsx
@@ -47,6 +47,7 @@ import { useAtomValue } from "jotai";
 import { fmsInformation } from "../network/server-settings.js";
 import { basketDisplayName, loadStationDisplayName } from "../cell-status/station-cycles.js";
 import { filterRemoveAddQueue } from "./log-entry-queue-filter.js";
+import { basketContainerName } from "./log-entry-container-name.js";
 
 type ColoredSpanType =
   | "machine"
@@ -111,10 +112,16 @@ function logType(entry: api.ILogEntry, fmsInfo: api.IFMSInfo): string {
 
     case api.LogType.BasketInLocation:
       if (entry.startofcycle) {
-        return "Depart";
-      } else {
         return "Arrive";
+      } else {
+        return "Depart";
       }
+
+    case api.LogType.BasketIdentityHint:
+      return `${basketName} Identity Hint`;
+
+    case api.LogType.BasketContentSnapshot:
+      return `${basketName} Content Snapshot`;
 
     case api.LogType.MachineCycle:
       if (entry.startofcycle) {
@@ -232,10 +239,7 @@ function display(props: LogEntryProps, fmsInfo: api.IFMSInfo): ReactNode {
       return (
         <span>
           {displayMat(entry.material)} {entry.program === "LOAD" ? "loaded onto" : "unloaded from"}{" "}
-          <ColoredSpan $type="pallet">
-            {basketName} {entry.pal}
-          </ColoredSpan>{" "}
-          at{" "}
+          <ColoredSpan $type="pallet">{basketContainerName(entry, basketName)}</ColoredSpan> at{" "}
           <ColoredSpan $type="loadStation">
             {loadStationDisplayName(entry.locnum, fmsInfo.loadStationNames)}
           </ColoredSpan>
@@ -255,6 +259,9 @@ function display(props: LogEntryProps, fmsInfo: api.IFMSInfo): ReactNode {
         return (
           <span>
             {basketName} {entry.pal} completed cycle
+            {entry.containerIds && entry.containerIds.length > 0
+              ? ` from ${entry.containerIds.length} UUID fragment${entry.containerIds.length === 1 ? "" : "s"}`
+              : ""}
           </span>
         );
       }
@@ -265,18 +272,37 @@ function display(props: LogEntryProps, fmsInfo: api.IFMSInfo): ReactNode {
       if (entry.startofcycle) {
         return (
           <span>
-            {basketName} {entry.pal} departed from {entry.loc}
+            {basketContainerName(entry, basketName)} arrived at {entry.loc}
             {entry.locnum > 0 ? ` position ${entry.locnum}` : ""}
           </span>
         );
       } else {
         return (
           <span>
-            {basketName} {entry.pal} arrived at {entry.loc}
+            {basketContainerName(entry, basketName)} departed from {entry.loc}
             {entry.locnum > 0 ? ` position ${entry.locnum}` : ""}
           </span>
         );
       }
+    }
+
+    case api.LogType.BasketIdentityHint: {
+      const basketName = basketDisplayName(fmsInfo.basketName);
+      return (
+        <span>
+          {basketContainerName(entry, basketName)} presently associated with {basketName}{" "}
+          {entry.pal}
+        </span>
+      );
+    }
+
+    case api.LogType.BasketContentSnapshot: {
+      const basketName = basketDisplayName(fmsInfo.basketName);
+      return (
+        <span>
+          {basketContainerName(entry, basketName)} contained {displayMat(entry.material)}
+        </span>
+      );
     }
 
     case api.LogType.MachineCycle:

--- a/client/insight/src/components/log-entry-container-name.ts
+++ b/client/insight/src/components/log-entry-container-name.ts
@@ -1,0 +1,9 @@
+import * as api from "../network/api.js";
+
+type ContainerNameEntry = Readonly<Pick<api.ILogEntry, "pal" | "containerId">>;
+
+export function basketContainerName(entry: ContainerNameEntry, basketName: string): string {
+  if (entry.containerId) return `${basketName} fragment ${entry.containerId.slice(0, 8)}`;
+  if (entry.pal > 0) return `${basketName} ${entry.pal}`;
+  return basketName;
+}

--- a/client/insight/src/network/api.ts
+++ b/client/insight/src/network/api.ts
@@ -3018,6 +3018,8 @@ export class LogEntry implements ILogEntry {
   loc!: string;
   locnum!: number;
   pal!: number;
+  containerId?: string | undefined;
+  containerIds?: string[];
   program!: string;
   result!: string;
   elapsed!: string;
@@ -3049,6 +3051,11 @@ export class LogEntry implements ILogEntry {
       this.loc = _data["loc"];
       this.locnum = _data["locnum"];
       this.pal = _data["pal"];
+      this.containerId = _data["containerId"];
+      if (Array.isArray(_data["containerIds"])) {
+        this.containerIds = [] as any;
+        for (let item of _data["containerIds"]) this.containerIds!.push(item);
+      }
       this.program = _data["program"];
       this.result = _data["result"];
       this.elapsed = _data["elapsed"];
@@ -3088,6 +3095,11 @@ export class LogEntry implements ILogEntry {
     data["loc"] = this.loc;
     data["locnum"] = this.locnum;
     data["pal"] = this.pal;
+    data["containerId"] = this.containerId;
+    if (Array.isArray(this.containerIds)) {
+      data["containerIds"] = [];
+      for (let item of this.containerIds) data["containerIds"].push(item);
+    }
     data["program"] = this.program;
     data["result"] = this.result;
     data["elapsed"] = this.elapsed;
@@ -3117,6 +3129,8 @@ export interface ILogEntry {
   loc: string;
   locnum: number;
   pal: number;
+  containerId?: string | undefined;
+  containerIds?: string[];
   program: string;
   result: string;
   elapsed: string;
@@ -3216,6 +3230,8 @@ export enum LogType {
   BasketLoadUnload = "BasketLoadUnload",
   BasketCycle = "BasketCycle",
   BasketInLocation = "BasketInLocation",
+  BasketIdentityHint = "BasketIdentityHint",
+  BasketContentSnapshot = "BasketContentSnapshot",
 }
 
 export class ToolUse implements IToolUse {
@@ -3725,6 +3741,7 @@ export interface IHoldPattern {
 }
 
 export class ProcessInfo implements IProcessInfo {
+  extraFields?: { [key: string]: number } | undefined;
   basketLoadStations?: number[] | undefined;
   expectedBasketLoadTime?: string | undefined;
   basketUnloadStations?: number[] | undefined;
@@ -3744,6 +3761,13 @@ export class ProcessInfo implements IProcessInfo {
 
   init(_data?: any) {
     if (_data) {
+      if (_data["ExtraFields"]) {
+        this.extraFields = {} as any;
+        for (let key in _data["ExtraFields"]) {
+          if (_data["ExtraFields"].hasOwnProperty(key))
+            (this.extraFields as any)![key] = _data["ExtraFields"][key];
+        }
+      }
       if (Array.isArray(_data["BasketLoadStations"])) {
         this.basketLoadStations = [] as any;
         for (let item of _data["BasketLoadStations"]) this.basketLoadStations!.push(item);
@@ -3770,6 +3794,13 @@ export class ProcessInfo implements IProcessInfo {
 
   toJSON(data?: any) {
     data = typeof data === "object" ? data : {};
+    if (this.extraFields) {
+      data["ExtraFields"] = {};
+      for (let key in this.extraFields) {
+        if (this.extraFields.hasOwnProperty(key))
+          (data["ExtraFields"] as any)[key] = (this.extraFields as any)[key];
+      }
+    }
     if (Array.isArray(this.basketLoadStations)) {
       data["BasketLoadStations"] = [];
       for (let item of this.basketLoadStations) data["BasketLoadStations"].push(item);
@@ -3789,6 +3820,7 @@ export class ProcessInfo implements IProcessInfo {
 }
 
 export interface IProcessInfo {
+  extraFields?: { [key: string]: number } | undefined;
   basketLoadStations?: number[] | undefined;
   expectedBasketLoadTime?: string | undefined;
   basketUnloadStations?: number[] | undefined;

--- a/client/insight/src/network/api.ts
+++ b/client/insight/src/network/api.ts
@@ -3019,7 +3019,7 @@ export class LogEntry implements ILogEntry {
   locnum!: number;
   pal!: number;
   containerId?: string | undefined;
-  containerIds?: string[];
+  containerIds?: string[] | undefined;
   program!: string;
   result!: string;
   elapsed!: string;
@@ -3130,7 +3130,7 @@ export interface ILogEntry {
   locnum: number;
   pal: number;
   containerId?: string | undefined;
-  containerIds?: string[];
+  containerIds?: string[] | undefined;
   program: string;
   result: string;
   elapsed: string;

--- a/server/fms-insight-api.json
+++ b/server/fms-insight-api.json
@@ -2276,6 +2276,7 @@
           },
           "containerIds": {
             "type": "array",
+            "nullable": true,
             "items": {
               "type": "string",
               "format": "guid"

--- a/server/fms-insight-api.json
+++ b/server/fms-insight-api.json
@@ -2269,6 +2269,18 @@
             "type": "integer",
             "format": "int32"
           },
+          "containerId": {
+            "type": "string",
+            "format": "guid",
+            "nullable": true
+          },
+          "containerIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "guid"
+            }
+          },
           "program": {
             "type": "string"
           },
@@ -2380,7 +2392,9 @@
           "CancelRebooking",
           "BasketLoadUnload",
           "BasketCycle",
-          "BasketInLocation"
+          "BasketInLocation",
+          "BasketIdentityHint",
+          "BasketContentSnapshot"
         ],
         "enum": [
           "LoadUnloadCycle",
@@ -2405,7 +2419,9 @@
           "CancelRebooking",
           "BasketLoadUnload",
           "BasketCycle",
-          "BasketInLocation"
+          "BasketInLocation",
+          "BasketIdentityHint",
+          "BasketContentSnapshot"
         ]
       },
       "ToolUse": {
@@ -2729,6 +2745,14 @@
         "additionalProperties": false,
         "required": ["paths", "paths"],
         "properties": {
+          "ExtraFields": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "number",
+              "format": "double"
+            }
+          },
           "BasketLoadStations": {
             "type": "array",
             "nullable": true,

--- a/server/lib/BlackMaple.MachineFramework/api/LogData.cs
+++ b/server/lib/BlackMaple.MachineFramework/api/LogData.cs
@@ -112,7 +112,38 @@ namespace BlackMaple.MachineFramework
     BasketLoadUnload = 116,
     BasketCycle = 117,
     BasketInLocation = 118,
+    BasketIdentityHint = 119,
+    BasketContentSnapshot = 120,
     // when adding types, must also update the display in client/insight/src/components/LogEntry.tsx
+  }
+
+  /// <summary>
+  /// The container identity recorded by an immutable event. The numbered form uses the historical
+  /// <see cref="LogEntry.Pallet"/> field, which can identify either a pallet or a basket depending
+  /// on the event type.
+  /// </summary>
+  public abstract record ContainerIdentity
+  {
+    private ContainerIdentity() { }
+
+    public sealed record None : ContainerIdentity;
+
+    public sealed record Numbered : ContainerIdentity
+    {
+      public required int ContainerNum { get; init; }
+    }
+
+    public sealed record Uuid : ContainerIdentity
+    {
+      public required Guid ContainerId { get; init; }
+    }
+  }
+
+  public record CurrentBasketIdentityHint
+  {
+    public required Guid ContainerId { get; init; }
+    public required int BasketNum { get; init; }
+    public required long HintEventCounter { get; init; }
   }
 
   [KnownType(typeof(MaterialProcessActualPath))]
@@ -141,6 +172,36 @@ namespace BlackMaple.MachineFramework
 
     [JsonPropertyName("pal")]
     public required int Pallet { get; init; }
+
+    /// <summary>
+    /// An opaque, globally unique container identity. Ordinary events record either this UUID or a
+    /// positive <see cref="Pallet"/>, never both. Basket-identity-hint events exceptionally record
+    /// both.
+    /// </summary>
+    [JsonPropertyName("containerId")]
+    public Guid? ContainerId { get; init; }
+
+    /// <summary>
+    /// UUID fragments authoritatively finalized by this numbered basket-cycle end event.
+    /// </summary>
+    [JsonPropertyName("containerIds")]
+    public ImmutableList<Guid> BasketCycleContainerIds { get; init; } = [];
+
+    [JsonIgnore]
+    public ContainerIdentity Identity =>
+      (Pallet, ContainerId, LogType) switch
+      {
+        (0, null, _) => new ContainerIdentity.None(),
+        (> 0, null, _) => new ContainerIdentity.Numbered { ContainerNum = Pallet },
+        (-1, Guid id, _) when id != Guid.Empty => new ContainerIdentity.Uuid { ContainerId = id },
+        (> 0, Guid id, LogType.BasketIdentityHint) when id != Guid.Empty =>
+          new ContainerIdentity.Uuid { ContainerId = id },
+        // Older databases can contain -1 as a non-identity sentinel.
+        (-1, null, _) => new ContainerIdentity.None(),
+        _ => throw new InvalidOperationException(
+          $"Invalid container identity on log entry {Counter}: container number {Pallet}, container ID {ContainerId}, log type {LogType}."
+        ),
+      };
 
     [JsonPropertyName("program")]
     public required string Program { get; init; }
@@ -181,6 +242,8 @@ namespace BlackMaple.MachineFramework
       Counter = cntr;
       Material = mat.ToImmutableList();
       Pallet = pal;
+      ContainerId = null;
+      BasketCycleContainerIds = [];
       LogType = ty;
       LocationName = locName;
       LocationNum = locNum;

--- a/server/lib/BlackMaple.MachineFramework/api/LogData.cs
+++ b/server/lib/BlackMaple.MachineFramework/api/LogData.cs
@@ -182,10 +182,10 @@ namespace BlackMaple.MachineFramework
     public Guid? ContainerId { get; init; }
 
     /// <summary>
-    /// UUID fragments authoritatively finalized by this numbered basket-cycle end event.
+    /// UUID fragments authoritatively finalized by this numbered cycle-end event.
     /// </summary>
     [JsonPropertyName("containerIds")]
-    public ImmutableList<Guid> BasketCycleContainerIds { get; init; } = [];
+    public ImmutableList<Guid>? CycleEndContainerIds { get; init; }
 
     [JsonIgnore]
     public ContainerIdentity Identity =>
@@ -243,7 +243,7 @@ namespace BlackMaple.MachineFramework
       Material = mat.ToImmutableList();
       Pallet = pal;
       ContainerId = null;
-      BasketCycleContainerIds = [];
+      CycleEndContainerIds = null;
       LogType = ty;
       LocationName = locName;
       LocationNum = locNum;

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -288,7 +288,8 @@ namespace BlackMaple.MachineFramework
             Material = matLst.ToImmutable(),
             Pallet = pal,
             ContainerId = containerId,
-            BasketCycleContainerIds = cycleContainerIds.ToImmutable(),
+            CycleEndContainerIds =
+              cycleContainerIds.Count > 0 ? cycleContainerIds.ToImmutable() : null,
             LogType = ty,
             LocationName = locName,
             LocationNum = locNum,
@@ -1452,7 +1453,7 @@ namespace BlackMaple.MachineFramework
       public required int LocationNum { get; init; }
       public required int Pallet { get; init; }
       public Guid? ContainerId { get; init; }
-      public ImmutableList<Guid> BasketCycleContainerIds { get; init; } = [];
+      public ImmutableList<Guid> CycleEndContainerIds { get; init; }
       public required string Program { get; init; }
       public required string Result { get; init; }
       public TimeSpan ElapsedTime { get; init; } = TimeSpan.FromMinutes(-1); //time from cycle-start to cycle-stop
@@ -1499,7 +1500,7 @@ namespace BlackMaple.MachineFramework
           LocationNum = this.LocationNum,
           Pallet = this.Pallet,
           ContainerId = this.ContainerId,
-          BasketCycleContainerIds = this.BasketCycleContainerIds,
+          CycleEndContainerIds = this.CycleEndContainerIds,
           Program = this.Program,
           Result = this.Result,
           ElapsedTime = this.ElapsedTime,
@@ -1519,7 +1520,7 @@ namespace BlackMaple.MachineFramework
           Material = e.Material.Select(EventLogMaterial.FromLogMat),
           Pallet = e.Pallet,
           ContainerId = e.ContainerId,
-          BasketCycleContainerIds = e.BasketCycleContainerIds,
+          CycleEndContainerIds = e.CycleEndContainerIds,
           LogType = e.LogType,
           LocationName = e.LocationName,
           LocationNum = e.LocationNum,
@@ -1599,7 +1600,7 @@ namespace BlackMaple.MachineFramework
         AddToolUse(ctr, log.Tools, trans);
         AddToolSnapshots(ctr, log.ToolPockets, trans);
 
-        foreach (var containerId in log.BasketCycleContainerIds)
+        foreach (var containerId in log.CycleEndContainerIds ?? [])
         {
           cmd.CommandText =
             "INSERT INTO basket_cycle_container_ids(CycleCounter, ContainerId) VALUES($counter, $containerId)";
@@ -1652,14 +1653,14 @@ namespace BlackMaple.MachineFramework
       if (log.LogType == LogType.BasketContentSnapshot && log.Pallet == 0)
         throw new ArgumentException("BasketContentSnapshot requires a container identity.");
       if (
-        log.BasketCycleContainerIds.Count > 0
+        log.CycleEndContainerIds is { Count: > 0 } cycleEndContainerIds
         && (
           log.LogType != LogType.BasketCycle
           || log.StartOfCycle
           || log.Pallet <= 0
           || log.ContainerId.HasValue
-          || log.BasketCycleContainerIds.Any(id => id == Guid.Empty)
-          || log.BasketCycleContainerIds.Count != log.BasketCycleContainerIds.Distinct().Count()
+          || cycleEndContainerIds.Any(id => id == Guid.Empty)
+          || cycleEndContainerIds.Count != cycleEndContainerIds.Distinct().Count()
         )
       )
         throw new ArgumentException(
@@ -3037,7 +3038,7 @@ namespace BlackMaple.MachineFramework
         cycle = ExistingFinalization(foreignId, trans);
         if (cycle is not null)
         {
-          if (cycle.Pallet != basketId || !cycle.BasketCycleContainerIds.SequenceEqual(ids))
+          if (cycle.Pallet != basketId || cycle.CycleEndContainerIds?.SequenceEqual(ids) != true)
             throw new ConflictRequestException(
               $"Foreign ID {foreignId} already identifies a different basket-cycle finalization."
             );
@@ -3086,7 +3087,7 @@ namespace BlackMaple.MachineFramework
               Result = "BasketCycle",
               ElapsedTime = timeUTC >= firstEventTime ? timeUTC - firstEventTime : TimeSpan.Zero,
               ActiveOperationTime = TimeSpan.Zero,
-              BasketCycleContainerIds = ids,
+              CycleEndContainerIds = ids,
             },
             foreignId,
             originalMessage

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -50,12 +50,14 @@ namespace BlackMaple.MachineFramework
       using (var matCmd = _connection.CreateCommand())
       using (var detailCmd = _connection.CreateCommand())
       using (var toolCmd = _connection.CreateCommand())
+      using (var membershipCmd = _connection.CreateCommand())
       {
         if (trans != null)
         {
           ((IDbCommand)matCmd).Transaction = trans;
           ((IDbCommand)detailCmd).Transaction = trans;
           ((IDbCommand)toolCmd).Transaction = trans;
+          ((IDbCommand)membershipCmd).Transaction = trans;
         }
         matCmd.CommandText =
           "SELECT sm.MaterialID, m.UniqueStr, sm.Process, m.PartName, m.NumProcesses, sm.Face, m.Serial, m.Workorder, mp.Path "
@@ -71,6 +73,10 @@ namespace BlackMaple.MachineFramework
         toolCmd.CommandText =
           "SELECT Tool, Pocket, UseInCycle, UseAtEndOfCycle, ToolLife, ToolChange, SerialAtStart, SerialAtEnd, CountInCycle, CountAtEndOfCycle, LifeCount FROM station_tool_use WHERE Counter = $cntr";
         toolCmd.Parameters.Add("cntr", SqliteType.Integer);
+
+        membershipCmd.CommandText =
+          "SELECT ContainerId FROM basket_cycle_container_ids WHERE CycleCounter = $cntr ORDER BY ContainerId";
+        membershipCmd.Parameters.Add("cntr", SqliteType.Integer);
 
         while (reader.Read())
         {
@@ -99,6 +105,10 @@ namespace BlackMaple.MachineFramework
           string locName = null;
           if (!reader.IsDBNull(11))
             locName = reader.GetString(11);
+          Guid? containerId =
+            reader.FieldCount <= 12 || reader.IsDBNull(12)
+              ? null
+              : Guid.Parse(reader.GetString(12));
 
           LogType ty;
           if (Enum.IsDefined(typeof(LogType), logType))
@@ -263,11 +273,22 @@ namespace BlackMaple.MachineFramework
             }
           }
 
+          var cycleContainerIds = ImmutableList.CreateBuilder<Guid>();
+          if (ty == LogType.BasketCycle && !start)
+          {
+            membershipCmd.Parameters[0].Value = ctr;
+            using var membershipReader = membershipCmd.ExecuteReader();
+            while (membershipReader.Read())
+              cycleContainerIds.Add(Guid.Parse(membershipReader.GetString(0)));
+          }
+
           yield return new LogEntry()
           {
             Counter = ctr,
             Material = matLst.ToImmutable(),
             Pallet = pal,
+            ContainerId = containerId,
+            BasketCycleContainerIds = cycleContainerIds.ToImmutable(),
             LogType = ty,
             LocationName = locName,
             LocationNum = locNum,
@@ -300,7 +321,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
           + " FROM stations WHERE TimeUTC >= $start AND TimeUTC <= $end ORDER BY Counter ASC";
 
         cmd.Parameters.Add("start", SqliteType.Integer).Value = startUTC.Ticks;
@@ -341,7 +362,7 @@ namespace BlackMaple.MachineFramework
         {
           cmd.Transaction = trans;
           cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
             + " FROM stations WHERE Counter > $cntr ORDER BY Counter ASC";
           cmd.Parameters.Add("cntr", SqliteType.Integer).Value = counter;
 
@@ -363,7 +384,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
           + " FROM stations WHERE ForeignID = $foreign ORDER BY Counter DESC LIMIT 1";
         cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignID;
 
@@ -381,7 +402,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
           + " FROM stations WHERE ForeignID <= $foreign ORDER BY ForeignID DESC, Counter DESC LIMIT 1";
         cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignID;
 
@@ -491,7 +512,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
           + " FROM stations WHERE Counter IN (SELECT stations_mat.Counter FROM matdetails INNER JOIN stations_mat ON stations_mat.MaterialID = matdetails.MaterialID WHERE matdetails.Serial = $ser) ORDER BY Counter ASC";
         cmd.Parameters.Add("ser", SqliteType.Text).Value = serial;
 
@@ -512,7 +533,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
           + " FROM stations WHERE Counter IN (SELECT stations_mat.Counter FROM matdetails INNER JOIN stations_mat ON stations_mat.MaterialID = matdetails.MaterialID WHERE matdetails.UniqueStr = $uniq) ORDER BY Counter ASC";
         cmd.Parameters.Add("uniq", SqliteType.Text).Value = jobUnique;
 
@@ -533,7 +554,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
           + " FROM stations "
           + " WHERE Counter IN (SELECT stations_mat.Counter FROM matdetails INNER JOIN stations_mat ON stations_mat.MaterialID = matdetails.MaterialID WHERE matdetails.Workorder = $work) "
           + "    OR (Pallet = 0 AND Result = $work AND StationLoc = $workloc) "
@@ -584,7 +605,7 @@ namespace BlackMaple.MachineFramework
       {
         cmd.Transaction = trans;
         cmd.CommandText =
-          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+          "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
           + " FROM stations WHERE Counter IN ("
           + searchCompleted
           + ") ORDER BY Counter ASC";
@@ -608,7 +629,7 @@ namespace BlackMaple.MachineFramework
       using var cmd = _connection.CreateCommand();
       cmd.Transaction = trans;
       cmd.CommandText =
-        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
         + " FROM stations WHERE Counter > $cntr AND StationLoc = $loadty AND Result = 'UNLOAD' AND Start = 0";
       cmd.Parameters.Add("cntr", SqliteType.Integer).Value = counter;
       cmd.Parameters.Add("loadty", SqliteType.Integer).Value = (int)LogType.LoadUnloadCycle;
@@ -649,7 +670,7 @@ namespace BlackMaple.MachineFramework
         if (counter == DBNull.Value)
         {
           cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
             + " FROM stations s "
             + " WHERE Pallet = $pal AND "
             + ignoreInvalidEventCondition
@@ -662,7 +683,7 @@ namespace BlackMaple.MachineFramework
         else
         {
           cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
             + " FROM stations s "
             + " WHERE Pallet = $pal AND Counter "
             + (includeLastPalletCycleEvt ? ">=" : ">")
@@ -707,9 +728,9 @@ namespace BlackMaple.MachineFramework
         if (counter == DBNull.Value)
         {
           cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
             + " FROM stations s "
-            + " WHERE Pallet = $basketId AND "
+            + " WHERE Pallet = $basketId AND ContainerId IS NULL AND "
             + ignoreInvalidEventCondition
             + " ORDER BY Counter ASC";
           cmd.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
@@ -723,9 +744,9 @@ namespace BlackMaple.MachineFramework
         else
         {
           cmd.CommandText =
-            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName "
+            "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
             + " FROM stations s "
-            + " WHERE Pallet = $basketId AND Counter "
+            + " WHERE Pallet = $basketId AND ContainerId IS NULL AND Counter "
             + (includeLastCycleEvt ? ">=" : ">")
             + " $cntr AND "
             + ignoreInvalidEventCondition
@@ -741,6 +762,195 @@ namespace BlackMaple.MachineFramework
           }
         }
       }
+    }
+
+    public ImmutableList<LogEntry> CurrentBasketLog(
+      ContainerIdentity basketIdentity,
+      bool includeLastCycleEvt = false
+    )
+    {
+      using var trans = _connection.BeginTransaction();
+      var logs = basketIdentity switch
+      {
+        ContainerIdentity.None => [],
+        ContainerIdentity.Numbered numbered when numbered.ContainerNum > 0 =>
+          CurrentNumberedBasketAndFragments(numbered.ContainerNum, includeLastCycleEvt, trans),
+        ContainerIdentity.Uuid uuid when uuid.ContainerId != Guid.Empty => CurrentUuidFragment(
+          uuid.ContainerId,
+          trans
+        ),
+        _ => throw new ArgumentException("Invalid basket identity.", nameof(basketIdentity)),
+      };
+      trans.Commit();
+      return logs;
+    }
+
+    private ImmutableList<LogEntry> CurrentNumberedBasketAndFragments(
+      int basketId,
+      bool includeLastCycleEvt,
+      SqliteTransaction trans
+    )
+    {
+      var logs = CurrentBasketLog(basketId, includeLastCycleEvt, trans);
+      using var cmd = _connection.CreateCommand();
+      cmd.Transaction = trans;
+      cmd.CommandText =
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
+        + "FROM stations WHERE ContainerId IN (SELECT ContainerId FROM current_basket_identity_hints WHERE BasketNum = $num) ORDER BY Counter";
+      cmd.Parameters.Add("num", SqliteType.Integer).Value = basketId;
+      using var reader = cmd.ExecuteReader();
+      logs.AddRange(LoadLog(reader, trans));
+      return logs.OrderBy(log => log.Counter).ToImmutableList();
+    }
+
+    private ImmutableList<LogEntry> CurrentUuidFragment(Guid containerId, SqliteTransaction trans)
+    {
+      using var cmd = _connection.CreateCommand();
+      cmd.Transaction = trans;
+      cmd.CommandText =
+        "SELECT EXISTS(SELECT 1 FROM basket_cycle_container_ids WHERE ContainerId = $id)";
+      cmd.Parameters.Add("id", SqliteType.Text).Value = containerId.ToString("D");
+      if ((long)cmd.ExecuteScalar() != 0)
+        return [];
+
+      cmd.CommandText =
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
+        + "FROM stations WHERE ContainerId = $id ORDER BY Counter";
+      using var reader = cmd.ExecuteReader();
+      return LoadLog(reader, trans).ToImmutableList();
+    }
+
+    public ImmutableList<CurrentBasketIdentityHint> GetCurrentBasketIdentityHints(
+      int? basketNum = null
+    )
+    {
+      using var cmd = _connection.CreateCommand();
+      cmd.CommandText =
+        "SELECT ContainerId, BasketNum, HintCounter FROM current_basket_identity_hints "
+        + (basketNum.HasValue ? "WHERE BasketNum = $num " : "")
+        + "ORDER BY BasketNum, ContainerId";
+      if (basketNum.HasValue)
+        cmd.Parameters.Add("num", SqliteType.Integer).Value = basketNum.Value;
+      using var reader = cmd.ExecuteReader();
+      var hints = ImmutableList.CreateBuilder<CurrentBasketIdentityHint>();
+      while (reader.Read())
+      {
+        hints.Add(
+          new CurrentBasketIdentityHint
+          {
+            ContainerId = Guid.Parse(reader.GetString(0)),
+            BasketNum = reader.GetInt32(1),
+            HintEventCounter = reader.GetInt64(2),
+          }
+        );
+      }
+      return hints.ToImmutable();
+    }
+
+    public ImmutableList<Guid> GetUnresolvedOpenBasketContainerIds()
+    {
+      using var cmd = _connection.CreateCommand();
+      cmd.CommandText =
+        "SELECT DISTINCT s.ContainerId FROM stations s "
+        + "WHERE s.ContainerId IS NOT NULL "
+        + "AND s.StationLoc IN ($loadUnloadType, $locationType, $snapshotType) "
+        + "AND NOT EXISTS(SELECT 1 FROM current_basket_identity_hints h WHERE h.ContainerId = s.ContainerId) "
+        + "AND NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = s.ContainerId) "
+        + "ORDER BY s.ContainerId";
+      cmd.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
+        LogType.BasketLoadUnload;
+      cmd.Parameters.Add("locationType", SqliteType.Integer).Value = (int)LogType.BasketInLocation;
+      cmd.Parameters.Add("snapshotType", SqliteType.Integer).Value = (int)
+        LogType.BasketContentSnapshot;
+      using var reader = cmd.ExecuteReader();
+      var ids = ImmutableList.CreateBuilder<Guid>();
+      while (reader.Read())
+        ids.Add(Guid.Parse(reader.GetString(0)));
+      return ids.ToImmutable();
+    }
+
+    public ImmutableDictionary<Guid, CurrentBasketIdentityHint> ReconstructBasketIdentityHints()
+    {
+      using var cmd = _connection.CreateCommand();
+      cmd.CommandText =
+        "SELECT s.ContainerId, s.Pallet, s.Counter FROM stations s "
+        + "WHERE s.StationLoc = $hintType AND s.ContainerId IS NOT NULL "
+        + "AND NOT EXISTS(SELECT 1 FROM stations newer WHERE newer.StationLoc = $hintType AND newer.ContainerId = s.ContainerId AND newer.Counter > s.Counter) "
+        + "AND NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = s.ContainerId)";
+      cmd.Parameters.Add("hintType", SqliteType.Integer).Value = (int)LogType.BasketIdentityHint;
+      using var reader = cmd.ExecuteReader();
+      var hints = ImmutableDictionary.CreateBuilder<Guid, CurrentBasketIdentityHint>();
+      while (reader.Read())
+      {
+        var id = Guid.Parse(reader.GetString(0));
+        hints.Add(
+          id,
+          new CurrentBasketIdentityHint
+          {
+            ContainerId = id,
+            BasketNum = reader.GetInt32(1),
+            HintEventCounter = reader.GetInt64(2),
+          }
+        );
+      }
+      return hints.ToImmutable();
+    }
+
+    public LogEntry GetFinalizedBasketCycle(long cycleCounter)
+    {
+      using var trans = _connection.BeginTransaction();
+      using var cmd = _connection.CreateCommand();
+      cmd.Transaction = trans;
+      cmd.CommandText =
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
+        + "FROM stations WHERE Counter = $counter AND StationLoc = $cycleType AND Start = 0 AND Result = 'BasketCycle'";
+      cmd.Parameters.Add("counter", SqliteType.Integer).Value = cycleCounter;
+      cmd.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)LogType.BasketCycle;
+      using var reader = cmd.ExecuteReader();
+      var cycle = LoadLog(reader, trans).SingleOrDefault();
+      trans.Commit();
+      return cycle;
+    }
+
+    public ImmutableList<LogEntry> GetFinalizedBasketCycles(int basketId)
+    {
+      if (basketId <= 0)
+        throw new ArgumentOutOfRangeException(nameof(basketId));
+      using var trans = _connection.BeginTransaction();
+      using var cmd = _connection.CreateCommand();
+      cmd.Transaction = trans;
+      cmd.CommandText =
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
+        + "FROM stations WHERE Pallet = $num AND StationLoc = $cycleType AND Start = 0 AND Result = 'BasketCycle' ORDER BY Counter";
+      cmd.Parameters.Add("num", SqliteType.Integer).Value = basketId;
+      cmd.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)LogType.BasketCycle;
+      using var reader = cmd.ExecuteReader();
+      var cycles = LoadLog(reader, trans).ToImmutableList();
+      trans.Commit();
+      return cycles;
+    }
+
+    public ImmutableList<LogEntry> GetLogForFinalizedBasketCycle(long cycleCounter)
+    {
+      using var trans = _connection.BeginTransaction();
+      using var cmd = _connection.CreateCommand();
+      cmd.Transaction = trans;
+      cmd.CommandText =
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
+        + "FROM stations s WHERE s.Counter = $counter OR (s.StationLoc != $hintType AND s.ContainerId IN "
+        + "(SELECT ContainerId FROM basket_cycle_container_ids WHERE CycleCounter = $counter)) ORDER BY Counter";
+      cmd.Parameters.Add("counter", SqliteType.Integer).Value = cycleCounter;
+      cmd.Parameters.Add("hintType", SqliteType.Integer).Value = (int)LogType.BasketIdentityHint;
+      using var reader = cmd.ExecuteReader();
+      var logs = LoadLog(reader, trans).ToImmutableList();
+      if (
+        logs.All(entry =>
+          entry.Counter != cycleCounter
+          || entry is not { LogType: LogType.BasketCycle, StartOfCycle: false }
+        )
+      )
+        return [];
+      return logs;
     }
 
     public IEnumerable<ToolSnapshot> ToolPocketSnapshotForCycle(long counter)
@@ -1241,6 +1451,8 @@ namespace BlackMaple.MachineFramework
       public required string LocationName { get; init; }
       public required int LocationNum { get; init; }
       public required int Pallet { get; init; }
+      public Guid? ContainerId { get; init; }
+      public ImmutableList<Guid> BasketCycleContainerIds { get; init; } = [];
       public required string Program { get; init; }
       public required string Result { get; init; }
       public TimeSpan ElapsedTime { get; init; } = TimeSpan.FromMinutes(-1); //time from cycle-start to cycle-stop
@@ -1286,6 +1498,8 @@ namespace BlackMaple.MachineFramework
           LocationName = this.LocationName,
           LocationNum = this.LocationNum,
           Pallet = this.Pallet,
+          ContainerId = this.ContainerId,
+          BasketCycleContainerIds = this.BasketCycleContainerIds,
           Program = this.Program,
           Result = this.Result,
           ElapsedTime = this.ElapsedTime,
@@ -1304,6 +1518,8 @@ namespace BlackMaple.MachineFramework
         {
           Material = e.Material.Select(EventLogMaterial.FromLogMat),
           Pallet = e.Pallet,
+          ContainerId = e.ContainerId,
+          BasketCycleContainerIds = e.BasketCycleContainerIds,
           LogType = e.LogType,
           LocationName = e.LocationName,
           LocationNum = e.LocationNum,
@@ -1333,13 +1549,16 @@ namespace BlackMaple.MachineFramework
       string origMessage
     )
     {
+      ValidateLogEntry(log);
+      if (log.ContainerId.HasValue)
+        EnsureContainerIdOpen(log.ContainerId.Value, trans);
       using (var cmd = _connection.CreateCommand())
       {
         ((IDbCommand)cmd).Transaction = trans;
 
         cmd.CommandText =
-          "INSERT INTO stations(Pallet, StationLoc, StationName, StationNum, Program, Start, TimeUTC, Result, Elapsed, ActiveTime, ForeignID,OriginalMessage)"
-          + "VALUES ($pal,$loc,$locname,$locnum,$prog,$start,$time,$result,$elapsed,$active,$foreign,$orig)";
+          "INSERT INTO stations(Pallet, StationLoc, StationName, StationNum, Program, Start, TimeUTC, Result, Elapsed, ActiveTime, ForeignID,OriginalMessage,ContainerId)"
+          + "VALUES ($pal,$loc,$locname,$locnum,$prog,$start,$time,$result,$elapsed,$active,$foreign,$orig,$containerId)";
 
         cmd.Parameters.Add("pal", SqliteType.Integer).Value = log.Pallet;
         cmd.Parameters.Add("loc", SqliteType.Integer).Value = (int)log.LogType;
@@ -1349,6 +1568,9 @@ namespace BlackMaple.MachineFramework
         cmd.Parameters.Add("start", SqliteType.Integer).Value = log.StartOfCycle;
         cmd.Parameters.Add("time", SqliteType.Integer).Value = log.EndTimeUTC.Ticks;
         cmd.Parameters.Add("result", SqliteType.Text).Value = log.Result;
+        cmd.Parameters.Add("containerId", SqliteType.Text).Value = log.ContainerId.HasValue
+          ? log.ContainerId.Value.ToString("D")
+          : DBNull.Value;
         if (log.ElapsedTime.Ticks >= 0)
           cmd.Parameters.Add("elapsed", SqliteType.Integer).Value = log.ElapsedTime.Ticks;
         else
@@ -1377,8 +1599,72 @@ namespace BlackMaple.MachineFramework
         AddToolUse(ctr, log.Tools, trans);
         AddToolSnapshots(ctr, log.ToolPockets, trans);
 
+        foreach (var containerId in log.BasketCycleContainerIds)
+        {
+          cmd.CommandText =
+            "INSERT INTO basket_cycle_container_ids(CycleCounter, ContainerId) VALUES($counter, $containerId)";
+          cmd.Parameters.Clear();
+          cmd.Parameters.Add("counter", SqliteType.Integer).Value = ctr;
+          cmd.Parameters.Add("containerId", SqliteType.Text).Value = containerId.ToString("D");
+          cmd.ExecuteNonQuery();
+        }
+
         return log.ToLogEntry(ctr, m => this.GetMaterialDetails(m, trans));
       }
+    }
+
+    private void EnsureContainerIdOpen(Guid containerId, IDbTransaction trans)
+    {
+      using var cmd = _connection.CreateCommand();
+      ((IDbCommand)cmd).Transaction = trans;
+      cmd.CommandText =
+        "SELECT CycleCounter FROM basket_cycle_container_ids WHERE ContainerId = $containerId";
+      cmd.Parameters.Add("containerId", SqliteType.Text).Value = containerId.ToString("D");
+      var cycleCounter = cmd.ExecuteScalar();
+      if (cycleCounter is not null)
+        throw new ConflictRequestException(
+          $"Container UUID {containerId:D} was finalized by basket cycle {cycleCounter}."
+        );
+    }
+
+    private static void ValidateLogEntry(NewEventLogEntry log)
+    {
+      var validIdentity = (log.Pallet, log.ContainerId, log.LogType) switch
+      {
+        (0, null, _) => true,
+        (> 0, null, _) => true,
+        (-1, Guid id, _) => id != Guid.Empty,
+        (> 0, Guid id, LogType.BasketIdentityHint) => id != Guid.Empty,
+        _ => false,
+      };
+      if (!validIdentity)
+        throw new ArgumentException(
+          $"Invalid container identity: container number {log.Pallet}, container ID {log.ContainerId}, log type {log.LogType}."
+        );
+
+      if (
+        log.LogType == LogType.BasketIdentityHint
+        && (log.Pallet <= 0 || !log.ContainerId.HasValue)
+      )
+        throw new ArgumentException(
+          "BasketIdentityHint requires a positive basket number and a non-empty UUID."
+        );
+      if (log.LogType == LogType.BasketContentSnapshot && log.Pallet == 0)
+        throw new ArgumentException("BasketContentSnapshot requires a container identity.");
+      if (
+        log.BasketCycleContainerIds.Count > 0
+        && (
+          log.LogType != LogType.BasketCycle
+          || log.StartOfCycle
+          || log.Pallet <= 0
+          || log.ContainerId.HasValue
+          || log.BasketCycleContainerIds.Any(id => id == Guid.Empty)
+          || log.BasketCycleContainerIds.Count != log.BasketCycleContainerIds.Distinct().Count()
+        )
+      )
+        throw new ArgumentException(
+          "UUID membership is valid only on a numbered basket-cycle end and must contain unique, non-empty UUIDs."
+        );
     }
 
     private void AddMaterial(long counter, IEnumerable<EventLogMaterial> mat, IDbTransaction trans)
@@ -2106,9 +2392,7 @@ namespace BlackMaple.MachineFramework
       return newLogs;
     }
 
-    // RecordPartialBasketOnlyLoadUnload is for partial basket-only operations.
-    // This method records BasketLoadUnload events but does NOT emit BasketCycle events.
-    // The caller will later call RecordBasketOnlyLoadUnload with this material.
+    // Compatibility entry point for partial numbered basket-only operations.
     public IEnumerable<LogEntry> RecordPartialBasketOnlyLoadUnload(
       MaterialToLoadOntoBasket toLoad,
       MaterialToUnloadFromBasket toUnload,
@@ -2119,7 +2403,31 @@ namespace BlackMaple.MachineFramework
       IReadOnlyDictionary<string, string> externalQueues
     )
     {
+      return RecordBasketLoadUnload(
+        toLoad,
+        toUnload,
+        lulNum,
+        new ContainerIdentity.Numbered { ContainerNum = basketId },
+        totalElapsed,
+        timeUTC,
+        externalQueues
+      );
+    }
+
+    // Records ordinary basket load/unload evidence and queue changes without emitting BasketCycle
+    // events. UUID integrations finalize the basket cycle separately.
+    public IEnumerable<LogEntry> RecordBasketLoadUnload(
+      MaterialToLoadOntoBasket toLoad,
+      MaterialToUnloadFromBasket toUnload,
+      int lulNum,
+      ContainerIdentity basketIdentity,
+      TimeSpan totalElapsed,
+      DateTime timeUTC,
+      IReadOnlyDictionary<string, string> externalQueues
+    )
+    {
       var sendToExternal = new List<MaterialToSendToExternalQueue>();
+      var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
 
       var newLogs = AddEntryInTransaction(trans =>
       {
@@ -2173,7 +2481,8 @@ namespace BlackMaple.MachineFramework
                   Face = 0,
                   Process = toUnload.Process,
                 }),
-                Pallet = basketId,
+                Pallet = containerNum,
+                ContainerId = containerId,
                 LogType = LogType.BasketLoadUnload,
                 LocationName = "L/U",
                 LocationNum = lulNum,
@@ -2265,7 +2574,8 @@ namespace BlackMaple.MachineFramework
                   Face = 0,
                   Process = toLoad.Process,
                 }),
-                Pallet = basketId,
+                Pallet = containerNum,
+                ContainerId = containerId,
                 LogType = LogType.BasketLoadUnload,
                 LocationName = "L/U",
                 LocationNum = lulNum,
@@ -2699,6 +3009,129 @@ namespace BlackMaple.MachineFramework
           null
         )
       );
+    }
+
+    public LogEntry RecordBasketCycleEnd(
+      int basketId,
+      IEnumerable<EventLogMaterial> mats,
+      IReadOnlySet<Guid> containerIds,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      if (basketId <= 0)
+        throw new ArgumentOutOfRangeException(nameof(basketId));
+      var ids = containerIds.OrderBy(id => id).ToImmutableList();
+      if (ids.Count == 0 || ids.Any(id => id == Guid.Empty))
+        throw new ArgumentException(
+          "A finalized UUID basket cycle requires at least one non-empty container UUID.",
+          nameof(containerIds)
+        );
+
+      LogEntry cycle;
+      var added = false;
+      lock (_cfg)
+      {
+        using var trans = _connection.BeginTransaction();
+        cycle = ExistingFinalization(foreignId, trans);
+        if (cycle is not null)
+        {
+          if (cycle.Pallet != basketId || !cycle.BasketCycleContainerIds.SequenceEqual(ids))
+            throw new ConflictRequestException(
+              $"Foreign ID {foreignId} already identifies a different basket-cycle finalization."
+            );
+          trans.Commit();
+        }
+        else
+        {
+          var firstEventTime = timeUTC;
+          foreach (var id in ids)
+          {
+            using var validate = _connection.CreateCommand();
+            validate.Transaction = trans;
+            validate.CommandText =
+              "SELECT MIN(TimeUTC) FROM stations WHERE ContainerId = $id "
+              + "AND StationLoc IN ($loadUnloadType, $locationType, $snapshotType) AND "
+              + "NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = $id)";
+            validate.Parameters.Add("id", SqliteType.Text).Value = id.ToString("D");
+            validate.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
+              LogType.BasketLoadUnload;
+            validate.Parameters.Add("locationType", SqliteType.Integer).Value = (int)
+              LogType.BasketInLocation;
+            validate.Parameters.Add("snapshotType", SqliteType.Integer).Value = (int)
+              LogType.BasketContentSnapshot;
+            var first = validate.ExecuteScalar();
+            if (first is null || first == DBNull.Value)
+              throw new ConflictRequestException(
+                $"Container UUID {id:D} is not an open event fragment."
+              );
+            var eventTime = new DateTime((long)first, DateTimeKind.Utc);
+            if (eventTime < firstEventTime)
+              firstEventTime = eventTime;
+          }
+
+          cycle = AddLogEntry(
+            trans,
+            new NewEventLogEntry
+            {
+              Material = mats,
+              Pallet = basketId,
+              LogType = LogType.BasketCycle,
+              LocationName = "Basket Cycle",
+              LocationNum = 0,
+              Program = "",
+              StartOfCycle = false,
+              EndTimeUTC = timeUTC,
+              Result = "BasketCycle",
+              ElapsedTime = timeUTC >= firstEventTime ? timeUTC - firstEventTime : TimeSpan.Zero,
+              ActiveOperationTime = TimeSpan.Zero,
+              BasketCycleContainerIds = ids,
+            },
+            foreignId,
+            originalMessage
+          );
+
+          using var removeHints = _connection.CreateCommand();
+          removeHints.Transaction = trans;
+          removeHints.CommandText =
+            "DELETE FROM current_basket_identity_hints WHERE ContainerId = $id";
+          removeHints.Parameters.Add("id", SqliteType.Text);
+          foreach (var id in ids)
+          {
+            removeHints.Parameters[0].Value = id.ToString("D");
+            removeHints.ExecuteNonQuery();
+          }
+          trans.Commit();
+          added = true;
+        }
+      }
+
+      if (added)
+        _cfg.OnNewLogEntry(cycle, foreignId, this);
+      return cycle;
+    }
+
+    private LogEntry ExistingFinalization(string foreignId, SqliteTransaction trans)
+    {
+      if (string.IsNullOrEmpty(foreignId))
+        return null;
+      using var cmd = _connection.CreateCommand();
+      cmd.Transaction = trans;
+      cmd.CommandText =
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
+        + "FROM stations WHERE ForeignID = $foreign ORDER BY Counter DESC LIMIT 1";
+      cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
+      using var reader = cmd.ExecuteReader();
+      var existing = LoadLog(reader, trans).SingleOrDefault();
+      if (
+        existing is not null
+        && (existing.LogType != LogType.BasketCycle || existing.StartOfCycle)
+      )
+        throw new ConflictRequestException(
+          $"Foreign ID {foreignId} already identifies a non-finalization event."
+        );
+      return existing;
     }
 
     private IReadOnlyList<EventLogMaterial> GetMaterialFromLogEvent(
@@ -3223,12 +3656,33 @@ namespace BlackMaple.MachineFramework
       string originalMessage = null
     )
     {
+      return RecordBasketLoadBegin(
+        mats,
+        new ContainerIdentity.Numbered { ContainerNum = basketId },
+        lulNum,
+        timeUTC,
+        foreignId,
+        originalMessage
+      );
+    }
+
+    public LogEntry RecordBasketLoadBegin(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      int lulNum,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
       return AddEntryInTransaction(trans =>
       {
+        var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
         var entry = new NewEventLogEntry()
         {
           Material = mats,
-          Pallet = basketId,
+          Pallet = containerNum,
+          ContainerId = containerId,
           LogType = LogType.BasketLoadUnload,
           LocationName = "L/U",
           LocationNum = lulNum,
@@ -3252,13 +3706,34 @@ namespace BlackMaple.MachineFramework
       string originalMessage = null
     )
     {
+      return RecordBasketUnloadBegin(
+        mats,
+        new ContainerIdentity.Numbered { ContainerNum = basketId },
+        lulNum,
+        timeUTC,
+        foreignId,
+        originalMessage
+      );
+    }
+
+    public LogEntry RecordBasketUnloadBegin(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      int lulNum,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
       return AddEntryInTransaction(trans =>
       {
+        var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
         // Create BasketLoadUnload event
         var entry = new NewEventLogEntry()
         {
           Material = mats,
-          Pallet = basketId,
+          Pallet = containerNum,
+          ContainerId = containerId,
           LogType = LogType.BasketLoadUnload,
           LocationName = "L/U",
           LocationNum = lulNum,
@@ -3283,12 +3758,35 @@ namespace BlackMaple.MachineFramework
       string originalMessage = null
     )
     {
+      return RecordBasketArriveLocation(
+        mats,
+        new ContainerIdentity.Numbered { ContainerNum = basketId },
+        locationName,
+        locationPosition,
+        timeUTC,
+        foreignId,
+        originalMessage
+      );
+    }
+
+    public LogEntry RecordBasketArriveLocation(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
       return AddEntryInTransaction(trans =>
       {
+        var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
         var entry = new NewEventLogEntry()
         {
           Material = mats,
-          Pallet = basketId,
+          Pallet = containerNum,
+          ContainerId = containerId,
           LogType = LogType.BasketInLocation,
           LocationName = locationName,
           LocationNum = locationPosition,
@@ -3314,12 +3812,37 @@ namespace BlackMaple.MachineFramework
       string originalMessage = null
     )
     {
+      return RecordBasketDepartLocation(
+        mats,
+        new ContainerIdentity.Numbered { ContainerNum = basketId },
+        locationName,
+        locationPosition,
+        timeUTC,
+        elapsed,
+        foreignId,
+        originalMessage
+      );
+    }
+
+    public LogEntry RecordBasketDepartLocation(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      TimeSpan elapsed,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
       return AddEntryInTransaction(trans =>
       {
+        var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
         var entry = new NewEventLogEntry()
         {
           Material = mats,
-          Pallet = basketId,
+          Pallet = containerNum,
+          ContainerId = containerId,
           LogType = LogType.BasketInLocation,
           LocationName = locationName,
           LocationNum = locationPosition,
@@ -3333,6 +3856,129 @@ namespace BlackMaple.MachineFramework
         return AddLogEntry(trans, entry, foreignId, originalMessage);
       });
     }
+
+    public LogEntry RecordBasketContentSnapshot(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      return AddEntryInTransaction(trans =>
+      {
+        var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
+        return AddLogEntry(
+          trans,
+          new NewEventLogEntry
+          {
+            Material = mats,
+            Pallet = containerNum,
+            ContainerId = containerId,
+            LogType = LogType.BasketContentSnapshot,
+            LocationName = "Basket",
+            LocationNum = 1,
+            Program = "Snapshot",
+            StartOfCycle = false,
+            EndTimeUTC = timeUTC,
+            Result = "CompleteContent",
+            ElapsedTime = TimeSpan.Zero,
+            ActiveOperationTime = TimeSpan.Zero,
+          },
+          foreignId,
+          originalMessage
+        );
+      });
+    }
+
+    public LogEntry RecordBasketIdentityHint(
+      Guid containerId,
+      int basketNum,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      if (containerId == Guid.Empty)
+        throw new ArgumentException("Container UUID can not be empty.", nameof(containerId));
+      if (basketNum <= 0)
+        throw new ArgumentOutOfRangeException(nameof(basketNum));
+
+      return AddEntryInTransaction(
+        trans =>
+        {
+          EnsureOpenBasketFragment(containerId, trans);
+          var hint = AddLogEntry(
+            trans,
+            new NewEventLogEntry
+            {
+              Material = [],
+              Pallet = basketNum,
+              ContainerId = containerId,
+              LogType = LogType.BasketIdentityHint,
+              LocationName = "Identity",
+              LocationNum = 1,
+              Program = "Hint",
+              StartOfCycle = false,
+              EndTimeUTC = timeUTC,
+              Result = "Current",
+              ElapsedTime = TimeSpan.Zero,
+              ActiveOperationTime = TimeSpan.Zero,
+            },
+            foreignId,
+            originalMessage
+          );
+          using var cmd = _connection.CreateCommand();
+          ((IDbCommand)cmd).Transaction = trans;
+          cmd.CommandText =
+            "INSERT INTO current_basket_identity_hints(ContainerId, BasketNum, HintCounter) "
+            + "VALUES($id, $num, $counter) ON CONFLICT(ContainerId) DO UPDATE SET "
+            + "BasketNum = excluded.BasketNum, HintCounter = excluded.HintCounter "
+            + "WHERE excluded.HintCounter > current_basket_identity_hints.HintCounter";
+          cmd.Parameters.Add("id", SqliteType.Text).Value = containerId.ToString("D");
+          cmd.Parameters.Add("num", SqliteType.Integer).Value = basketNum;
+          cmd.Parameters.Add("counter", SqliteType.Integer).Value = hint.Counter;
+          cmd.ExecuteNonQuery();
+          return hint;
+        },
+        foreignId
+      );
+    }
+
+    private void EnsureOpenBasketFragment(Guid containerId, IDbTransaction trans)
+    {
+      using var cmd = _connection.CreateCommand();
+      ((IDbCommand)cmd).Transaction = trans;
+      cmd.CommandText =
+        "SELECT EXISTS(SELECT 1 FROM stations WHERE ContainerId = $id "
+        + "AND StationLoc IN ($loadUnloadType, $locationType, $snapshotType))";
+      cmd.Parameters.Add("id", SqliteType.Text).Value = containerId.ToString("D");
+      cmd.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
+        LogType.BasketLoadUnload;
+      cmd.Parameters.Add("locationType", SqliteType.Integer).Value = (int)LogType.BasketInLocation;
+      cmd.Parameters.Add("snapshotType", SqliteType.Integer).Value = (int)
+        LogType.BasketContentSnapshot;
+      if ((long)cmd.ExecuteScalar() == 0)
+        throw new ConflictRequestException(
+          $"Container UUID {containerId:D} does not identify an open basket fragment."
+        );
+    }
+
+    private static (int ContainerNum, Guid? ContainerId) RecordedContainerIdentity(
+      ContainerIdentity identity
+    ) =>
+      identity switch
+      {
+        ContainerIdentity.Numbered numbered when numbered.ContainerNum > 0 => (
+          numbered.ContainerNum,
+          null
+        ),
+        ContainerIdentity.Uuid uuid when uuid.ContainerId != Guid.Empty => (-1, uuid.ContainerId),
+        _ => throw new ArgumentException(
+          "A basket event requires a positive numbered identity or a non-empty UUID.",
+          nameof(identity)
+        ),
+      };
 
     public LogEntry RecordSerialForMaterialID(
       long materialID,

--- a/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
@@ -64,6 +64,16 @@ namespace BlackMaple.MachineFramework
     IEnumerable<LogEntry> GetLogForWorkorder(string workorder);
     List<LogEntry> CurrentPalletLog(int pallet, bool includeLastPalletCycleEvt = false);
     List<LogEntry> CurrentBasketLog(int basketId, bool includeLastCycleEvt = false);
+    ImmutableList<LogEntry> CurrentBasketLog(
+      ContainerIdentity basketIdentity,
+      bool includeLastCycleEvt = false
+    );
+    ImmutableList<CurrentBasketIdentityHint> GetCurrentBasketIdentityHints(int? basketNum = null);
+    ImmutableList<Guid> GetUnresolvedOpenBasketContainerIds();
+    ImmutableDictionary<Guid, CurrentBasketIdentityHint> ReconstructBasketIdentityHints();
+    LogEntry GetFinalizedBasketCycle(long cycleCounter);
+    ImmutableList<LogEntry> GetLogForFinalizedBasketCycle(long cycleCounter);
+    ImmutableList<LogEntry> GetFinalizedBasketCycles(int basketId);
     IEnumerable<ToolSnapshot> ToolPocketSnapshotForCycle(long counter);
     bool CycleExists(DateTime endUTC, int pal, LogType logTy, string locName, int locNum);
     ImmutableList<ActiveWorkorder> GetActiveWorkorder(string workorder);
@@ -107,9 +117,25 @@ namespace BlackMaple.MachineFramework
       string foreignId = null,
       string originalMessage = null
     );
+    LogEntry RecordBasketLoadBegin(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      int lulNum,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    );
     LogEntry RecordBasketUnloadBegin(
       IEnumerable<EventLogMaterial> mats,
       int basketId,
+      int lulNum,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    );
+    LogEntry RecordBasketUnloadBegin(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
       int lulNum,
       DateTime timeUTC,
       string foreignId = null,
@@ -157,6 +183,18 @@ namespace BlackMaple.MachineFramework
       MaterialToUnloadFromBasket toUnload,
       int lulNum,
       int basketId,
+      TimeSpan totalElapsed,
+      DateTime timeUTC,
+      IReadOnlyDictionary<string, string> externalQueues
+    );
+
+    // Records ordinary basket load/unload evidence and queue changes without implicitly opening or
+    // closing a numbered basket cycle. UUID-based integrations finalize the cycle separately.
+    IEnumerable<LogEntry> RecordBasketLoadUnload(
+      MaterialToLoadOntoBasket toLoad,
+      MaterialToUnloadFromBasket toUnload,
+      int lulNum,
+      ContainerIdentity basketIdentity,
       TimeSpan totalElapsed,
       DateTime timeUTC,
       IReadOnlyDictionary<string, string> externalQueues
@@ -285,6 +323,15 @@ namespace BlackMaple.MachineFramework
       string foreignId = null,
       string originalMessage = null
     );
+    LogEntry RecordBasketArriveLocation(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    );
     LogEntry RecordBasketDepartLocation(
       IEnumerable<EventLogMaterial> mats,
       int basketId,
@@ -292,6 +339,38 @@ namespace BlackMaple.MachineFramework
       int locationPosition,
       DateTime timeUTC,
       TimeSpan elapsed,
+      string foreignId = null,
+      string originalMessage = null
+    );
+    LogEntry RecordBasketDepartLocation(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      string locationName,
+      int locationPosition,
+      DateTime timeUTC,
+      TimeSpan elapsed,
+      string foreignId = null,
+      string originalMessage = null
+    );
+    LogEntry RecordBasketContentSnapshot(
+      IEnumerable<EventLogMaterial> mats,
+      ContainerIdentity basketIdentity,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    );
+    LogEntry RecordBasketIdentityHint(
+      Guid containerId,
+      int basketNum,
+      DateTime timeUTC,
+      string foreignId = null,
+      string originalMessage = null
+    );
+    LogEntry RecordBasketCycleEnd(
+      int basketId,
+      IEnumerable<EventLogMaterial> mats,
+      IReadOnlySet<Guid> containerIds,
+      DateTime timeUTC,
       string foreignId = null,
       string originalMessage = null
     );

--- a/server/lib/BlackMaple.MachineFramework/db/Schema.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/Schema.cs
@@ -41,7 +41,7 @@ namespace BlackMaple.MachineFramework
 {
   internal static class DatabaseSchema
   {
-    private const int Version = 41;
+    private const int Version = 42;
 
     #region Create
     public static void CreateTables(SqliteConnection connection, SerialSettings settings)
@@ -86,7 +86,7 @@ namespace BlackMaple.MachineFramework
         cmd.CommandText =
           "CREATE TABLE stations(Counter INTEGER PRIMARY KEY AUTOINCREMENT,  Pallet INTEGER,"
           + "StationLoc INTEGER, StationName TEXT, StationNum INTEGER, Program TEXT, Start INTEGER, TimeUTC INTEGER,"
-          + "Result TEXT, EndOfRoute INTEGER, Elapsed INTEGER, ActiveTime INTEGER, ForeignID TEXT, OriginalMessage TEXT)";
+          + "Result TEXT, EndOfRoute INTEGER, Elapsed INTEGER, ActiveTime INTEGER, ForeignID TEXT, OriginalMessage TEXT, ContainerId TEXT)";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -98,6 +98,14 @@ namespace BlackMaple.MachineFramework
         cmd.ExecuteNonQuery();
 
         cmd.CommandText = "CREATE INDEX stations_pal ON stations(Pallet, Result)";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE INDEX stations_container_id ON stations(ContainerId, StationLoc, Result, Counter) WHERE ContainerId IS NOT NULL";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE INDEX stations_basket_cycles ON stations(Pallet, Counter) WHERE StationLoc = 117 AND Result = 'BasketCycle'";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -152,6 +160,20 @@ namespace BlackMaple.MachineFramework
           "CREATE TABLE queues(MaterialID INTEGER, Queue TEXT, Position INTEGER, AddTimeUTC INTEGER, PRIMARY KEY(MaterialID, Queue))";
         cmd.ExecuteNonQuery();
         cmd.CommandText = "CREATE INDEX queues_idx ON queues(Queue, Position)";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE TABLE current_basket_identity_hints(ContainerId TEXT PRIMARY KEY, BasketNum INTEGER NOT NULL, HintCounter INTEGER NOT NULL UNIQUE)";
+        cmd.ExecuteNonQuery();
+        cmd.CommandText =
+          "CREATE INDEX current_basket_identity_hints_num ON current_basket_identity_hints(BasketNum, ContainerId)";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE TABLE basket_cycle_container_ids(CycleCounter INTEGER NOT NULL, ContainerId TEXT PRIMARY KEY)";
+        cmd.ExecuteNonQuery();
+        cmd.CommandText =
+          "CREATE INDEX basket_cycle_container_ids_cycle ON basket_cycle_container_ids(CycleCounter, ContainerId)";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
@@ -512,6 +534,9 @@ namespace BlackMaple.MachineFramework
 
           if (curVersion < 41)
             Ver40ToVer41(trans, updateJobsTables);
+
+          if (curVersion < 42)
+            Ver41ToVer42(trans);
 
           //update the version in the database
           cmd.Transaction = trans;
@@ -1304,6 +1329,33 @@ namespace BlackMaple.MachineFramework
       cmd.Transaction = trans;
       cmd.CommandText =
         "CREATE TABLE process_extra_fields(UniqueStr TEXT, Process INTEGER, Name TEXT, Value NUMERIC NOT NULL, PRIMARY KEY(UniqueStr,Process,Name))";
+      cmd.ExecuteNonQuery();
+    }
+
+    private static void Ver41ToVer42(IDbTransaction trans)
+    {
+      using var cmd = trans.Connection.CreateCommand();
+      cmd.Transaction = trans;
+
+      cmd.CommandText = "ALTER TABLE stations ADD ContainerId TEXT";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE INDEX stations_container_id ON stations(ContainerId, StationLoc, Result, Counter) WHERE ContainerId IS NOT NULL";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE INDEX stations_basket_cycles ON stations(Pallet, Counter) WHERE StationLoc = 117 AND Result = 'BasketCycle'";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE TABLE current_basket_identity_hints(ContainerId TEXT PRIMARY KEY, BasketNum INTEGER NOT NULL, HintCounter INTEGER NOT NULL UNIQUE)";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE INDEX current_basket_identity_hints_num ON current_basket_identity_hints(BasketNum, ContainerId)";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE TABLE basket_cycle_container_ids(CycleCounter INTEGER NOT NULL, ContainerId TEXT PRIMARY KEY)";
+      cmd.ExecuteNonQuery();
+      cmd.CommandText =
+        "CREATE INDEX basket_cycle_container_ids_cycle ON basket_cycle_container_ids(CycleCounter, ContainerId)";
       cmd.ExecuteNonQuery();
     }
 

--- a/server/machines/mazak/sync/LogTranslation.cs
+++ b/server/machines/mazak/sync/LogTranslation.cs
@@ -271,6 +271,9 @@ namespace MazakMachineInterface
     private bool HandleNonLulEndEvent(LogEntry e)
     {
       var translatedPallet = mazakConfig.TranslatePalletNumber(e.Pallet);
+      // Mazak uses -1 when an event has no pallet. New log events use zero for no container
+      // identity; -1 is reserved for UUID-identified containers.
+      var eventPallet = Math.Max(0, translatedPallet);
       var cycle = new List<MWI.LogEntry>();
       if (translatedPallet >= 1)
         cycle = repo.CurrentPalletLog(translatedPallet);
@@ -298,7 +301,7 @@ namespace MazakMachineInterface
                 Face = 0,
               },
             ],
-            pallet: translatedPallet,
+            pallet: eventPallet,
             lulNum: mazakConfig.TranslateLoadStationNumber(e.StationNumber),
             timeUTC: e.TimeUTC,
             foreignId: e.ForeignID
@@ -311,7 +314,7 @@ namespace MazakMachineInterface
 
           repo.RecordUnloadStart(
             mats: GetMaterialOnPallet(e, cycle).Select(m => m.Mat),
-            pallet: translatedPallet,
+            pallet: eventPallet,
             lulNum: mazakConfig.TranslateLoadStationNumber(e.StationNumber),
             timeUTC: e.TimeUTC,
             foreignId: e.ForeignID
@@ -341,7 +344,7 @@ namespace MazakMachineInterface
           LookupProgram(machineMats, e, out var progName, out var progRev);
           repo.RecordMachineStart(
             mats: machineMats.Select(m => m.Mat),
-            pallet: translatedPallet,
+            pallet: eventPallet,
             statName: machGroupName,
             statNum: mcNum,
             program: progName,
@@ -400,7 +403,7 @@ namespace MazakMachineInterface
             LookupProgram(machineMats, e, out var progName, out var progRev);
             var s = repo.RecordMachineEnd(
               mats: machineMats.Select(m => m.Mat),
-              pallet: translatedPallet,
+              pallet: eventPallet,
               statName: machGroupName,
               statNum: mcNum,
               program: progName,
@@ -444,7 +447,7 @@ namespace MazakMachineInterface
           }
           repo.RecordPalletDepartRotaryInbound(
             mats: GetAllMaterialOnPallet(cycle).Select(EventLogMaterial.FromLogMat),
-            pallet: translatedPallet,
+            pallet: eventPallet,
             statName: machGroupName,
             statNum: mcNum,
             timeUTC: e.TimeUTC,
@@ -479,7 +482,7 @@ namespace MazakMachineInterface
               }
               repo.RecordPalletDepartRotaryInbound(
                 mats: GetAllMaterialOnPallet(cycle).Select(EventLogMaterial.FromLogMat),
-                pallet: translatedPallet,
+                pallet: eventPallet,
                 statName: machGroupName,
                 statNum: mcNum,
                 rotateIntoWorktable: false,
@@ -499,7 +502,7 @@ namespace MazakMachineInterface
             {
               repo.RecordPalletDepartStocker(
                 mats: GetAllMaterialOnPallet(cycle).Select(EventLogMaterial.FromLogMat),
-                pallet: translatedPallet,
+                pallet: eventPallet,
                 stockerNum: stockerNum,
                 timeUTC: e.TimeUTC,
                 waitForMachine: !cycle.Any(c => c.LogType == LogType.MachineCycle),
@@ -531,7 +534,7 @@ namespace MazakMachineInterface
               }
               repo.RecordPalletArriveRotaryInbound(
                 mats: GetAllMaterialOnPallet(cycle).Select(EventLogMaterial.FromLogMat),
-                pallet: translatedPallet,
+                pallet: eventPallet,
                 statName: machGroupName,
                 statNum: mcNum,
                 timeUTC: e.TimeUTC,
@@ -549,7 +552,7 @@ namespace MazakMachineInterface
             {
               repo.RecordPalletArriveStocker(
                 mats: GetAllMaterialOnPallet(cycle).Select(EventLogMaterial.FromLogMat),
-                pallet: translatedPallet,
+                pallet: eventPallet,
                 stockerNum: stockerNum,
                 waitForMachine: !cycle.Any(c => c.LogType == LogType.MachineCycle),
                 timeUTC: e.TimeUTC,

--- a/server/test/ContainerIdentitySpec.cs
+++ b/server/test/ContainerIdentitySpec.cs
@@ -1,0 +1,559 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using BlackMaple.MachineFramework;
+using Microsoft.Data.Sqlite;
+
+namespace BlackMaple.FMSInsight.Tests;
+
+#pragma warning disable TUnit0018 // Restart coverage intentionally replaces the repository config.
+public sealed class ContainerIdentitySpec : IDisposable
+{
+  private readonly string _databaseFile = Path.Combine(
+    Path.GetTempPath(),
+    Guid.NewGuid().ToString("N") + ".db"
+  );
+  private RepositoryConfig _repositoryConfig;
+
+  public ContainerIdentitySpec()
+  {
+    _repositoryConfig = RepositoryConfig.InitializeEventDatabase(
+      null,
+      _databaseFile,
+      pooling: false
+    );
+  }
+
+  public void Dispose()
+  {
+    _repositoryConfig.Dispose();
+    if (File.Exists(_databaseFile))
+      File.Delete(_databaseFile);
+  }
+
+  [Test]
+  public async Task PersistsNumberedUuidAndNoContainerIdentity()
+  {
+    var id = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+
+    var noIdentity = repository.RecordGeneralMessage(
+      mats: [],
+      program: "NoIdentity",
+      result: "",
+      pallet: 0
+    );
+    var numbered = repository.RecordBasketContentSnapshot(
+      mats: [],
+      new ContainerIdentity.Numbered { ContainerNum = 7 },
+      DateTime.UtcNow
+    );
+    var uuid = repository.RecordBasketContentSnapshot(
+      mats: [],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      DateTime.UtcNow
+    );
+
+    var loaded = repository.GetRecentLog(0).ToImmutableList();
+    await Assert
+      .That(loaded.Single(entry => entry.Counter == noIdentity.Counter).Identity)
+      .IsTypeOf<ContainerIdentity.None>();
+    await Assert
+      .That(loaded.Single(entry => entry.Counter == numbered.Counter).Identity)
+      .IsEqualTo(new ContainerIdentity.Numbered { ContainerNum = 7 });
+    await Assert
+      .That(loaded.Single(entry => entry.Counter == uuid.Counter).Identity)
+      .IsEqualTo(new ContainerIdentity.Uuid { ContainerId = id });
+  }
+
+  [Test]
+  public async Task CompleteSnapshotRoundTripsMaterialForNumberedAndUuidContainers()
+  {
+    var id = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 2);
+    var material = new EventLogMaterial
+    {
+      MaterialID = materialId,
+      Process = 1,
+      Face = 3,
+    };
+
+    var numbered = repository.RecordBasketContentSnapshot(
+      [material],
+      new ContainerIdentity.Numbered { ContainerNum = 4 },
+      DateTime.UtcNow
+    );
+    var uuid = repository.RecordBasketContentSnapshot(
+      [material],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      DateTime.UtcNow
+    );
+
+    foreach (var counter in new[] { numbered.Counter, uuid.Counter })
+    {
+      var snapshot = repository.GetRecentLog(0).Single(entry => entry.Counter == counter);
+      await Assert.That(snapshot.LogType).IsEqualTo(LogType.BasketContentSnapshot);
+      await Assert.That(snapshot.Material.Single().MaterialID).IsEqualTo(materialId);
+      await Assert.That(snapshot.Material.Single().Face).IsEqualTo(3);
+    }
+  }
+
+  [Test]
+  public async Task BasketLoadUnloadCanUseUuidIdentity()
+  {
+    var id = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 1);
+    var logs = repository
+      .RecordBasketLoadUnload(
+        new MaterialToLoadOntoBasket
+        {
+          MaterialIDs = [materialId],
+          Process = 1,
+          ActiveOperationTime = TimeSpan.FromMinutes(1),
+        },
+        toUnload: null,
+        lulNum: 2,
+        basketIdentity: new ContainerIdentity.Uuid { ContainerId = id },
+        totalElapsed: TimeSpan.FromMinutes(2),
+        timeUTC: DateTime.UtcNow,
+        externalQueues: ImmutableDictionary<string, string>.Empty
+      )
+      .Single(entry => entry.LogType == LogType.BasketLoadUnload);
+
+    await Assert.That(logs.Pallet).IsEqualTo(-1);
+    await Assert.That(logs.ContainerId).IsEqualTo(id);
+    await Assert.That(logs.Material.Single().MaterialID).IsEqualTo(materialId);
+  }
+
+  [Test]
+  public async Task RejectsInvalidOrdinaryIdentityShapes()
+  {
+    using var repository = _repositoryConfig.OpenConnection();
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordBasketContentSnapshot([], new ContainerIdentity.None(), DateTime.UtcNow)
+    );
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordBasketArriveLocation(
+        [],
+        new ContainerIdentity.Uuid { ContainerId = Guid.Empty },
+        "Staging",
+        1,
+        DateTime.UtcNow
+      )
+    );
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordBasketIdentityHint(Guid.Empty, 1, DateTime.UtcNow)
+    );
+    await Assert.That(repository.GetRecentLog(0)).IsEmpty();
+    await Assert
+      .That(
+        new LogEntry(
+          -1,
+          [],
+          -1,
+          LogType.GeneralMessage,
+          "Legacy",
+          1,
+          "",
+          false,
+          DateTime.UtcNow,
+          ""
+        ).Identity
+      )
+      .IsTypeOf<ContainerIdentity.None>();
+  }
+
+  [Test]
+  public async Task BasketHintRequiresAnOpenBasketFragment()
+  {
+    using var repository = _repositoryConfig.OpenConnection();
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketIdentityHint(Guid.NewGuid(), 4, DateTime.UtcNow)
+    );
+    await Assert.That(repository.GetRecentLog(0)).IsEmpty();
+    await Assert.That(repository.GetCurrentBasketIdentityHints()).IsEmpty();
+  }
+
+  [Test]
+  public async Task UnresolvedBasketFragmentsExcludeHintedAndFinalizedIds()
+  {
+    var id = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    repository.RecordBasketContentSnapshot(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      DateTime.UtcNow
+    );
+
+    await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).IsEquivalentTo([id]);
+    repository.RecordBasketIdentityHint(id, 4, DateTime.UtcNow);
+    await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).IsEmpty();
+    repository.RecordBasketCycleEnd(4, [], ImmutableHashSet.Create(id), DateTime.UtcNow);
+    await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).IsEmpty();
+  }
+
+  [Test]
+  public async Task BackdatedBasketHintDoesNotChangeFinalizedCycleElapsedTime()
+  {
+    var id = Guid.NewGuid();
+    var fragmentStart = new DateTime(2026, 7, 17, 10, 0, 0, DateTimeKind.Utc);
+    using var repository = _repositoryConfig.OpenConnection();
+    repository.RecordBasketContentSnapshot(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      fragmentStart
+    );
+    repository.RecordBasketIdentityHint(id, 4, fragmentStart.AddDays(-1));
+
+    var cycle = repository.RecordBasketCycleEnd(
+      4,
+      [],
+      ImmutableHashSet.Create(id),
+      fragmentStart.AddHours(2)
+    );
+
+    await Assert.That(cycle.ElapsedTime).IsEqualTo(TimeSpan.FromHours(2));
+  }
+
+  [Test]
+  public async Task HintCorrectionUsesCounterAndSurvivesRestart()
+  {
+    var id = Guid.NewGuid();
+    var laterTime = DateTime.UtcNow;
+    long correctionCounter;
+    using (var repository = _repositoryConfig.OpenConnection())
+    {
+      repository.RecordBasketContentSnapshot(
+        [],
+        new ContainerIdentity.Uuid { ContainerId = id },
+        laterTime
+      );
+      var first = repository.RecordBasketIdentityHint(id, 4, laterTime);
+      var correction = repository.RecordBasketIdentityHint(id, 6, laterTime.AddDays(-1));
+      correctionCounter = correction.Counter;
+
+      var current = repository.GetCurrentBasketIdentityHints().Single();
+      await Assert.That(current.BasketNum).IsEqualTo(6);
+      await Assert.That(current.HintEventCounter).IsEqualTo(correction.Counter);
+      await Assert.That(correction.Counter).IsGreaterThan(first.Counter);
+      await Assert.That(repository.ReconstructBasketIdentityHints()[id]).IsEqualTo(current);
+      await Assert
+        .That(repository.CurrentBasketLog(new ContainerIdentity.Numbered { ContainerNum = 4 }))
+        .IsEmpty();
+      var assembled = repository.CurrentBasketLog(
+        new ContainerIdentity.Numbered { ContainerNum = 6 }
+      );
+      await Assert.That(assembled).Count().IsEqualTo(3);
+      await Assert.That(assembled.Select(entry => entry.Counter).Distinct()).Count().IsEqualTo(3);
+    }
+
+    _repositoryConfig.Dispose();
+    _repositoryConfig = RepositoryConfig.InitializeEventDatabase(
+      null,
+      _databaseFile,
+      pooling: false
+    );
+    using var restarted = _repositoryConfig.OpenConnection();
+    var restartedHint = restarted.GetCurrentBasketIdentityHints().Single();
+    await Assert.That(restartedHint.BasketNum).IsEqualTo(6);
+    await Assert.That(restartedHint.HintEventCounter).IsEqualTo(correctionCounter);
+  }
+
+  [Test]
+  public async Task SeveralOpenFragmentsCanHintToOneNumber()
+  {
+    var first = Guid.NewGuid();
+    var second = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    foreach (var id in new[] { first, second })
+    {
+      repository.RecordBasketContentSnapshot(
+        [],
+        new ContainerIdentity.Uuid { ContainerId = id },
+        DateTime.UtcNow
+      );
+      repository.RecordBasketIdentityHint(id, 5, DateTime.UtcNow);
+    }
+
+    await Assert.That(repository.GetCurrentBasketIdentityHints(5)).Count().IsEqualTo(2);
+    await Assert
+      .That(
+        repository
+          .CurrentBasketLog(new ContainerIdentity.Numbered { ContainerNum = 5 })
+          .Where(entry => entry.LogType == LogType.BasketContentSnapshot)
+          .Select(entry => entry.ContainerId)
+      )
+      .IsEquivalentTo(new Guid?[] { first, second });
+  }
+
+  [Test]
+  public async Task HintAndCacheUpdateRollBackTogether()
+  {
+    var id = Guid.NewGuid();
+    using (var setupRepository = _repositoryConfig.OpenConnection())
+    {
+      setupRepository.RecordBasketContentSnapshot(
+        [],
+        new ContainerIdentity.Uuid { ContainerId = id },
+        DateTime.UtcNow
+      );
+    }
+    using (var connection = new SqliteConnection("Data Source=" + _databaseFile))
+    {
+      connection.Open();
+      using var command = connection.CreateCommand();
+      command.CommandText =
+        "CREATE TRIGGER fail_hint_cache BEFORE INSERT ON current_basket_identity_hints BEGIN SELECT RAISE(ABORT, 'test rollback'); END";
+      command.ExecuteNonQuery();
+    }
+
+    using var repository = _repositoryConfig.OpenConnection();
+    await AssertThrows<SqliteException>(() =>
+      repository.RecordBasketIdentityHint(id, 4, DateTime.UtcNow)
+    );
+    await Assert.That(repository.GetRecentLog(0)).Count().IsEqualTo(1);
+    await Assert.That(repository.GetCurrentBasketIdentityHints()).IsEmpty();
+  }
+
+  [Test]
+  public async Task FinalizationClosesSeveralFragmentsAtomically()
+  {
+    var first = Guid.NewGuid();
+    var second = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    foreach (var id in new[] { first, second })
+    {
+      repository.RecordBasketContentSnapshot(
+        [],
+        new ContainerIdentity.Uuid { ContainerId = id },
+        DateTime.UtcNow
+      );
+      repository.RecordBasketIdentityHint(id, 5, DateTime.UtcNow);
+    }
+
+    var cycle = repository.RecordBasketCycleEnd(
+      basketId: 5,
+      mats: [],
+      containerIds: ImmutableHashSet.Create(first, second),
+      timeUTC: DateTime.UtcNow,
+      foreignId: "cycle-5-1"
+    );
+    var retry = repository.RecordBasketCycleEnd(
+      basketId: 5,
+      mats: [],
+      containerIds: ImmutableHashSet.Create(second, first),
+      timeUTC: DateTime.UtcNow.AddMinutes(1),
+      foreignId: "cycle-5-1"
+    );
+
+    await Assert.That(cycle.Pallet).IsEqualTo(5);
+    await Assert.That(retry.Counter).IsEqualTo(cycle.Counter);
+    await Assert.That(cycle.BasketCycleContainerIds).IsEquivalentTo([first, second]);
+    await Assert.That(repository.GetCurrentBasketIdentityHints()).IsEmpty();
+    await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).IsEmpty();
+    await Assert.That(repository.ReconstructBasketIdentityHints()).IsEmpty();
+    var loadedCycle = repository.GetFinalizedBasketCycle(cycle.Counter);
+    await Assert.That(loadedCycle.Counter).IsEqualTo(cycle.Counter);
+    await Assert.That(loadedCycle.BasketCycleContainerIds).IsEquivalentTo([first, second]);
+    await Assert
+      .That(repository.GetFinalizedBasketCycles(5).Select(entry => entry.Counter))
+      .IsEquivalentTo([cycle.Counter]);
+    await Assert
+      .That(repository.CurrentBasketLog(new ContainerIdentity.Uuid { ContainerId = first }))
+      .IsEmpty();
+  }
+
+  [Test]
+  public async Task FinalizationRetryIsIdempotentAndConflictingReuseIsRejected()
+  {
+    var id = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    repository.RecordBasketContentSnapshot(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      DateTime.UtcNow
+    );
+    var first = repository.RecordBasketCycleEnd(
+      2,
+      [],
+      ImmutableHashSet.Create(id),
+      DateTime.UtcNow,
+      foreignId: "finalize-2"
+    );
+    var retry = repository.RecordBasketCycleEnd(
+      2,
+      [],
+      ImmutableHashSet.Create(id),
+      DateTime.UtcNow.AddMinutes(1),
+      foreignId: "finalize-2"
+    );
+
+    await Assert.That(retry.Counter).IsEqualTo(first.Counter);
+    await Assert.That(repository.GetRecentLog(0).Count()).IsEqualTo(2);
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketContentSnapshot(
+        [],
+        new ContainerIdentity.Uuid { ContainerId = id },
+        DateTime.UtcNow
+      )
+    );
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketIdentityHint(id, 3, DateTime.UtcNow)
+    );
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketCycleEnd(
+        3,
+        [],
+        ImmutableHashSet.Create(id),
+        DateTime.UtcNow,
+        foreignId: "finalize-3"
+      )
+    );
+  }
+
+  [Test]
+  public async Task FinalizationAndHintRemovalRollBackTogether()
+  {
+    var id = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    repository.RecordBasketContentSnapshot(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      DateTime.UtcNow
+    );
+    repository.RecordBasketIdentityHint(id, 9, DateTime.UtcNow);
+    using (var command = new SqliteConnection("Data Source=" + _databaseFile))
+    {
+      command.Open();
+      using var trigger = command.CreateCommand();
+      trigger.CommandText =
+        "CREATE TRIGGER fail_membership BEFORE INSERT ON basket_cycle_container_ids BEGIN SELECT RAISE(ABORT, 'test rollback'); END";
+      trigger.ExecuteNonQuery();
+    }
+
+    await AssertThrows<SqliteException>(() =>
+      repository.RecordBasketCycleEnd(
+        9,
+        [],
+        ImmutableHashSet.Create(id),
+        DateTime.UtcNow,
+        foreignId: "rollback-cycle"
+      )
+    );
+    await Assert.That(repository.GetRecentLog(0)).Count().IsEqualTo(2);
+    await Assert.That(repository.GetCurrentBasketIdentityHints()).Count().IsEqualTo(1);
+    await Assert.That(repository.GetFinalizedBasketCycles(9)).IsEmpty();
+  }
+
+  [Test]
+  public async Task FinalizedHistoryUsesMembershipAndIgnoresWrongHint()
+  {
+    var id = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    var arrival = repository.RecordBasketArriveLocation(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      "Staging",
+      1,
+      DateTime.UtcNow
+    );
+    repository.RecordBasketIdentityHint(id, 3, DateTime.UtcNow);
+    var departure = repository.RecordBasketDepartLocation(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      "Staging",
+      1,
+      DateTime.UtcNow.AddMinutes(7),
+      TimeSpan.FromMinutes(7)
+    );
+    var cycle = repository.RecordBasketCycleEnd(
+      4,
+      [],
+      ImmutableHashSet.Create(id),
+      DateTime.UtcNow.AddMinutes(8)
+    );
+
+    var history = repository.GetLogForFinalizedBasketCycle(cycle.Counter);
+    await Assert
+      .That(history.Select(entry => entry.Counter))
+      .IsEquivalentTo([arrival.Counter, departure.Counter, cycle.Counter]);
+    await Assert
+      .That(history.Single(entry => entry.Counter == departure.Counter).ElapsedTime)
+      .IsEqualTo(TimeSpan.FromMinutes(7));
+    await Assert.That(history).DoesNotContain(entry => entry.LogType == LogType.BasketIdentityHint);
+    await Assert.That(repository.GetFinalizedBasketCycles(3)).IsEmpty();
+    await Assert.That(repository.GetFinalizedBasketCycles(4)).Count().IsEqualTo(1);
+  }
+
+  [Test]
+  public async Task FinalizedHistoryCombinesLocationEvidenceAcrossFragments()
+  {
+    var arrivalId = Guid.NewGuid();
+    var departureId = Guid.NewGuid();
+    var arrivalTime = new DateTime(2026, 7, 17, 8, 0, 0, DateTimeKind.Utc);
+    using var repository = _repositoryConfig.OpenConnection();
+    var arrival = repository.RecordBasketArriveLocation(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = arrivalId },
+      "Staging",
+      1,
+      arrivalTime
+    );
+    repository.RecordBasketIdentityHint(arrivalId, 5, arrivalTime);
+    var departure = repository.RecordBasketDepartLocation(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = departureId },
+      "Staging",
+      1,
+      arrivalTime.AddMinutes(12),
+      TimeSpan.FromMinutes(12)
+    );
+    repository.RecordBasketIdentityHint(departureId, 5, arrivalTime.AddMinutes(12));
+    var cycle = repository.RecordBasketCycleEnd(
+      5,
+      [],
+      ImmutableHashSet.Create(arrivalId, departureId),
+      arrivalTime.AddMinutes(15)
+    );
+
+    var history = repository.GetLogForFinalizedBasketCycle(cycle.Counter);
+    await Assert
+      .That(history.Select(entry => entry.Counter))
+      .IsEquivalentTo([arrival.Counter, departure.Counter, cycle.Counter]);
+    await Assert
+      .That(history.Single(entry => entry.Counter == departure.Counter).ElapsedTime)
+      .IsEqualTo(TimeSpan.FromMinutes(12));
+  }
+
+  [Test]
+  public async Task LegacyNumberedBasketCycleHasNoUuidMembership()
+  {
+    using var repository = _repositoryConfig.OpenConnection();
+    repository.RecordEmptyBasket(8, DateTime.UtcNow);
+    var cycleEnd = repository.RecordEmptyBasket(8, DateTime.UtcNow, basketEnd: true).Single();
+
+    await Assert.That(cycleEnd.BasketCycleContainerIds).IsEmpty();
+    await Assert
+      .That(repository.GetFinalizedBasketCycle(cycleEnd.Counter).Counter)
+      .IsEqualTo(cycleEnd.Counter);
+  }
+
+  private static async Task AssertThrows<TException>(Action action)
+    where TException : Exception
+  {
+    Exception exception = null;
+    try
+    {
+      action();
+    }
+    catch (Exception caught)
+    {
+      exception = caught;
+    }
+    await Assert.That(exception).IsTypeOf<TException>();
+  }
+}

--- a/server/test/ContainerIdentitySpec.cs
+++ b/server/test/ContainerIdentitySpec.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using BlackMaple.MachineFramework;
 using Microsoft.Data.Sqlite;
@@ -352,13 +353,13 @@ public sealed class ContainerIdentitySpec : IDisposable
 
     await Assert.That(cycle.Pallet).IsEqualTo(5);
     await Assert.That(retry.Counter).IsEqualTo(cycle.Counter);
-    await Assert.That(cycle.BasketCycleContainerIds).IsEquivalentTo([first, second]);
+    await Assert.That(cycle.CycleEndContainerIds).IsEquivalentTo([first, second]);
     await Assert.That(repository.GetCurrentBasketIdentityHints()).IsEmpty();
     await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).IsEmpty();
     await Assert.That(repository.ReconstructBasketIdentityHints()).IsEmpty();
     var loadedCycle = repository.GetFinalizedBasketCycle(cycle.Counter);
     await Assert.That(loadedCycle.Counter).IsEqualTo(cycle.Counter);
-    await Assert.That(loadedCycle.BasketCycleContainerIds).IsEquivalentTo([first, second]);
+    await Assert.That(loadedCycle.CycleEndContainerIds).IsEquivalentTo([first, second]);
     await Assert
       .That(repository.GetFinalizedBasketCycles(5).Select(entry => entry.Counter))
       .IsEquivalentTo([cycle.Counter]);
@@ -536,10 +537,44 @@ public sealed class ContainerIdentitySpec : IDisposable
     repository.RecordEmptyBasket(8, DateTime.UtcNow);
     var cycleEnd = repository.RecordEmptyBasket(8, DateTime.UtcNow, basketEnd: true).Single();
 
-    await Assert.That(cycleEnd.BasketCycleContainerIds).IsEmpty();
+    await Assert.That(cycleEnd.CycleEndContainerIds).IsNull();
     await Assert
       .That(repository.GetFinalizedBasketCycle(cycleEnd.Counter).Counter)
       .IsEqualTo(cycleEnd.Counter);
+  }
+
+  [Test]
+  public async Task ContainerIdsAreOmittedUnlessTheCycleEndFinalizesFragments()
+  {
+    var id = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    repository.RecordEmptyBasket(8, DateTime.UtcNow);
+    var legacyCycleEnd = repository.RecordEmptyBasket(8, DateTime.UtcNow, basketEnd: true).Single();
+    repository.RecordBasketContentSnapshot(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = id },
+      DateTime.UtcNow
+    );
+    var finalizedCycleEnd = repository.RecordBasketCycleEnd(
+      9,
+      [],
+      ImmutableHashSet.Create(id),
+      DateTime.UtcNow
+    );
+    var jsonOptions = new JsonSerializerOptions();
+    FMSInsightWebHost.JsonSettings(jsonOptions);
+
+    var legacyJson = JsonSerializer.Serialize(legacyCycleEnd, jsonOptions);
+    using var finalizedJson = JsonDocument.Parse(
+      JsonSerializer.Serialize(finalizedCycleEnd, jsonOptions)
+    );
+
+    await Assert.That(legacyJson).DoesNotContain("\"containerIds\"");
+    await Assert
+      .That(
+        finalizedJson.RootElement.GetProperty("containerIds").EnumerateArray().Single().GetGuid()
+      )
+      .IsEqualTo(id);
   }
 
   private static async Task AssertThrows<TException>(Action action)


### PR DESCRIPTION
Add generic UUID container identities with basket-specific current hints, normalized basket-cycle membership, typed content snapshots, and cohesive basket event APIs. Finalization atomically closes ordinary UUID fragments, excludes backdated hints from cycle timing, and preserves numbered legacy cycles. Expose current and finalized projections, optimize membership loading, update API/client display, and cover persistence, rollback, restart, correction, and idempotency.