### PR TITLE
events: record explicit basket transitions

### DIFF
--- a/server/debug-mock/DebugMock.cs
+++ b/server/debug-mock/DebugMock.cs
@@ -634,6 +634,7 @@ namespace DebugMachineWatchApiServer
         }
         else if (e.LogType == LogType.LoadUnloadCycle && !e.StartOfCycle && e.Program == "UNLOAD")
         {
+          var basketId = EventDetailAsInt(e, "BasketId");
           LogDB.RecordPartialLoadUnload(
             toLoad: null,
             toUnload:
@@ -644,11 +645,10 @@ namespace DebugMachineWatchApiServer
                   m => m.MaterialID,
                   m =>
                   {
-                    var basketId = EventDetailAsInt(e, "BasketId");
                     var queue = EventDetail(e, "Queue");
                     if (basketId.HasValue)
                     {
-                      return new UnloadDestination() { BasketId = basketId.Value };
+                      return new UnloadDestination();
                     }
                     else if (!string.IsNullOrEmpty(queue))
                     {
@@ -669,7 +669,24 @@ namespace DebugMachineWatchApiServer
             lulNum: e.LocationNum,
             timeUTC: e.EndTimeUTC.Add(offset),
             totalElapsed: e.ElapsedTime,
-            externalQueues: null
+            externalQueues: null,
+            basketCompletion: basketId.HasValue
+              ? new BasketLoadUnloadCompletion
+              {
+                Transfers =
+                [
+                  new BasketTransfer.LoadOntoBasket
+                  {
+                    BasketIdentity = new ContainerIdentity.Numbered
+                    {
+                      ContainerNum = basketId.Value,
+                    },
+                    Material = e.Material.Select(EventLogMaterial.FromLogMat).ToImmutableList(),
+                  },
+                ],
+                CycleBoundaries = [],
+              }
+              : null
           );
         }
         else if (e.LogType == LogType.PalletCycle)

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -854,7 +854,7 @@ namespace BlackMaple.MachineFramework
       cmd.CommandText =
         "SELECT DISTINCT s.ContainerId FROM stations s "
         + "WHERE s.ContainerId IS NOT NULL "
-        + "AND s.StationLoc IN ($loadUnloadType, $locationType, $snapshotType) "
+        + "AND s.StationLoc IN ($loadUnloadType, $locationType, $snapshotType, $cycleType) "
         + "AND NOT EXISTS(SELECT 1 FROM current_basket_identity_hints h WHERE h.ContainerId = s.ContainerId) "
         + "AND NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = s.ContainerId) "
         + "ORDER BY s.ContainerId";
@@ -863,6 +863,7 @@ namespace BlackMaple.MachineFramework
       cmd.Parameters.Add("locationType", SqliteType.Integer).Value = (int)LogType.BasketInLocation;
       cmd.Parameters.Add("snapshotType", SqliteType.Integer).Value = (int)
         LogType.BasketContentSnapshot;
+      cmd.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)LogType.BasketCycle;
       using var reader = cmd.ExecuteReader();
       var ids = ImmutableList.CreateBuilder<Guid>();
       while (reader.Read())
@@ -1912,9 +1913,11 @@ namespace BlackMaple.MachineFramework
       int pallet,
       TimeSpan totalElapsed,
       DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues
+      IReadOnlyDictionary<string, string> externalQueues,
+      BasketLoadUnloadCompletion basketCompletion = null
     )
     {
+      ValidateBasketCompletion(basketCompletion, toLoad, toUnload);
       var sendToExternal = new List<MaterialToSendToExternalQueue>();
 
       var newLogs = AddEntryInTransaction(trans =>
@@ -1952,7 +1955,7 @@ namespace BlackMaple.MachineFramework
           }
         }
 
-        var materialPerBasket = RecordUnloadEnd(
+        RecordUnloadEnd(
           toUnload: toUnload,
           lulNum: lulNum,
           pallet: pallet,
@@ -1966,7 +1969,14 @@ namespace BlackMaple.MachineFramework
           trans: trans
         );
 
-        RecordBasketUnloadEnds(toLoad, lulNum: lulNum, timeUTC: timeUTC, trans: trans, logs: logs);
+        RecordBasketTransferEnds<BasketTransfer.UnloadFromBasket>(
+          basketCompletion,
+          lulNum,
+          timeUTC,
+          trans,
+          logs
+        );
+        RecordExplicitBasketCycleEnds(basketCompletion, timeUTC, logs, trans);
 
         RecordLoadMaterialPaths(toLoad: toLoad, trans: trans);
 
@@ -1979,16 +1989,18 @@ namespace BlackMaple.MachineFramework
           totalActive: allHaveActive && totalActive > TimeSpan.Zero ? totalActive : null,
           timeUTC: timeUTC,
           logs: logs,
-          trans: trans
+          trans: trans,
+          materialFromBaskets: BasketMaterialIds<BasketTransfer.UnloadFromBasket>(basketCompletion)
         );
 
-        RecordBasketLoadEnds(
-          materialPerBasket,
-          lulNum: lulNum,
-          timeUTC: timeUTC,
-          logs: logs,
-          trans: trans
+        RecordBasketTransferEnds<BasketTransfer.LoadOntoBasket>(
+          basketCompletion,
+          lulNum,
+          timeUTC,
+          trans,
+          logs
         );
+        RecordExplicitBasketCycleStarts(basketCompletion, timeUTC, logs, trans);
 
         return logs;
       });
@@ -2001,15 +2013,531 @@ namespace BlackMaple.MachineFramework
       return newLogs;
     }
 
+    public IEnumerable<LogEntry> RecordBasketLoadUnloadCompletion(
+      BasketLoadUnloadCompletion basketCompletion,
+      int lulNum,
+      DateTime timeUTC,
+      string foreignId,
+      string originalMessage = null
+    )
+    {
+      if (string.IsNullOrWhiteSpace(foreignId))
+        throw new ArgumentException(
+          "A delayed basket completion requires a foreign ID.",
+          nameof(foreignId)
+        );
+      ArgumentNullException.ThrowIfNull(basketCompletion);
+      ValidateBasketCompletion(basketCompletion, toLoad: null, toUnload: null);
+
+      ImmutableList<LogEntry> logs;
+      var added = false;
+      lock (_cfg)
+      {
+        using var trans = _connection.BeginTransaction();
+        var existing = BasketCompletionForForeignId(foreignId, trans);
+        if (existing.Count > 0)
+        {
+          if (
+            !BasketCompletionMatches(existing, basketCompletion, lulNum)
+            || BasketCompletionOriginalMessage(foreignId, trans) != (originalMessage ?? "")
+          )
+            throw new ConflictRequestException(
+              $"Foreign ID {foreignId} already identifies different basket events."
+            );
+          logs = existing;
+        }
+        else
+        {
+          var newLogs = new List<LogEntry>();
+          RecordBasketTransferEnds<BasketTransfer.UnloadFromBasket>(
+            basketCompletion,
+            lulNum,
+            timeUTC,
+            trans,
+            newLogs,
+            foreignId,
+            originalMessage
+          );
+          RecordExplicitBasketCycleEnds(
+            basketCompletion,
+            timeUTC,
+            newLogs,
+            trans,
+            foreignId,
+            originalMessage
+          );
+          RecordBasketTransferEnds<BasketTransfer.LoadOntoBasket>(
+            basketCompletion,
+            lulNum,
+            timeUTC,
+            trans,
+            newLogs,
+            foreignId,
+            originalMessage
+          );
+          RecordExplicitBasketCycleStarts(
+            basketCompletion,
+            timeUTC,
+            newLogs,
+            trans,
+            foreignId,
+            originalMessage
+          );
+          logs = newLogs.ToImmutableList();
+          added = true;
+        }
+        trans.Commit();
+      }
+
+      if (added)
+      {
+        foreach (var log in logs)
+          _cfg.OnNewLogEntry(log, foreignId, this);
+      }
+      return logs;
+    }
+
+    private static void ValidateBasketCompletion(
+      BasketLoadUnloadCompletion basketCompletion,
+      IReadOnlyList<MaterialToLoadOntoFace> toLoad,
+      IReadOnlyList<MaterialToUnloadFromFace> toUnload
+    )
+    {
+      if (basketCompletion is null)
+      {
+        if (
+          toUnload?.Any(unload =>
+            unload.MaterialIDToDestination.Values.Any(destination =>
+              destination is not null && destination.Queue is null
+            )
+          ) == true
+        )
+          throw new ArgumentException(
+            "Pallet unloads without a queue destination require an explicit basket completion.",
+            nameof(basketCompletion)
+          );
+        return;
+      }
+      if (basketCompletion.Transfers.Count == 0 && basketCompletion.CycleBoundaries.Count == 0)
+        throw new ArgumentException(
+          "A basket completion requires a transfer or cycle boundary.",
+          nameof(basketCompletion)
+        );
+
+      var transferredToBasket = ImmutableHashSet.CreateBuilder<long>();
+      var transferredFromBasket = ImmutableHashSet.CreateBuilder<long>();
+      foreach (var transfer in basketCompletion.Transfers)
+      {
+        RecordedContainerIdentity(transfer.BasketIdentity);
+        if (transfer.Material.Count == 0)
+          throw new ArgumentException(
+            "A basket transfer requires material.",
+            nameof(basketCompletion)
+          );
+        var target =
+          transfer is BasketTransfer.LoadOntoBasket ? transferredToBasket : transferredFromBasket;
+        foreach (var material in transfer.Material)
+        {
+          if (!target.Add(material.MaterialID))
+            throw new ArgumentException(
+              $"Material {material.MaterialID} is repeated in basket transfers.",
+              nameof(basketCompletion)
+            );
+        }
+      }
+
+      var starts = new HashSet<ContainerIdentity>();
+      var ends = new HashSet<ContainerIdentity>();
+      foreach (var boundary in basketCompletion.CycleBoundaries)
+      {
+        RecordedContainerIdentity(boundary.BasketIdentity);
+        if (
+          boundary.Material.Select(material => material.MaterialID).Distinct().Count()
+          != boundary.Material.Count
+        )
+          throw new ArgumentException(
+            "Basket cycle material must contain each material exactly once.",
+            nameof(basketCompletion)
+          );
+        if (boundary is BasketCycleBoundary.Start)
+        {
+          if (boundary.Material.Count == 0 || !starts.Add(boundary.BasketIdentity))
+            throw new ArgumentException(
+              "Each ready basket requires one non-empty cycle start.",
+              nameof(basketCompletion)
+            );
+        }
+        else if (boundary is BasketCycleBoundary.End end)
+        {
+          if (!ends.Add(boundary.BasketIdentity))
+            throw new ArgumentException(
+              "Each completed basket can have only one cycle end.",
+              nameof(basketCompletion)
+            );
+          if (
+            boundary.BasketIdentity is not ContainerIdentity.Numbered
+            || end.ContainerIds.Any(id => id == Guid.Empty)
+          )
+            throw new ArgumentException(
+              "A basket cycle end requires a numbered basket identity and may contain only non-empty fragment UUIDs.",
+              nameof(basketCompletion)
+            );
+        }
+      }
+
+      foreach (var transfer in basketCompletion.Transfers)
+      {
+        var matchingBoundary = basketCompletion.CycleBoundaries.FirstOrDefault(boundary =>
+          boundary.BasketIdentity == transfer.BasketIdentity
+          && (
+            (transfer is BasketTransfer.LoadOntoBasket && boundary is BasketCycleBoundary.Start)
+            || (transfer is BasketTransfer.UnloadFromBasket && boundary is BasketCycleBoundary.End)
+          )
+        );
+        if (
+          matchingBoundary is not null
+          && transfer.Material.Any(material =>
+            !matchingBoundary.Material.Any(cycleMaterial =>
+              cycleMaterial.MaterialID == material.MaterialID
+            )
+          )
+        )
+          throw new ArgumentException(
+            "Transferred material must be present in the corresponding complete cycle material.",
+            nameof(basketCompletion)
+          );
+
+        if (
+          transfer
+            is BasketTransfer.UnloadFromBasket
+            {
+              BasketIdentity: ContainerIdentity.Uuid { ContainerId: var containerId },
+            }
+          && basketCompletion
+            .CycleBoundaries.OfType<BasketCycleBoundary.End>()
+            .FirstOrDefault(end => end.ContainerIds.Contains(containerId))
+            is { } fragmentEnd
+          && transfer.Material.Any(material =>
+            !fragmentEnd.Material.Any(cycleMaterial =>
+              cycleMaterial.MaterialID == material.MaterialID
+            )
+          )
+        )
+          throw new ArgumentException(
+            "Material unloaded from a finalized UUID fragment must be present in the complete cycle end.",
+            nameof(basketCompletion)
+          );
+      }
+
+      if (toLoad is not null)
+      {
+        var palletLoadIds = toLoad.SelectMany(load => load.MaterialIDs).ToImmutableHashSet();
+        if (transferredFromBasket.Any(id => !palletLoadIds.Contains(id)))
+          throw new ArgumentException(
+            "Basket-to-pallet material must be present in the pallet load.",
+            nameof(basketCompletion)
+          );
+      }
+      if (toUnload is not null)
+      {
+        var basketDestinationIds = toUnload
+          .SelectMany(unload =>
+            unload.MaterialIDToDestination.Where(destination =>
+              destination.Value is not null && destination.Value.Queue is null
+            )
+          )
+          .Select(destination => destination.Key)
+          .ToImmutableHashSet();
+        if (!transferredToBasket.SetEquals(basketDestinationIds))
+          throw new ArgumentException(
+            "Pallet unloads without a queue destination must exactly match pallet-to-basket transfers.",
+            nameof(basketCompletion)
+          );
+      }
+    }
+
+    private static ImmutableHashSet<long> BasketMaterialIds<TTransfer>(
+      BasketLoadUnloadCompletion basketCompletion
+    )
+      where TTransfer : BasketTransfer =>
+      basketCompletion
+        ?.Transfers.OfType<TTransfer>()
+        .SelectMany(transfer => transfer.Material)
+        .Select(material => material.MaterialID)
+        .ToImmutableHashSet()
+      ?? [];
+
+    private void RecordBasketTransferEnds<TTransfer>(
+      BasketLoadUnloadCompletion basketCompletion,
+      int lulNum,
+      DateTime timeUTC,
+      IDbTransaction trans,
+      List<LogEntry> logs,
+      string foreignId = null,
+      string originalMessage = null
+    )
+      where TTransfer : BasketTransfer
+    {
+      foreach (var transfer in basketCompletion?.Transfers.OfType<TTransfer>() ?? [])
+      {
+        var (containerNum, containerId) = RecordedContainerIdentity(transfer.BasketIdentity);
+        var loadOntoBasket = transfer is BasketTransfer.LoadOntoBasket;
+        logs.Add(
+          AddLogEntry(
+            trans,
+            new NewEventLogEntry
+            {
+              Material = transfer.Material,
+              Pallet = containerNum,
+              ContainerId = containerId,
+              LogType = LogType.BasketLoadUnload,
+              LocationName = "L/U",
+              LocationNum = lulNum,
+              Program = loadOntoBasket ? "LOAD" : "UNLOAD",
+              StartOfCycle = false,
+              EndTimeUTC = timeUTC,
+              Result = loadOntoBasket ? "LOAD" : "UNLOAD",
+              ElapsedTime = TimeSpan.Zero,
+              ActiveOperationTime = TimeSpan.Zero,
+            },
+            foreignId,
+            originalMessage
+          )
+        );
+      }
+    }
+
+    private void RecordExplicitBasketCycleEnds(
+      BasketLoadUnloadCompletion basketCompletion,
+      DateTime timeUTC,
+      List<LogEntry> logs,
+      IDbTransaction trans,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      foreach (
+        var boundary in basketCompletion?.CycleBoundaries.OfType<BasketCycleBoundary.End>() ?? []
+      )
+      {
+        var (containerNum, containerId) = RecordedContainerIdentity(boundary.BasketIdentity);
+        var containerIds = boundary.ContainerIds.OrderBy(id => id).ToImmutableList();
+        var firstEventTime = timeUTC;
+        foreach (var id in containerIds)
+        {
+          var eventTime = EnsureOpenBasketFragment(id, trans);
+          if (eventTime < firstEventTime)
+            firstEventTime = eventTime;
+        }
+        if (
+          containerIds.Count == 0
+          && MostRecentBasketCycleStart(boundary.BasketIdentity, trans) is { } cycleStart
+        )
+          firstEventTime = cycleStart;
+
+        logs.Add(
+          AddLogEntry(
+            trans,
+            new NewEventLogEntry
+            {
+              Material = boundary.Material,
+              Pallet = containerNum,
+              ContainerId = containerId,
+              LogType = LogType.BasketCycle,
+              LocationName = "Basket Cycle",
+              LocationNum = 0,
+              Program = "",
+              StartOfCycle = false,
+              EndTimeUTC = timeUTC,
+              Result = "BasketCycle",
+              ElapsedTime = timeUTC >= firstEventTime ? timeUTC - firstEventTime : TimeSpan.Zero,
+              ActiveOperationTime = TimeSpan.Zero,
+              CycleEndContainerIds = containerIds.Count == 0 ? null : containerIds,
+            },
+            foreignId,
+            originalMessage
+          )
+        );
+
+        if (containerIds.Count > 0)
+        {
+          using var removeHints = _connection.CreateCommand();
+          ((IDbCommand)removeHints).Transaction = trans;
+          removeHints.CommandText =
+            "DELETE FROM current_basket_identity_hints WHERE ContainerId = $id";
+          removeHints.Parameters.Add("id", SqliteType.Text);
+          foreach (var id in containerIds)
+          {
+            removeHints.Parameters[0].Value = id.ToString("D");
+            removeHints.ExecuteNonQuery();
+          }
+        }
+      }
+    }
+
+    private DateTime? MostRecentBasketCycleStart(
+      ContainerIdentity basketIdentity,
+      IDbTransaction trans
+    )
+    {
+      var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
+      using var cmd = _connection.CreateCommand();
+      ((IDbCommand)cmd).Transaction = trans;
+      cmd.CommandText =
+        "SELECT TimeUTC FROM stations WHERE Pallet = $num "
+        + "AND (($id IS NULL AND ContainerId IS NULL) OR ContainerId = $id) "
+        + "AND StationLoc = $cycleType AND Start = 1 ORDER BY Counter DESC LIMIT 1";
+      cmd.Parameters.Add("num", SqliteType.Integer).Value = containerNum;
+      cmd.Parameters.Add("id", SqliteType.Text).Value = containerId is { } id
+        ? id.ToString("D")
+        : DBNull.Value;
+      cmd.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)LogType.BasketCycle;
+      var start = cmd.ExecuteScalar();
+      return start is null or DBNull ? null : new DateTime((long)start, DateTimeKind.Utc);
+    }
+
+    private void RecordExplicitBasketCycleStarts(
+      BasketLoadUnloadCompletion basketCompletion,
+      DateTime timeUTC,
+      List<LogEntry> logs,
+      IDbTransaction trans,
+      string foreignId = null,
+      string originalMessage = null
+    )
+    {
+      foreach (
+        var boundary in basketCompletion?.CycleBoundaries.OfType<BasketCycleBoundary.Start>() ?? []
+      )
+      {
+        var (containerNum, containerId) = RecordedContainerIdentity(boundary.BasketIdentity);
+        logs.Add(
+          AddLogEntry(
+            trans,
+            new NewEventLogEntry
+            {
+              Material = boundary.Material,
+              Pallet = containerNum,
+              ContainerId = containerId,
+              LogType = LogType.BasketCycle,
+              LocationName = "Basket Cycle",
+              LocationNum = 0,
+              Program = "",
+              StartOfCycle = true,
+              EndTimeUTC = timeUTC,
+              Result = "BasketCycle",
+              ElapsedTime = TimeSpan.Zero,
+              ActiveOperationTime = TimeSpan.Zero,
+            },
+            foreignId,
+            originalMessage
+          )
+        );
+      }
+    }
+
+    private ImmutableList<LogEntry> BasketCompletionForForeignId(
+      string foreignId,
+      IDbTransaction trans
+    )
+    {
+      using var cmd = _connection.CreateCommand();
+      ((IDbCommand)cmd).Transaction = trans;
+      cmd.CommandText =
+        "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
+        + "FROM stations WHERE ForeignID = $foreign ORDER BY Counter";
+      cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
+      using var reader = cmd.ExecuteReader();
+      return LoadLog(reader, trans).ToImmutableList();
+    }
+
+    private string BasketCompletionOriginalMessage(string foreignId, IDbTransaction trans)
+    {
+      using var cmd = _connection.CreateCommand();
+      ((IDbCommand)cmd).Transaction = trans;
+      cmd.CommandText =
+        "SELECT OriginalMessage FROM stations WHERE ForeignID = $foreign ORDER BY Counter LIMIT 1";
+      cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
+      return cmd.ExecuteScalar() as string ?? "";
+    }
+
+    private static bool BasketCompletionMatches(
+      ImmutableList<LogEntry> logs,
+      BasketLoadUnloadCompletion basketCompletion,
+      int lulNum
+    )
+    {
+      var expected = basketCompletion
+        .Transfers.OfType<BasketTransfer.UnloadFromBasket>()
+        .Select(transfer =>
+          (Transfer: (BasketTransfer)transfer, Boundary: (BasketCycleBoundary)null)
+        )
+        .Concat(
+          basketCompletion
+            .CycleBoundaries.OfType<BasketCycleBoundary.End>()
+            .Select(boundary =>
+              (Transfer: (BasketTransfer)null, Boundary: (BasketCycleBoundary)boundary)
+            )
+        )
+        .Concat(
+          basketCompletion
+            .Transfers.OfType<BasketTransfer.LoadOntoBasket>()
+            .Select(transfer =>
+              (Transfer: (BasketTransfer)transfer, Boundary: (BasketCycleBoundary)null)
+            )
+        )
+        .Concat(
+          basketCompletion
+            .CycleBoundaries.OfType<BasketCycleBoundary.Start>()
+            .Select(boundary =>
+              (Transfer: (BasketTransfer)null, Boundary: (BasketCycleBoundary)boundary)
+            )
+        )
+        .ToImmutableList();
+      if (logs.Count != expected.Count)
+        return false;
+
+      return logs.Zip(expected)
+        .All(pair =>
+        {
+          var (log, item) = pair;
+          var identity = item.Transfer?.BasketIdentity ?? item.Boundary.BasketIdentity;
+          var material = item.Transfer?.Material ?? item.Boundary.Material;
+          var expectedType = item.Transfer is null ? LogType.BasketCycle : LogType.BasketLoadUnload;
+          var expectedStart = item.Boundary is BasketCycleBoundary.Start;
+          var expectedProgram = item.Transfer switch
+          {
+            BasketTransfer.LoadOntoBasket => "LOAD",
+            BasketTransfer.UnloadFromBasket => "UNLOAD",
+            _ => "",
+          };
+          var expectedContainerIds =
+            item.Boundary is BasketCycleBoundary.End end && end.ContainerIds.Count > 0
+              ? end.ContainerIds.OrderBy(id => id).ToImmutableList()
+              : null;
+          return log.Identity == identity
+            && log.LogType == expectedType
+            && log.StartOfCycle == expectedStart
+            && log.Program == expectedProgram
+            && (expectedType == LogType.BasketCycle || log.LocationNum == lulNum)
+            && log.Material.Select(mat => (mat.MaterialID, mat.Process, mat.Face))
+              .SequenceEqual(material.Select(mat => (mat.MaterialID, mat.Process, mat.Face)))
+            && (
+              expectedContainerIds is null
+                ? log.CycleEndContainerIds is null
+                : log.CycleEndContainerIds?.SequenceEqual(expectedContainerIds) == true
+            );
+        });
+    }
+
     // RecordLoadUnloadComplete is used ONLY for load/unload operations involving a pallet.
     // This includes:
     //   - Pallet to/from queue (material loaded from queue onto pallet, or unloaded from pallet to queue)
     //   - Pallet to/from basket (material transferred between pallet face and basket)
     // For basket-only operations (basket to/from queue), use RecordBasketOnlyLoadUnload instead.
     //
-    // The completedBaskets parameter controls when basket cycle events are emitted. If null/empty,
-    // no basket cycle events are emitted even if material was loaded/unloaded from baskets.
-    // When provided, maps basket ID to the material now on that basket (for the cycle start event).
+    // Basket events are never inferred from event history. Callers that know basket state
+    // synchronously provide an explicit basketCompletion. Delayed reconcilers can use
+    // RecordBasketLoadUnloadCompletion after this method records the pallet events.
     public IEnumerable<LogEntry> RecordLoadUnloadComplete(
       IReadOnlyList<MaterialToLoadOntoFace> toLoad,
       IReadOnlyList<EventLogMaterial> previouslyLoaded,
@@ -2020,9 +2548,10 @@ namespace BlackMaple.MachineFramework
       TimeSpan totalElapsed,
       DateTime timeUTC,
       IReadOnlyDictionary<string, string> externalQueues,
-      IReadOnlyDictionary<int, IEnumerable<EventLogMaterial>> completedBaskets = null
+      BasketLoadUnloadCompletion basketCompletion = null
     )
     {
+      ValidateBasketCompletion(basketCompletion, toLoad, toUnload);
       var sendToExternal = new List<MaterialToSendToExternalQueue>();
 
       var newLogs = AddEntryInTransaction(trans =>
@@ -2060,7 +2589,7 @@ namespace BlackMaple.MachineFramework
           }
         }
 
-        var materialPerBasket = RecordUnloadEnd(
+        RecordUnloadEnd(
           toUnload: toUnload,
           lulNum: lulNum,
           pallet: pallet,
@@ -2074,7 +2603,13 @@ namespace BlackMaple.MachineFramework
           trans: trans
         );
 
-        RecordBasketUnloadEnds(toLoad, lulNum: lulNum, timeUTC: timeUTC, trans: trans, logs: logs);
+        RecordBasketTransferEnds<BasketTransfer.UnloadFromBasket>(
+          basketCompletion,
+          lulNum,
+          timeUTC,
+          trans,
+          logs
+        );
 
         var allUnload = (previouslyUnloaded ?? []).Concat(
           (toUnload ?? []).SelectMany(u =>
@@ -2097,14 +2632,7 @@ namespace BlackMaple.MachineFramework
           );
         }
 
-        // Emit basket cycle ends for baskets in completedBaskets
-        // (must be after pallet cycle end, before pallet cycle start)
-        foreach (
-          var basketKv in completedBaskets ?? new Dictionary<int, IEnumerable<EventLogMaterial>>()
-        )
-        {
-          RecordBasketCycleEnd(basketId: basketKv.Key, timeUTC: timeUTC, logs: logs, trans: trans);
-        }
+        RecordExplicitBasketCycleEnds(basketCompletion, timeUTC, logs, trans);
 
         RecordLoadMaterialPaths(toLoad: toLoad, trans: trans);
 
@@ -2130,25 +2658,6 @@ namespace BlackMaple.MachineFramework
           );
         }
 
-        // Emit basket cycle starts for baskets in completedBaskets
-        // (must be after pallet cycle start)
-        foreach (
-          var basketKv in completedBaskets ?? new Dictionary<int, IEnumerable<EventLogMaterial>>()
-        )
-        {
-          if (basketKv.Value.Any())
-          {
-            RecordBasketCycleStart(
-              basketId: basketKv.Key,
-              mats: basketKv.Value,
-              timeUTC: timeUTC,
-              logs: logs,
-              trans: trans,
-              foreignId: null
-            );
-          }
-        }
-
         RecordLoadEnd(
           toLoad: toLoad,
           lulNum: lulNum,
@@ -2158,16 +2667,18 @@ namespace BlackMaple.MachineFramework
           totalActive: allHaveActive && totalActive > TimeSpan.Zero ? totalActive : null,
           timeUTC: timeUTC,
           logs: logs,
-          trans: trans
+          trans: trans,
+          materialFromBaskets: BasketMaterialIds<BasketTransfer.UnloadFromBasket>(basketCompletion)
         );
 
-        RecordBasketLoadEnds(
-          materialPerBasket,
-          lulNum: lulNum,
-          timeUTC: timeUTC,
-          logs: logs,
-          trans: trans
+        RecordBasketTransferEnds<BasketTransfer.LoadOntoBasket>(
+          basketCompletion,
+          lulNum,
+          timeUTC,
+          trans,
+          logs
         );
+        RecordExplicitBasketCycleStarts(basketCompletion, timeUTC, logs, trans);
 
         return logs;
       });
@@ -2540,7 +3051,7 @@ namespace BlackMaple.MachineFramework
           }
         }
 
-        // Process loads onto basket (no cycle events)
+        // Process loads onto basket
         if (toLoad != null)
         {
           TimeSpan elapsed = totalElapsed;
@@ -2671,10 +3182,9 @@ namespace BlackMaple.MachineFramework
       });
     }
 
-    // Records pallet unload events and basket load events.
-    // Returns a dictionary of basket ID to material that was loaded onto those baskets.
-    // Does NOT emit basket cycle events - caller controls when to emit those.
-    private IReadOnlyDictionary<int, IReadOnlyList<EventLogMaterial>> RecordUnloadEnd(
+    // Records pallet unload events and queue destinations. Basket destinations are recorded only
+    // from an explicit BasketLoadUnloadCompletion.
+    private void RecordUnloadEnd(
       IEnumerable<MaterialToUnloadFromFace> toUnload,
       int lulNum,
       int pallet,
@@ -2688,8 +3198,6 @@ namespace BlackMaple.MachineFramework
       IDbTransaction trans
     )
     {
-      var materialPerBasket = new Dictionary<int, List<EventLogMaterial>>();
-
       foreach (var face in toUnload ?? [])
       {
         foreach (var matAndDest in face.MaterialIDToDestination)
@@ -2728,22 +3236,6 @@ namespace BlackMaple.MachineFramework
                 )
               );
             }
-          }
-          else if (dest.BasketId.HasValue)
-          {
-            var basketId = dest.BasketId.Value;
-            var mat = new EventLogMaterial()
-            {
-              MaterialID = matAndDest.Key,
-              Process = face.Process,
-              Face = 0,
-            };
-
-            if (!materialPerBasket.ContainsKey(basketId))
-            {
-              materialPerBasket[basketId] = new List<EventLogMaterial>();
-            }
-            materialPerBasket[basketId].Add(mat);
           }
         }
 
@@ -2795,47 +3287,6 @@ namespace BlackMaple.MachineFramework
             face.OriginalMessage
           )
         );
-      }
-
-      // Return materialPerBasket so it can be passed to RecordBasketLoadEnds later.
-      // This allows the basket loads to be sequenced after the basket cycle (if any)
-
-      return materialPerBasket.ToDictionary(
-        kv => kv.Key,
-        kv => (IReadOnlyList<EventLogMaterial>)kv.Value
-      );
-    }
-
-    private void RecordBasketLoadEnds(
-      IReadOnlyDictionary<int, IReadOnlyList<EventLogMaterial>> materialPerBasket,
-      IDbTransaction trans,
-      int lulNum,
-      DateTime timeUTC,
-      List<LogEntry> logs
-    )
-    {
-      // Emit BasketLoadUnload LOAD events for each basket (but no cycle events)
-      foreach (var basketKv in materialPerBasket)
-      {
-        var basketId = basketKv.Key;
-        var mats = basketKv.Value;
-
-        var entry1 = new NewEventLogEntry()
-        {
-          Material = mats,
-          Pallet = basketId,
-          LogType = LogType.BasketLoadUnload,
-          LocationName = "L/U",
-          LocationNum = lulNum,
-          Program = "LOAD",
-          StartOfCycle = false,
-          // Add 1 second to be after the basket cycle
-          EndTimeUTC = timeUTC.AddSeconds(1),
-          Result = "LOAD",
-          ElapsedTime = TimeSpan.Zero,
-          ActiveOperationTime = TimeSpan.Zero,
-        };
-        logs.Add(AddLogEntry(trans, entry1, null, null));
       }
     }
 
@@ -2922,13 +3373,34 @@ namespace BlackMaple.MachineFramework
       string foreignId = null
     )
     {
+      RecordBasketCycleStart(
+        new ContainerIdentity.Numbered { ContainerNum = basketId },
+        mats,
+        timeUTC,
+        logs,
+        trans,
+        foreignId
+      );
+    }
+
+    private void RecordBasketCycleStart(
+      ContainerIdentity basketIdentity,
+      IEnumerable<EventLogMaterial> mats,
+      DateTime timeUTC,
+      List<LogEntry> logs,
+      IDbTransaction trans,
+      string foreignId = null
+    )
+    {
+      var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
       logs.Add(
         AddLogEntry(
           trans,
           new NewEventLogEntry()
           {
             Material = mats,
-            Pallet = basketId,
+            Pallet = containerNum,
+            ContainerId = containerId,
             LogType = LogType.BasketCycle,
             LocationName = "Basket Cycle",
             LocationNum = 0,
@@ -3053,7 +3525,7 @@ namespace BlackMaple.MachineFramework
             validate.Transaction = trans;
             validate.CommandText =
               "SELECT MIN(TimeUTC) FROM stations WHERE ContainerId = $id "
-              + "AND StationLoc IN ($loadUnloadType, $locationType, $snapshotType) AND "
+              + "AND StationLoc IN ($loadUnloadType, $locationType, $snapshotType, $cycleType) AND "
               + "NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = $id)";
             validate.Parameters.Add("id", SqliteType.Text).Value = id.ToString("D");
             validate.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
@@ -3062,6 +3534,8 @@ namespace BlackMaple.MachineFramework
               LogType.BasketInLocation;
             validate.Parameters.Add("snapshotType", SqliteType.Integer).Value = (int)
               LogType.BasketContentSnapshot;
+            validate.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)
+              LogType.BasketCycle;
             var first = validate.ExecuteScalar();
             if (first is null || first == DBNull.Value)
               throw new ConflictRequestException(
@@ -3189,13 +3663,16 @@ namespace BlackMaple.MachineFramework
       int totMatCnt,
       DateTime timeUTC,
       List<LogEntry> logs,
-      IDbTransaction trans
+      IDbTransaction trans,
+      IReadOnlySet<long> materialFromBaskets = null
     )
     {
       foreach (var face in toLoad ?? [])
       {
         foreach (var mat in face.MaterialIDs)
         {
+          if (materialFromBaskets?.Contains(mat) == true)
+            continue;
           var prevProcMat = new EventLogMaterial()
           {
             MaterialID = mat,
@@ -3260,101 +3737,6 @@ namespace BlackMaple.MachineFramework
             face.OriginalMessage
           )
         );
-      }
-    }
-
-    // Basket Unload Ends come from material that is being loaded
-    // (if it is loaded out of a basket and not a queue)
-    private void RecordBasketUnloadEnds(
-      IEnumerable<MaterialToLoadOntoFace> toLoad,
-      int lulNum,
-      DateTime timeUTC,
-      IDbTransaction trans,
-      List<LogEntry> logs
-    )
-    {
-      var materialPerBasket = new Dictionary<int, List<EventLogMaterial>>();
-
-      foreach (var face in toLoad ?? [])
-      {
-        foreach (var mat in face.MaterialIDs)
-        {
-          var prevProcMat = new EventLogMaterial()
-          {
-            MaterialID = mat,
-            Process = face.Process - 1,
-            Face = 0,
-          };
-
-          // Check if material is on a basket by looking for most recent non-invalidated BasketCycle START event
-          using (var cmd = _connection.CreateCommand())
-          {
-            cmd.Transaction = (SqliteTransaction)trans;
-            cmd.CommandText =
-              "SELECT s.Pallet, "
-              + "(SELECT COUNT(*) FROM program_details WHERE program_details.Counter = s.Counter AND program_details.Key = 'PalletCycleInvalidated') As Invalidated "
-              + "FROM stations s "
-              + "INNER JOIN stations_mat sm ON s.Counter = sm.Counter "
-              + "WHERE sm.MaterialID = $mid "
-              + "  AND s.StationLoc = $basketCycleType "
-              + "  AND s.Result = 'BasketCycle' "
-              + "  AND s.Start = 1 "
-              + "ORDER BY s.Counter DESC LIMIT 1";
-            cmd.Parameters.Add("mid", SqliteType.Integer).Value = mat;
-            cmd.Parameters.Add("basketCycleType", SqliteType.Integer).Value = (int)
-              LogType.BasketCycle;
-
-            int basketId = 0;
-            int invalidated = 0;
-            using (var reader = cmd.ExecuteReader())
-            {
-              if (reader.Read())
-              {
-                basketId = reader.GetInt32(0);
-                invalidated = reader.GetInt32(1);
-              }
-            }
-
-            if (basketId != 0 && invalidated == 0)
-            {
-              var matOnBasket = new EventLogMaterial()
-              {
-                MaterialID = mat,
-                Process = face.Process - 1,
-                Face = 0,
-              };
-
-              if (!materialPerBasket.ContainsKey(basketId))
-              {
-                materialPerBasket[basketId] = new List<EventLogMaterial>();
-              }
-              materialPerBasket[basketId].Add(matOnBasket);
-            }
-          }
-        }
-      }
-
-      // Emit BasketLoadUnload UNLOAD events for each basket
-      foreach (var basketKv in materialPerBasket)
-      {
-        var basketId = basketKv.Key;
-        var mats = basketKv.Value;
-
-        var entry2 = new NewEventLogEntry()
-        {
-          Material = mats,
-          Pallet = basketId,
-          LogType = LogType.BasketLoadUnload,
-          LocationName = "L/U",
-          LocationNum = lulNum,
-          Program = "UNLOAD",
-          StartOfCycle = false,
-          EndTimeUTC = timeUTC,
-          Result = "UNLOAD",
-          ElapsedTime = TimeSpan.Zero,
-          ActiveOperationTime = TimeSpan.Zero,
-        };
-        logs.Add(AddLogEntry(trans, entry2, null, null));
       }
     }
 
@@ -3946,23 +4328,27 @@ namespace BlackMaple.MachineFramework
       );
     }
 
-    private void EnsureOpenBasketFragment(Guid containerId, IDbTransaction trans)
+    private DateTime EnsureOpenBasketFragment(Guid containerId, IDbTransaction trans)
     {
       using var cmd = _connection.CreateCommand();
       ((IDbCommand)cmd).Transaction = trans;
       cmd.CommandText =
-        "SELECT EXISTS(SELECT 1 FROM stations WHERE ContainerId = $id "
-        + "AND StationLoc IN ($loadUnloadType, $locationType, $snapshotType))";
+        "SELECT MIN(TimeUTC) FROM stations WHERE ContainerId = $id "
+        + "AND StationLoc IN ($loadUnloadType, $locationType, $snapshotType, $cycleType) "
+        + "AND NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = $id)";
       cmd.Parameters.Add("id", SqliteType.Text).Value = containerId.ToString("D");
       cmd.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
         LogType.BasketLoadUnload;
       cmd.Parameters.Add("locationType", SqliteType.Integer).Value = (int)LogType.BasketInLocation;
       cmd.Parameters.Add("snapshotType", SqliteType.Integer).Value = (int)
         LogType.BasketContentSnapshot;
-      if ((long)cmd.ExecuteScalar() == 0)
+      cmd.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)LogType.BasketCycle;
+      var firstEventTime = cmd.ExecuteScalar();
+      if (firstEventTime is null or DBNull)
         throw new ConflictRequestException(
           $"Container UUID {containerId:D} does not identify an open basket fragment."
         );
+      return new DateTime((long)firstEventTime, DateTimeKind.Utc);
     }
 
     private static (int ContainerNum, Guid? ContainerId) RecordedContainerIdentity(

--- a/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
@@ -152,15 +152,15 @@ namespace BlackMaple.MachineFramework
       int pallet,
       TimeSpan totalElapsed,
       DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues
+      IReadOnlyDictionary<string, string> externalQueues,
+      BasketLoadUnloadCompletion basketCompletion = null
     );
 
     // The main method for recording a completed pallet load/unload, which combines
     // pallet <-> queue and pallet <-> basket operations along with any previously
-    // recorded partial options in calls to `RecordPartialLoadUnload`.  This will
-    // emit a cycle event for the pallet.  The optional `completedBaskets` field
-    // contains any baskets which are now filled or empty, and this method will emit a basket
-    // cycle event for each of them.
+    // recorded partial options in calls to `RecordPartialLoadUnload`. This emits pallet cycle
+    // events. Basket transfer evidence and basket cycle boundaries are emitted only from the
+    // optional explicit basket completion.
     IEnumerable<LogEntry> RecordLoadUnloadComplete(
       IReadOnlyList<MaterialToLoadOntoFace> toLoad,
       IReadOnlyList<EventLogMaterial> previouslyLoaded,
@@ -171,13 +171,25 @@ namespace BlackMaple.MachineFramework
       TimeSpan totalElapsed,
       DateTime timeUTC,
       IReadOnlyDictionary<string, string> externalQueues,
-      IReadOnlyDictionary<int, IEnumerable<EventLogMaterial>> completedBaskets = null
+      BasketLoadUnloadCompletion basketCompletion = null
+    );
+
+    // Records explicit basket transfer evidence and cycle boundaries atomically without duplicating
+    // pallet events. This supports integrations which reconstruct basket state after pallet
+    // completion. foreignId is required: an identical retry returns the original event group, while
+    // reuse for different evidence throws ConflictRequestException.
+    IEnumerable<LogEntry> RecordBasketLoadUnloadCompletion(
+      BasketLoadUnloadCompletion basketCompletion,
+      int lulNum,
+      DateTime timeUTC,
+      string foreignId,
+      string originalMessage = null
     );
 
     // RecordPartialBasketOnlyLoadUnload is for partial basket-only operations.
     // Records BasketLoadUnload events but NO BasketCycle events.  Material loaded here
-    // should be later passed into either `completedBaskets` on `RecordLoadUnloadComplete`
-    // or `previouslyLoaded` in `RecordBasketOnlyLoadUnload`.
+    // should be later passed into an explicit BasketLoadUnloadCompletion or `previouslyLoaded`
+    // in `RecordBasketOnlyLoadUnload`.
     IEnumerable<LogEntry> RecordPartialBasketOnlyLoadUnload(
       MaterialToLoadOntoBasket toLoad,
       MaterialToUnloadFromBasket toUnload,
@@ -805,8 +817,48 @@ namespace BlackMaple.MachineFramework
 
   public record UnloadDestination
   {
-    public string Queue { get; init; } // should be string? but no #nullable yet
-    public int? BasketId { get; init; }
+    public string Queue { get; init; }
+  }
+
+  public abstract record BasketTransfer
+  {
+    private BasketTransfer() { }
+
+    public required ContainerIdentity BasketIdentity { get; init; }
+    public required ImmutableList<EventLogMaterial> Material { get; init; }
+
+    public sealed record LoadOntoBasket : BasketTransfer;
+
+    public sealed record UnloadFromBasket : BasketTransfer;
+  }
+
+  public abstract record BasketCycleBoundary
+  {
+    private BasketCycleBoundary() { }
+
+    public required ContainerIdentity BasketIdentity { get; init; }
+
+    /// <summary>
+    /// Complete, slot-aware material for the cycle being ended or started.
+    /// </summary>
+    public required ImmutableList<EventLogMaterial> Material { get; init; }
+
+    public sealed record End : BasketCycleBoundary
+    {
+      /// <summary>
+      /// UUID fragments finalized by this numbered basket end. Leave empty for a numbered cycle
+      /// which has no UUID fragments.
+      /// </summary>
+      public required ImmutableHashSet<Guid> ContainerIds { get; init; }
+    }
+
+    public sealed record Start : BasketCycleBoundary;
+  }
+
+  public record BasketLoadUnloadCompletion
+  {
+    public required ImmutableList<BasketTransfer> Transfers { get; init; }
+    public required ImmutableList<BasketCycleBoundary> CycleBoundaries { get; init; }
   }
 
   public record MaterialToUnloadFromFace

--- a/server/test/ContainerIdentitySpec.cs
+++ b/server/test/ContainerIdentitySpec.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using BlackMaple.MachineFramework;
 using Microsoft.Data.Sqlite;
+using VerifyTUnit;
 
 namespace BlackMaple.FMSInsight.Tests;
 
@@ -128,6 +129,474 @@ public sealed class ContainerIdentitySpec : IDisposable
     await Assert.That(logs.Pallet).IsEqualTo(-1);
     await Assert.That(logs.ContainerId).IsEqualTo(id);
     await Assert.That(logs.Material.Single().MaterialID).IsEqualTo(materialId);
+  }
+
+  [Test]
+  public async Task UuidBasketLoadCompletionRecordsLoadAndCompleteCycleStart()
+  {
+    var basketId = Guid.Parse("418a9c3e-dd45-4b8f-a2f8-064772599927");
+    var completionTime = new DateTime(2026, 7, 24, 14, 30, 0, DateTimeKind.Utc);
+    using var repository = _repositoryConfig.OpenConnection();
+    var existingMaterialId = repository.AllocateMaterialID("job", "part", 2);
+    var loadedMaterialId = repository.AllocateMaterialID("job", "part", 2);
+    var completeContents = ImmutableList.Create(
+      new EventLogMaterial
+      {
+        MaterialID = existingMaterialId,
+        Process = 2,
+        Face = 3,
+      },
+      new EventLogMaterial
+      {
+        MaterialID = loadedMaterialId,
+        Process = 2,
+        Face = 7,
+      }
+    );
+
+    var completion = new BasketLoadUnloadCompletion
+    {
+      Transfers =
+      [
+        new BasketTransfer.LoadOntoBasket
+        {
+          BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
+          Material = [completeContents[1]],
+        },
+      ],
+      CycleBoundaries =
+      [
+        new BasketCycleBoundary.Start
+        {
+          BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
+          Material = completeContents,
+        },
+      ],
+    };
+    var logs = repository
+      .RecordBasketLoadUnloadCompletion(
+        completion,
+        lulNum: 4,
+        timeUTC: completionTime,
+        foreignId: "uuid-load-complete",
+        originalMessage: "robot evidence"
+      )
+      .ToImmutableList();
+
+    await Assert.That(logs).Count().IsEqualTo(2);
+    var loadEnd = logs[0];
+    await Assert.That(loadEnd.LogType).IsEqualTo(LogType.BasketLoadUnload);
+    await Assert.That(loadEnd.Program).IsEqualTo("LOAD");
+    await Assert.That(loadEnd.StartOfCycle).IsFalse();
+    await Assert
+      .That(loadEnd.Identity)
+      .IsEqualTo(new ContainerIdentity.Uuid { ContainerId = basketId });
+    await Assert.That(loadEnd.Material.Single().MaterialID).IsEqualTo(loadedMaterialId);
+    await Assert.That(loadEnd.Material.Single().Process).IsEqualTo(2);
+    await Assert.That(loadEnd.Material.Single().Face).IsEqualTo(7);
+
+    var cycleStart = logs[1];
+    await Assert.That(cycleStart.LogType).IsEqualTo(LogType.BasketCycle);
+    await Assert.That(cycleStart.StartOfCycle).IsTrue();
+    await Assert
+      .That(cycleStart.Identity)
+      .IsEqualTo(new ContainerIdentity.Uuid { ContainerId = basketId });
+    await Assert
+      .That(
+        cycleStart.Material.Select(material =>
+          (material.MaterialID, material.Process, material.Face)
+        )
+      )
+      .IsEquivalentTo(new[] { (existingMaterialId, 2, 3), (loadedMaterialId, 2, 7) });
+    var retry = repository
+      .RecordBasketLoadUnloadCompletion(
+        completion,
+        lulNum: 4,
+        timeUTC: completionTime.AddMinutes(1),
+        foreignId: "uuid-load-complete",
+        originalMessage: "robot evidence"
+      )
+      .ToImmutableList();
+    await Assert
+      .That(retry.Select(log => log.Counter))
+      .IsEquivalentTo(logs.Select(log => log.Counter));
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketLoadUnloadCompletion(
+        completion,
+        lulNum: 4,
+        timeUTC: completionTime,
+        foreignId: "uuid-load-complete",
+        originalMessage: "different evidence"
+      )
+    );
+    await Assert
+      .That(repository.CurrentBasketLog(new ContainerIdentity.Uuid { ContainerId = basketId }))
+      .Count()
+      .IsEqualTo(2);
+    await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).IsEquivalentTo([basketId]);
+
+    await Verifier
+      .Verify(
+        logs.Select(log => new
+        {
+          Type = log.LogType.ToString(),
+          log.Program,
+          log.StartOfCycle,
+          log.Pallet,
+          log.ContainerId,
+          Material = log.Material.Select(material => new
+          {
+            material.MaterialID,
+            material.Process,
+            Slot = material.Face,
+          }),
+        })
+      )
+      .UseDirectory("snapshots");
+  }
+
+  [Test]
+  public async Task UuidBasketLoadCompletionIsAtomic()
+  {
+    var basketId = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 1);
+    using (var connection = new SqliteConnection("Data Source=" + _databaseFile))
+    {
+      connection.Open();
+      using var trigger = connection.CreateCommand();
+      trigger.CommandText =
+        "CREATE TRIGGER fail_uuid_load BEFORE INSERT ON stations WHEN NEW.StationLoc = "
+        + (int)LogType.BasketCycle
+        + " BEGIN SELECT RAISE(ABORT, 'test rollback'); END";
+      trigger.ExecuteNonQuery();
+    }
+
+    await AssertThrows<SqliteException>(() =>
+      repository.RecordBasketLoadUnloadCompletion(
+        new BasketLoadUnloadCompletion
+        {
+          Transfers =
+          [
+            new BasketTransfer.LoadOntoBasket
+            {
+              BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = materialId,
+                  Process = 1,
+                  Face = 5,
+                },
+              ],
+            },
+          ],
+          CycleBoundaries =
+          [
+            new BasketCycleBoundary.Start
+            {
+              BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = materialId,
+                  Process = 1,
+                  Face = 5,
+                },
+              ],
+            },
+          ],
+        },
+        lulNum: 1,
+        DateTime.UtcNow,
+        foreignId: "atomic-uuid-load"
+      )
+    );
+    await Assert.That(repository.GetRecentLog(0)).IsEmpty();
+    await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).IsEmpty();
+  }
+
+  [Test]
+  public async Task ExplicitCycleEndFinalizesSeveralUuidTransferFragments()
+  {
+    var first = Guid.NewGuid();
+    var second = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    var firstMaterial = repository.AllocateMaterialID("job", "part", 1);
+    var secondMaterial = repository.AllocateMaterialID("job", "part", 1);
+    var firstContents = ImmutableList.Create(
+      new EventLogMaterial
+      {
+        MaterialID = firstMaterial,
+        Process = 1,
+        Face = 2,
+      }
+    );
+    var secondContents = ImmutableList.Create(
+      new EventLogMaterial
+      {
+        MaterialID = secondMaterial,
+        Process = 1,
+        Face = 8,
+      }
+    );
+    var firstEvidenceTime = new DateTime(2026, 7, 24, 10, 0, 0, DateTimeKind.Utc);
+    repository.RecordBasketContentSnapshot(
+      firstContents,
+      new ContainerIdentity.Uuid { ContainerId = first },
+      firstEvidenceTime,
+      foreignId: "first-fragment"
+    );
+    repository.RecordBasketContentSnapshot(
+      secondContents,
+      new ContainerIdentity.Uuid { ContainerId = second },
+      firstEvidenceTime.AddMinutes(1),
+      foreignId: "second-fragment"
+    );
+    var completion = new BasketLoadUnloadCompletion
+    {
+      Transfers =
+      [
+        new BasketTransfer.UnloadFromBasket
+        {
+          BasketIdentity = new ContainerIdentity.Uuid { ContainerId = first },
+          Material = firstContents,
+        },
+        new BasketTransfer.UnloadFromBasket
+        {
+          BasketIdentity = new ContainerIdentity.Uuid { ContainerId = second },
+          Material = secondContents,
+        },
+      ],
+      CycleBoundaries =
+      [
+        new BasketCycleBoundary.End
+        {
+          BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 9 },
+          Material = [.. firstContents, .. secondContents],
+          ContainerIds = [first, second],
+        },
+      ],
+    };
+
+    var logs = repository
+      .RecordBasketLoadUnloadCompletion(
+        completion,
+        lulNum: 3,
+        timeUTC: firstEvidenceTime.AddMinutes(10),
+        foreignId: "finalize-basket-9"
+      )
+      .ToImmutableList();
+    var retry = repository
+      .RecordBasketLoadUnloadCompletion(
+        completion,
+        lulNum: 3,
+        timeUTC: firstEvidenceTime.AddMinutes(11),
+        foreignId: "finalize-basket-9"
+      )
+      .ToImmutableList();
+
+    await Assert.That(logs.Select(log => log.Program)).IsEquivalentTo(["UNLOAD", "UNLOAD", ""]);
+    var cycleEnd = logs[2];
+    await Assert
+      .That(cycleEnd.Identity)
+      .IsEqualTo(new ContainerIdentity.Numbered { ContainerNum = 9 });
+    await Assert.That(cycleEnd.CycleEndContainerIds).IsEquivalentTo([first, second]);
+    await Assert.That(cycleEnd.Material.Select(material => material.Face)).IsEquivalentTo([2, 8]);
+    await Assert.That(cycleEnd.ElapsedTime).IsEqualTo(TimeSpan.FromMinutes(10));
+    await Assert
+      .That(retry.Select(log => log.Counter))
+      .IsEquivalentTo(logs.Select(log => log.Counter));
+    await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).IsEmpty();
+  }
+
+  [Test]
+  public async Task ExplicitCycleEndRejectsAnAlreadyFinalizedUuidFragment()
+  {
+    var fragment = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    repository.RecordBasketContentSnapshot(
+      [],
+      new ContainerIdentity.Uuid { ContainerId = fragment },
+      DateTime.UtcNow
+    );
+    var completion = new BasketLoadUnloadCompletion
+    {
+      Transfers = [],
+      CycleBoundaries =
+      [
+        new BasketCycleBoundary.End
+        {
+          BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 9 },
+          Material = [],
+          ContainerIds = [fragment],
+        },
+      ],
+    };
+
+    repository.RecordBasketLoadUnloadCompletion(
+      completion,
+      lulNum: 3,
+      timeUTC: DateTime.UtcNow,
+      foreignId: "first-finalization"
+    );
+
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketLoadUnloadCompletion(
+        completion,
+        lulNum: 3,
+        timeUTC: DateTime.UtcNow,
+        foreignId: "duplicate-finalization"
+      )
+    );
+  }
+
+  [Test]
+  public async Task ExplicitCycleEndRejectsMaterialMissingFromFinalizedFragment()
+  {
+    var fragment = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    var transferredMaterial = repository.AllocateMaterialID("job", "part", 1);
+    var unrelatedMaterial = repository.AllocateMaterialID("job", "part", 1);
+
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordBasketLoadUnloadCompletion(
+        new BasketLoadUnloadCompletion
+        {
+          Transfers =
+          [
+            new BasketTransfer.UnloadFromBasket
+            {
+              BasketIdentity = new ContainerIdentity.Uuid { ContainerId = fragment },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = transferredMaterial,
+                  Process = 1,
+                  Face = 2,
+                },
+              ],
+            },
+          ],
+          CycleBoundaries =
+          [
+            new BasketCycleBoundary.End
+            {
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 9 },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = unrelatedMaterial,
+                  Process = 1,
+                  Face = 2,
+                },
+              ],
+              ContainerIds = [fragment],
+            },
+          ],
+        },
+        lulNum: 3,
+        timeUTC: DateTime.UtcNow,
+        foreignId: "invalid-fragment-finalization"
+      )
+    );
+    await Assert.That(repository.GetRecentLog(0)).IsEmpty();
+  }
+
+  [Test]
+  public async Task PartialPalletUnloadAcceptsExplicitUuidBasketTransferWithoutStartingCycle()
+  {
+    var basketId = Guid.NewGuid();
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 2);
+
+    var logs = repository
+      .RecordPartialLoadUnload(
+        toLoad: null,
+        toUnload:
+        [
+          new MaterialToUnloadFromFace
+          {
+            MaterialIDToDestination = ImmutableDictionary<long, UnloadDestination>.Empty.Add(
+              materialId,
+              new UnloadDestination()
+            ),
+            FaceNum = 1,
+            Process = 1,
+            ActiveOperationTime = TimeSpan.Zero,
+          },
+        ],
+        lulNum: 2,
+        pallet: 4,
+        totalElapsed: TimeSpan.Zero,
+        timeUTC: DateTime.UtcNow,
+        externalQueues: ImmutableDictionary<string, string>.Empty,
+        basketCompletion: new BasketLoadUnloadCompletion
+        {
+          Transfers =
+          [
+            new BasketTransfer.LoadOntoBasket
+            {
+              BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = materialId,
+                  Process = 2,
+                  Face = 6,
+                },
+              ],
+            },
+          ],
+          CycleBoundaries = [],
+        }
+      )
+      .ToImmutableList();
+
+    var basketLoad = logs.Single(log => log.LogType == LogType.BasketLoadUnload);
+    await Assert
+      .That(basketLoad.Identity)
+      .IsEqualTo(new ContainerIdentity.Uuid { ContainerId = basketId });
+    await Assert.That(basketLoad.Material.Single().Process).IsEqualTo(2);
+    await Assert.That(basketLoad.Material.Single().Face).IsEqualTo(6);
+    await Assert.That(logs).DoesNotContain(log => log.LogType == LogType.BasketCycle);
+  }
+
+  [Test]
+  public async Task PalletUnloadWithoutQueueRequiresMatchingBasketTransfer()
+  {
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 1);
+
+    await AssertThrows<ArgumentException>(() =>
+      repository.RecordPartialLoadUnload(
+        toLoad: null,
+        toUnload:
+        [
+          new MaterialToUnloadFromFace
+          {
+            MaterialIDToDestination = ImmutableDictionary<long, UnloadDestination>.Empty.Add(
+              materialId,
+              new UnloadDestination()
+            ),
+            FaceNum = 1,
+            Process = 1,
+            ActiveOperationTime = TimeSpan.Zero,
+          },
+        ],
+        lulNum: 2,
+        pallet: 4,
+        totalElapsed: TimeSpan.Zero,
+        timeUTC: DateTime.UtcNow,
+        externalQueues: ImmutableDictionary<string, string>.Empty
+      )
+    );
+    await Assert.That(repository.GetRecentLog(0)).IsEmpty();
   }
 
   [Test]

--- a/server/test/JobLogTest.cs
+++ b/server/test/JobLogTest.cs
@@ -6701,8 +6701,22 @@ namespace BlackMaple.FMSInsight.Tests
         externalQueues: null
       );
 
-      // Now unload from pallet to basket
-      // Pass completedBaskets to emit basket cycle events for basket 3
+      var basket3Contents = ImmutableList.Create(
+        new EventLogMaterial
+        {
+          MaterialID = mat1.MaterialID,
+          Process = 1,
+          Face = 1,
+        },
+        new EventLogMaterial
+        {
+          MaterialID = mat2.MaterialID,
+          Process = 1,
+          Face = 2,
+        }
+      );
+
+      // Now unload from pallet to basket with explicit transfer and ready-cycle evidence.
       var unloadToBasket = _jobLog.RecordLoadUnloadComplete(
         toLoad: null,
         toUnload:
@@ -6710,8 +6724,8 @@ namespace BlackMaple.FMSInsight.Tests
           new MaterialToUnloadFromFace()
           {
             MaterialIDToDestination = ImmutableDictionary<long, UnloadDestination>
-              .Empty.Add(mat1.MaterialID, new UnloadDestination() { BasketId = 3 })
-              .Add(mat2.MaterialID, new UnloadDestination() { BasketId = 3 }),
+              .Empty.Add(mat1.MaterialID, new UnloadDestination())
+              .Add(mat2.MaterialID, new UnloadDestination()),
             FaceNum = 1,
             Process = 1,
             ActiveOperationTime = TimeSpan.FromMinutes(15),
@@ -6724,23 +6738,24 @@ namespace BlackMaple.FMSInsight.Tests
         totalElapsed: TimeSpan.FromMinutes(20),
         timeUTC: start.AddMinutes(30),
         externalQueues: null,
-        completedBaskets: new Dictionary<int, IEnumerable<EventLogMaterial>>
+        basketCompletion: new BasketLoadUnloadCompletion
         {
-          [3] = new[]
-          {
-            new EventLogMaterial()
+          Transfers =
+          [
+            new BasketTransfer.LoadOntoBasket
             {
-              MaterialID = mat1.MaterialID,
-              Process = 1,
-              Face = 0,
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
+              Material = basket3Contents,
             },
-            new EventLogMaterial()
+          ],
+          CycleBoundaries =
+          [
+            new BasketCycleBoundary.Start
             {
-              MaterialID = mat2.MaterialID,
-              Process = 1,
-              Face = 0,
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
+              Material = basket3Contents,
             },
-          },
+          ],
         }
       );
 
@@ -6777,8 +6792,7 @@ namespace BlackMaple.FMSInsight.Tests
       basketCycleStart.Material[0].MaterialID.ShouldBe(mat1.MaterialID);
       basketCycleStart.Material[1].MaterialID.ShouldBe(mat2.MaterialID);
 
-      // Now load from basket back to pallet
-      // Pass completedBaskets with empty material to emit basket cycle end for basket 3
+      // Now load from basket back to pallet and explicitly complete the basket cycle.
       var loadFromBasket = _jobLog.RecordLoadUnloadComplete(
         toLoad:
         [
@@ -6799,9 +6813,25 @@ namespace BlackMaple.FMSInsight.Tests
         totalElapsed: TimeSpan.FromMinutes(8),
         timeUTC: start.AddMinutes(50),
         externalQueues: null,
-        completedBaskets: new Dictionary<int, IEnumerable<EventLogMaterial>>
+        basketCompletion: new BasketLoadUnloadCompletion
         {
-          [3] = [], // Basket 3 is now empty
+          Transfers =
+          [
+            new BasketTransfer.UnloadFromBasket
+            {
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
+              Material = basket3Contents,
+            },
+          ],
+          CycleBoundaries =
+          [
+            new BasketCycleBoundary.End
+            {
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
+              Material = basket3Contents,
+              ContainerIds = [],
+            },
+          ],
         }
       );
 
@@ -7223,7 +7253,7 @@ namespace BlackMaple.FMSInsight.Tests
     }
 
     [Test]
-    public void BasketLoadEventUses1SecondDelay()
+    public void BasketLoadEventPrecedesCycleStart()
     {
       var start = new DateTime(2018, 01, 15, 17, 30, 0, DateTimeKind.Utc);
       using var _jobLog = _repoCfg.OpenConnection();
@@ -7265,7 +7295,7 @@ namespace BlackMaple.FMSInsight.Tests
           {
             MaterialIDToDestination = ImmutableDictionary<long, UnloadDestination>.Empty.Add(
               mat1.MaterialID,
-              new UnloadDestination() { BasketId = 3 }
+              new UnloadDestination()
             ),
             FaceNum = 1,
             Process = 1,
@@ -7279,17 +7309,40 @@ namespace BlackMaple.FMSInsight.Tests
         totalElapsed: TimeSpan.FromMinutes(20),
         timeUTC: start.AddMinutes(30),
         externalQueues: null,
-        completedBaskets: new Dictionary<int, IEnumerable<EventLogMaterial>>
+        basketCompletion: new BasketLoadUnloadCompletion
         {
-          [3] = new[]
-          {
-            new EventLogMaterial()
+          Transfers =
+          [
+            new BasketTransfer.LoadOntoBasket
             {
-              MaterialID = mat1.MaterialID,
-              Process = 1,
-              Face = 0,
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = mat1.MaterialID,
+                  Process = 1,
+                  Face = 1,
+                },
+              ],
             },
-          },
+          ],
+          CycleBoundaries =
+          [
+            new BasketCycleBoundary.Start
+            {
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = mat1.MaterialID,
+                  Process = 1,
+                  Face = 1,
+                },
+              ],
+            },
+          ],
         }
       );
 
@@ -7299,8 +7352,12 @@ namespace BlackMaple.FMSInsight.Tests
       );
       basketLoad.ShouldNotBeNull();
 
-      // Basket LOAD should be 1 second after the base time
-      basketLoad.EndTimeUTC.ShouldBe(start.AddMinutes(30).AddSeconds(1));
+      // Explicit basket LOAD evidence is recorded before the ready-cycle start.
+      basketLoad.EndTimeUTC.ShouldBe(start.AddMinutes(30));
+      var basketCycleStart = loadCompleteLogs.First(e =>
+        e.LogType == LogType.BasketCycle && e.StartOfCycle
+      );
+      basketLoad.Counter.ShouldBeLessThan(basketCycleStart.Counter);
 
       // Find the Pallet LOAD event (from first toLoad)
       var palletLoad = loadCompleteLogs.FirstOrDefault(e =>
@@ -7414,9 +7471,41 @@ namespace BlackMaple.FMSInsight.Tests
         totalElapsed: TimeSpan.FromMinutes(3),
         timeUTC: start.AddMinutes(10),
         externalQueues: null,
-        completedBaskets: new Dictionary<int, IEnumerable<EventLogMaterial>>
+        basketCompletion: new BasketLoadUnloadCompletion
         {
-          [55] = [], // Basket is now empty
+          Transfers =
+          [
+            new BasketTransfer.UnloadFromBasket
+            {
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 55 },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = mat1.MaterialID,
+                  Process = 1,
+                  Face = 0,
+                },
+              ],
+            },
+          ],
+          CycleBoundaries =
+          [
+            new BasketCycleBoundary.End
+            {
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 55 },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = mat1.MaterialID,
+                  Process = 1,
+                  Face = 0,
+                },
+              ],
+              ContainerIds = [],
+            },
+          ],
         }
       );
 

--- a/server/test/snapshots/ContainerIdentitySpec.UuidBasketLoadCompletionRecordsLoadAndCompleteCycleStart.verified.txt
+++ b/server/test/snapshots/ContainerIdentitySpec.UuidBasketLoadCompletionRecordsLoadAndCompleteCycleStart.verified.txt
@@ -1,0 +1,35 @@
+﻿[
+  {
+    Type: BasketLoadUnload,
+    Program: LOAD,
+    StartOfCycle: false,
+    Pallet: -1,
+    ContainerId: Guid_1,
+    Material: [
+      {
+        MaterialID: 2,
+        Process: 2,
+        Slot: 7
+      }
+    ]
+  },
+  {
+    Type: BasketCycle,
+    Program: ,
+    StartOfCycle: true,
+    Pallet: -1,
+    ContainerId: Guid_1,
+    Material: [
+      {
+        MaterialID: 1,
+        Process: 2,
+        Slot: 3
+      },
+      {
+        MaterialID: 2,
+        Process: 2,
+        Slot: 7
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds explicit, transactional basket transfer and cycle-boundary evidence, including idempotent delayed reconciliation. Review additionally rejects attempts to finalize an already-finalized UUID fragment with a domain conflict rather than a SQLite constraint error.