### PR TITLE
events: simplify atomic basket station recording

### DIFF
--- a/server/debug-mock/DebugMock.cs
+++ b/server/debug-mock/DebugMock.cs
@@ -776,20 +776,26 @@ namespace DebugMachineWatchApiServer
           var queue = EventDetail(e, "Queue");
           if (!string.IsNullOrEmpty(queue))
           {
-            LogDB.RecordBasketOnlyLoadUnload(
-              toLoad: new MaterialToLoadOntoBasket()
+            LogDB.RecordBasketStationLoadUnload(
+              operation: new BasketStationLoadUnload
               {
-                MaterialIDs = e.Material.Select(m => m.MaterialID).ToImmutableList(),
-                Process = e.Material[0].Process,
-                ActiveOperationTime = e.ActiveOperationTime,
+                Transfers =
+                [
+                  new BasketStationTransfer.LoadOntoBasket
+                  {
+                    BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = e.Pallet },
+                    Material = e.Material.Select(EventLogMaterial.FromLogMat).ToImmutableList(),
+                    ActiveOperationTime = e.ActiveOperationTime,
+                    SourceQueue = queue,
+                  },
+                ],
+                CycleBoundaries = [],
               },
-              previouslyLoaded: ImmutableList<EventLogMaterial>.Empty,
-              toUnload: null,
               lulNum: e.LocationNum,
-              basketId: e.Pallet,
               totalElapsed: e.ElapsedTime,
               timeUTC: e.EndTimeUTC.Add(offset),
-              externalQueues: null
+              externalQueues: null,
+              foreignId: $"debug-replay-basket:{e.Counter}"
             );
           }
         }
@@ -798,20 +804,26 @@ namespace DebugMachineWatchApiServer
           var queue = EventDetail(e, "Queue");
           if (!string.IsNullOrEmpty(queue))
           {
-            LogDB.RecordBasketOnlyLoadUnload(
-              toLoad: null,
-              previouslyLoaded: ImmutableList<EventLogMaterial>.Empty,
-              toUnload: new MaterialToUnloadFromBasket()
+            LogDB.RecordBasketStationLoadUnload(
+              operation: new BasketStationLoadUnload
               {
-                MaterialIDToQueue = e.Material.ToImmutableDictionary(m => m.MaterialID, _ => queue),
-                Process = e.Material[0].Process,
-                ActiveOperationTime = e.ActiveOperationTime,
+                Transfers =
+                [
+                  new BasketStationTransfer.UnloadFromBasket
+                  {
+                    BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = e.Pallet },
+                    Material = e.Material.Select(EventLogMaterial.FromLogMat).ToImmutableList(),
+                    ActiveOperationTime = e.ActiveOperationTime,
+                    DestinationQueue = queue,
+                  },
+                ],
+                CycleBoundaries = [],
               },
               lulNum: e.LocationNum,
-              basketId: e.Pallet,
               totalElapsed: e.ElapsedTime,
               timeUTC: e.EndTimeUTC.Add(offset),
-              externalQueues: null
+              externalQueues: null,
+              foreignId: $"debug-replay-basket:{e.Counter}"
             );
           }
         }

--- a/server/debug-mock/DebugMock.cs
+++ b/server/debug-mock/DebugMock.cs
@@ -670,12 +670,12 @@ namespace DebugMachineWatchApiServer
             timeUTC: e.EndTimeUTC.Add(offset),
             totalElapsed: e.ElapsedTime,
             externalQueues: null,
-            basketCompletion: basketId.HasValue
-              ? new BasketLoadUnloadCompletion
+            palletBasketCompletion: basketId.HasValue
+              ? new PalletBasketLoadUnloadCompletion
               {
                 Transfers =
                 [
-                  new BasketTransfer.LoadOntoBasket
+                  new PalletBasketTransfer.LoadOntoBasket
                   {
                     BasketIdentity = new ContainerIdentity.Numbered
                     {
@@ -776,8 +776,8 @@ namespace DebugMachineWatchApiServer
           var queue = EventDetail(e, "Queue");
           if (!string.IsNullOrEmpty(queue))
           {
-            LogDB.RecordBasketStationLoadUnload(
-              operation: new BasketStationLoadUnload
+            LogDB.RecordBasketStationOperation(
+              operation: new BasketStationOperation
               {
                 Transfers =
                 [
@@ -786,7 +786,6 @@ namespace DebugMachineWatchApiServer
                     BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = e.Pallet },
                     Material = e.Material.Select(EventLogMaterial.FromLogMat).ToImmutableList(),
                     ActiveOperationTime = e.ActiveOperationTime,
-                    SourceQueue = queue,
                   },
                 ],
                 CycleBoundaries = [],
@@ -804,8 +803,8 @@ namespace DebugMachineWatchApiServer
           var queue = EventDetail(e, "Queue");
           if (!string.IsNullOrEmpty(queue))
           {
-            LogDB.RecordBasketStationLoadUnload(
-              operation: new BasketStationLoadUnload
+            LogDB.RecordBasketStationOperation(
+              operation: new BasketStationOperation
               {
                 Transfers =
                 [

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -1942,10 +1942,10 @@ namespace BlackMaple.MachineFramework
       TimeSpan totalElapsed,
       DateTime timeUTC,
       IReadOnlyDictionary<string, string> externalQueues,
-      BasketLoadUnloadCompletion basketCompletion = null
+      PalletBasketLoadUnloadCompletion palletBasketCompletion = null
     )
     {
-      ValidateBasketCompletion(basketCompletion, toLoad, toUnload);
+      ValidatePalletBasketCompletion(palletBasketCompletion, toLoad, toUnload);
       var sendToExternal = new List<MaterialToSendToExternalQueue>();
 
       var newLogs = AddEntryInTransaction(trans =>
@@ -1997,14 +1997,14 @@ namespace BlackMaple.MachineFramework
           trans: trans
         );
 
-        RecordBasketTransferEnds<BasketTransfer.UnloadFromBasket>(
-          basketCompletion,
+        RecordPalletBasketTransferEnds<PalletBasketTransfer.UnloadFromBasket>(
+          palletBasketCompletion,
           lulNum,
           timeUTC,
           trans,
           logs
         );
-        RecordExplicitBasketCycleEnds(basketCompletion, timeUTC, logs, trans);
+        RecordExplicitBasketCycleEnds(palletBasketCompletion, timeUTC, logs, trans);
 
         RecordLoadMaterialPaths(toLoad: toLoad, trans: trans);
 
@@ -2018,17 +2018,19 @@ namespace BlackMaple.MachineFramework
           timeUTC: timeUTC,
           logs: logs,
           trans: trans,
-          materialFromBaskets: BasketMaterialIds<BasketTransfer.UnloadFromBasket>(basketCompletion)
+          materialFromBaskets: PalletBasketMaterialIds<PalletBasketTransfer.UnloadFromBasket>(
+            palletBasketCompletion
+          )
         );
 
-        RecordBasketTransferEnds<BasketTransfer.LoadOntoBasket>(
-          basketCompletion,
+        RecordPalletBasketTransferEnds<PalletBasketTransfer.LoadOntoBasket>(
+          palletBasketCompletion,
           lulNum,
           timeUTC,
           trans,
           logs
         );
-        RecordExplicitBasketCycleStarts(basketCompletion, timeUTC, logs, trans);
+        RecordExplicitBasketCycleStarts(palletBasketCompletion, timeUTC, logs, trans);
 
         return logs;
       });
@@ -2041,13 +2043,13 @@ namespace BlackMaple.MachineFramework
       return newLogs;
     }
 
-    private static void ValidateBasketCompletion(
-      BasketLoadUnloadCompletion basketCompletion,
+    private static void ValidatePalletBasketCompletion(
+      PalletBasketLoadUnloadCompletion palletBasketCompletion,
       IReadOnlyList<MaterialToLoadOntoFace> toLoad,
       IReadOnlyList<MaterialToUnloadFromFace> toUnload
     )
     {
-      if (basketCompletion is null)
+      if (palletBasketCompletion is null)
       {
         if (
           toUnload?.Any(unload =>
@@ -2058,32 +2060,37 @@ namespace BlackMaple.MachineFramework
         )
           throw new ArgumentException(
             "Pallet unloads without a queue destination require an explicit basket completion.",
-            nameof(basketCompletion)
+            nameof(palletBasketCompletion)
           );
         return;
       }
-      if (basketCompletion.Transfers.Count == 0 && basketCompletion.CycleBoundaries.Count == 0)
+      if (
+        palletBasketCompletion.Transfers.Count == 0
+        && palletBasketCompletion.CycleBoundaries.Count == 0
+      )
         throw new ArgumentException(
           "A basket completion requires a transfer or cycle boundary.",
-          nameof(basketCompletion)
+          nameof(palletBasketCompletion)
         );
 
       var transferredToBasket = ImmutableHashSet.CreateBuilder<long>();
       var transferredFromBasket = ImmutableHashSet.CreateBuilder<long>();
       var transferredToBasketWithProcess = ImmutableHashSet.CreateBuilder<(long, int)>();
       var transferredFromBasketWithProcess = ImmutableHashSet.CreateBuilder<(long, int)>();
-      foreach (var transfer in basketCompletion.Transfers)
+      foreach (var transfer in palletBasketCompletion.Transfers)
       {
         RecordedContainerIdentity(transfer.BasketIdentity);
         if (transfer.Material.Count == 0)
           throw new ArgumentException(
             "A basket transfer requires material.",
-            nameof(basketCompletion)
+            nameof(palletBasketCompletion)
           );
         var target =
-          transfer is BasketTransfer.LoadOntoBasket ? transferredToBasket : transferredFromBasket;
+          transfer is PalletBasketTransfer.LoadOntoBasket
+            ? transferredToBasket
+            : transferredFromBasket;
         var targetWithProcess =
-          transfer is BasketTransfer.LoadOntoBasket
+          transfer is PalletBasketTransfer.LoadOntoBasket
             ? transferredToBasketWithProcess
             : transferredFromBasketWithProcess;
         foreach (var material in transfer.Material)
@@ -2091,7 +2098,7 @@ namespace BlackMaple.MachineFramework
           if (!target.Add(material.MaterialID))
             throw new ArgumentException(
               $"Material {material.MaterialID} is repeated in basket transfers.",
-              nameof(basketCompletion)
+              nameof(palletBasketCompletion)
             );
           targetWithProcess.Add((material.MaterialID, material.Process));
         }
@@ -2099,7 +2106,7 @@ namespace BlackMaple.MachineFramework
 
       var starts = new HashSet<ContainerIdentity>();
       var ends = new HashSet<ContainerIdentity>();
-      foreach (var boundary in basketCompletion.CycleBoundaries)
+      foreach (var boundary in palletBasketCompletion.CycleBoundaries)
       {
         RecordedContainerIdentity(boundary.BasketIdentity);
         if (
@@ -2108,14 +2115,14 @@ namespace BlackMaple.MachineFramework
         )
           throw new ArgumentException(
             "Basket cycle material must contain each material exactly once.",
-            nameof(basketCompletion)
+            nameof(palletBasketCompletion)
           );
         if (boundary is BasketCycleBoundary.Start)
         {
           if (boundary.Material.Count == 0 || !starts.Add(boundary.BasketIdentity))
             throw new ArgumentException(
               "Each ready basket requires one non-empty cycle start.",
-              nameof(basketCompletion)
+              nameof(palletBasketCompletion)
             );
         }
         else if (boundary is BasketCycleBoundary.End end)
@@ -2123,7 +2130,7 @@ namespace BlackMaple.MachineFramework
           if (!ends.Add(boundary.BasketIdentity))
             throw new ArgumentException(
               "Each completed basket can have only one cycle end.",
-              nameof(basketCompletion)
+              nameof(palletBasketCompletion)
             );
           if (
             boundary.BasketIdentity is not ContainerIdentity.Numbered
@@ -2131,18 +2138,24 @@ namespace BlackMaple.MachineFramework
           )
             throw new ArgumentException(
               "A basket cycle end requires a numbered basket identity and may contain only non-empty fragment UUIDs.",
-              nameof(basketCompletion)
+              nameof(palletBasketCompletion)
             );
         }
       }
 
-      foreach (var transfer in basketCompletion.Transfers)
+      foreach (var transfer in palletBasketCompletion.Transfers)
       {
-        var matchingBoundary = basketCompletion.CycleBoundaries.FirstOrDefault(boundary =>
+        var matchingBoundary = palletBasketCompletion.CycleBoundaries.FirstOrDefault(boundary =>
           boundary.BasketIdentity == transfer.BasketIdentity
           && (
-            (transfer is BasketTransfer.LoadOntoBasket && boundary is BasketCycleBoundary.Start)
-            || (transfer is BasketTransfer.UnloadFromBasket && boundary is BasketCycleBoundary.End)
+            (
+              transfer is PalletBasketTransfer.LoadOntoBasket
+              && boundary is BasketCycleBoundary.Start
+            )
+            || (
+              transfer is PalletBasketTransfer.UnloadFromBasket
+              && boundary is BasketCycleBoundary.End
+            )
           )
         );
         if (
@@ -2156,16 +2169,16 @@ namespace BlackMaple.MachineFramework
         )
           throw new ArgumentException(
             "Transferred material must be present in the corresponding complete cycle material.",
-            nameof(basketCompletion)
+            nameof(palletBasketCompletion)
           );
 
         if (
           transfer
-            is BasketTransfer.UnloadFromBasket
+            is PalletBasketTransfer.UnloadFromBasket
             {
               BasketIdentity: ContainerIdentity.Uuid { ContainerId: var containerId },
             }
-          && basketCompletion
+          && palletBasketCompletion
             .CycleBoundaries.OfType<BasketCycleBoundary.End>()
             .FirstOrDefault(end => end.ReconciledBasketIdentities.Contains(containerId))
             is { } fragmentEnd
@@ -2178,7 +2191,7 @@ namespace BlackMaple.MachineFramework
         )
           throw new ArgumentException(
             "Material unloaded from a finalized UUID fragment must be present in the complete cycle end.",
-            nameof(basketCompletion)
+            nameof(palletBasketCompletion)
           );
       }
 
@@ -2192,7 +2205,7 @@ namespace BlackMaple.MachineFramework
         )
           throw new ArgumentException(
             "Basket-to-pallet material and process must match the pallet load.",
-            nameof(basketCompletion)
+            nameof(palletBasketCompletion)
           );
       }
       if (toUnload is not null)
@@ -2209,24 +2222,24 @@ namespace BlackMaple.MachineFramework
         if (!transferredToBasketWithProcess.SetEquals(basketDestinationMaterial))
           throw new ArgumentException(
             "Pallet unloads without a queue destination must exactly match pallet-to-basket material and process.",
-            nameof(basketCompletion)
+            nameof(palletBasketCompletion)
           );
       }
     }
 
-    private static ImmutableHashSet<long> BasketMaterialIds<TTransfer>(
-      BasketLoadUnloadCompletion basketCompletion
+    private static ImmutableHashSet<long> PalletBasketMaterialIds<TTransfer>(
+      PalletBasketLoadUnloadCompletion palletBasketCompletion
     )
-      where TTransfer : BasketTransfer =>
-      basketCompletion
+      where TTransfer : PalletBasketTransfer =>
+      palletBasketCompletion
         ?.Transfers.OfType<TTransfer>()
         .SelectMany(transfer => transfer.Material)
         .Select(material => material.MaterialID)
         .ToImmutableHashSet()
       ?? [];
 
-    private void RecordBasketTransferEnds<TTransfer>(
-      BasketLoadUnloadCompletion basketCompletion,
+    private void RecordPalletBasketTransferEnds<TTransfer>(
+      PalletBasketLoadUnloadCompletion palletBasketCompletion,
       int lulNum,
       DateTime timeUTC,
       IDbTransaction trans,
@@ -2234,12 +2247,12 @@ namespace BlackMaple.MachineFramework
       string foreignId = null,
       string originalMessage = null
     )
-      where TTransfer : BasketTransfer
+      where TTransfer : PalletBasketTransfer
     {
-      foreach (var transfer in basketCompletion?.Transfers.OfType<TTransfer>() ?? [])
+      foreach (var transfer in palletBasketCompletion?.Transfers.OfType<TTransfer>() ?? [])
       {
         var (containerNum, containerId) = RecordedContainerIdentity(transfer.BasketIdentity);
-        var loadOntoBasket = transfer is BasketTransfer.LoadOntoBasket;
+        var loadOntoBasket = transfer is PalletBasketTransfer.LoadOntoBasket;
         logs.Add(
           AddLogEntry(
             trans,
@@ -2266,7 +2279,7 @@ namespace BlackMaple.MachineFramework
     }
 
     private void RecordExplicitBasketCycleEnds(
-      BasketLoadUnloadCompletion basketCompletion,
+      PalletBasketLoadUnloadCompletion palletBasketCompletion,
       DateTime timeUTC,
       List<LogEntry> logs,
       IDbTransaction trans,
@@ -2275,7 +2288,8 @@ namespace BlackMaple.MachineFramework
     )
     {
       foreach (
-        var boundary in basketCompletion?.CycleBoundaries.OfType<BasketCycleBoundary.End>() ?? []
+        var boundary in palletBasketCompletion?.CycleBoundaries.OfType<BasketCycleBoundary.End>()
+          ?? []
       )
       {
         var (containerNum, containerId) = RecordedContainerIdentity(boundary.BasketIdentity);
@@ -2355,7 +2369,7 @@ namespace BlackMaple.MachineFramework
     }
 
     private void RecordExplicitBasketCycleStarts(
-      BasketLoadUnloadCompletion basketCompletion,
+      PalletBasketLoadUnloadCompletion palletBasketCompletion,
       DateTime timeUTC,
       List<LogEntry> logs,
       IDbTransaction trans,
@@ -2364,7 +2378,8 @@ namespace BlackMaple.MachineFramework
     )
     {
       foreach (
-        var boundary in basketCompletion?.CycleBoundaries.OfType<BasketCycleBoundary.Start>() ?? []
+        var boundary in palletBasketCompletion?.CycleBoundaries.OfType<BasketCycleBoundary.Start>()
+          ?? []
       )
       {
         var (containerNum, containerId) = RecordedContainerIdentity(boundary.BasketIdentity);
@@ -2393,8 +2408,10 @@ namespace BlackMaple.MachineFramework
       }
     }
 
-    private ImmutableList<LogEntry> BasketCompletionForForeignId(
+    private ImmutableList<LogEntry> BasketStationOperationForForeignId(
       string foreignId,
+      long firstCounter,
+      long lastCounter,
       IDbTransaction trans
     )
     {
@@ -2402,89 +2419,13 @@ namespace BlackMaple.MachineFramework
       ((IDbCommand)cmd).Transaction = trans;
       cmd.CommandText =
         "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
-        + "FROM stations WHERE ForeignID = $foreign ORDER BY Counter";
+        + "FROM stations WHERE ForeignID = $foreign "
+        + "AND Counter >= $firstCounter AND Counter <= $lastCounter ORDER BY Counter";
       cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
+      cmd.Parameters.Add("firstCounter", SqliteType.Integer).Value = firstCounter;
+      cmd.Parameters.Add("lastCounter", SqliteType.Integer).Value = lastCounter;
       using var reader = cmd.ExecuteReader();
       return LoadLog(reader, trans).ToImmutableList();
-    }
-
-    private string BasketCompletionOriginalMessage(string foreignId, IDbTransaction trans)
-    {
-      using var cmd = _connection.CreateCommand();
-      ((IDbCommand)cmd).Transaction = trans;
-      cmd.CommandText =
-        "SELECT OriginalMessage FROM stations WHERE ForeignID = $foreign ORDER BY Counter LIMIT 1";
-      cmd.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
-      return cmd.ExecuteScalar() as string ?? "";
-    }
-
-    private static bool BasketCompletionMatches(
-      ImmutableList<LogEntry> logs,
-      BasketLoadUnloadCompletion basketCompletion,
-      int lulNum
-    )
-    {
-      var expected = basketCompletion
-        .Transfers.OfType<BasketTransfer.UnloadFromBasket>()
-        .Select(transfer =>
-          (Transfer: (BasketTransfer)transfer, Boundary: (BasketCycleBoundary)null)
-        )
-        .Concat(
-          basketCompletion
-            .CycleBoundaries.OfType<BasketCycleBoundary.End>()
-            .Select(boundary =>
-              (Transfer: (BasketTransfer)null, Boundary: (BasketCycleBoundary)boundary)
-            )
-        )
-        .Concat(
-          basketCompletion
-            .Transfers.OfType<BasketTransfer.LoadOntoBasket>()
-            .Select(transfer =>
-              (Transfer: (BasketTransfer)transfer, Boundary: (BasketCycleBoundary)null)
-            )
-        )
-        .Concat(
-          basketCompletion
-            .CycleBoundaries.OfType<BasketCycleBoundary.Start>()
-            .Select(boundary =>
-              (Transfer: (BasketTransfer)null, Boundary: (BasketCycleBoundary)boundary)
-            )
-        )
-        .ToImmutableList();
-      if (logs.Count != expected.Count)
-        return false;
-
-      return logs.Zip(expected)
-        .All(pair =>
-        {
-          var (log, item) = pair;
-          var identity = item.Transfer?.BasketIdentity ?? item.Boundary.BasketIdentity;
-          var material = item.Transfer?.Material ?? item.Boundary.Material;
-          var expectedType = item.Transfer is null ? LogType.BasketCycle : LogType.BasketLoadUnload;
-          var expectedStart = item.Boundary is BasketCycleBoundary.Start;
-          var expectedProgram = item.Transfer switch
-          {
-            BasketTransfer.LoadOntoBasket => "LOAD",
-            BasketTransfer.UnloadFromBasket => "UNLOAD",
-            _ => "",
-          };
-          var expectedContainerIds =
-            item.Boundary is BasketCycleBoundary.End end && end.ReconciledBasketIdentities.Count > 0
-              ? end.ReconciledBasketIdentities.OrderBy(id => id).ToImmutableList()
-              : null;
-          return log.Identity == identity
-            && log.LogType == expectedType
-            && log.StartOfCycle == expectedStart
-            && log.Program == expectedProgram
-            && (expectedType == LogType.BasketCycle || log.LocationNum == lulNum)
-            && log.Material.Select(mat => (mat.MaterialID, mat.Process, mat.Face))
-              .SequenceEqual(material.Select(mat => (mat.MaterialID, mat.Process, mat.Face)))
-            && (
-              expectedContainerIds is null
-                ? log.CycleEndContainerIds is null
-                : log.CycleEndContainerIds?.SequenceEqual(expectedContainerIds) == true
-            );
-        });
     }
 
     // RecordLoadUnloadComplete is used ONLY for load/unload operations involving a pallet.
@@ -2492,8 +2433,8 @@ namespace BlackMaple.MachineFramework
     //   - Pallet to/from queue (material loaded from queue onto pallet, or unloaded from pallet to queue)
     //   - Pallet to/from basket (material transferred between pallet face and basket)
     // Basket events are never inferred from event history. Callers that know basket state
-    // synchronously provide an explicit basketCompletion. Delayed evidence and basket-station
-    // queue work are recorded with RecordBasketStationLoadUnload.
+    // synchronously provide an explicit palletBasketCompletion. Delayed evidence and basket-station
+    // queue work are recorded with RecordBasketStationOperation.
     public IEnumerable<LogEntry> RecordLoadUnloadComplete(
       IReadOnlyList<MaterialToLoadOntoFace> toLoad,
       IReadOnlyList<EventLogMaterial> previouslyLoaded,
@@ -2504,10 +2445,10 @@ namespace BlackMaple.MachineFramework
       TimeSpan totalElapsed,
       DateTime timeUTC,
       IReadOnlyDictionary<string, string> externalQueues,
-      BasketLoadUnloadCompletion basketCompletion = null
+      PalletBasketLoadUnloadCompletion palletBasketCompletion = null
     )
     {
-      ValidateBasketCompletion(basketCompletion, toLoad, toUnload);
+      ValidatePalletBasketCompletion(palletBasketCompletion, toLoad, toUnload);
       var sendToExternal = new List<MaterialToSendToExternalQueue>();
 
       var newLogs = AddEntryInTransaction(trans =>
@@ -2559,8 +2500,8 @@ namespace BlackMaple.MachineFramework
           trans: trans
         );
 
-        RecordBasketTransferEnds<BasketTransfer.UnloadFromBasket>(
-          basketCompletion,
+        RecordPalletBasketTransferEnds<PalletBasketTransfer.UnloadFromBasket>(
+          palletBasketCompletion,
           lulNum,
           timeUTC,
           trans,
@@ -2588,7 +2529,7 @@ namespace BlackMaple.MachineFramework
           );
         }
 
-        RecordExplicitBasketCycleEnds(basketCompletion, timeUTC, logs, trans);
+        RecordExplicitBasketCycleEnds(palletBasketCompletion, timeUTC, logs, trans);
 
         RecordLoadMaterialPaths(toLoad: toLoad, trans: trans);
 
@@ -2624,17 +2565,19 @@ namespace BlackMaple.MachineFramework
           timeUTC: timeUTC,
           logs: logs,
           trans: trans,
-          materialFromBaskets: BasketMaterialIds<BasketTransfer.UnloadFromBasket>(basketCompletion)
+          materialFromBaskets: PalletBasketMaterialIds<PalletBasketTransfer.UnloadFromBasket>(
+            palletBasketCompletion
+          )
         );
 
-        RecordBasketTransferEnds<BasketTransfer.LoadOntoBasket>(
-          basketCompletion,
+        RecordPalletBasketTransferEnds<PalletBasketTransfer.LoadOntoBasket>(
+          palletBasketCompletion,
           lulNum,
           timeUTC,
           trans,
           logs
         );
-        RecordExplicitBasketCycleStarts(basketCompletion, timeUTC, logs, trans);
+        RecordExplicitBasketCycleStarts(palletBasketCompletion, timeUTC, logs, trans);
 
         return logs;
       });
@@ -2647,8 +2590,8 @@ namespace BlackMaple.MachineFramework
       return newLogs;
     }
 
-    public IEnumerable<LogEntry> RecordBasketStationLoadUnload(
-      BasketStationLoadUnload operation,
+    public IEnumerable<LogEntry> RecordBasketStationOperation(
+      BasketStationOperation operation,
       int lulNum,
       TimeSpan totalElapsed,
       DateTime timeUTC,
@@ -2666,8 +2609,8 @@ namespace BlackMaple.MachineFramework
       if (totalElapsed < TimeSpan.Zero)
         throw new ArgumentOutOfRangeException(nameof(totalElapsed));
 
-      var completion = BasketStationCompletion(operation);
-      ValidateBasketCompletion(completion, toLoad: null, toUnload: null);
+      var palletCompletion = ToPalletBasketLoadUnloadCompletion(operation);
+      ValidatePalletBasketCompletion(palletCompletion, toLoad: null, toUnload: null);
       foreach (var transfer in operation.Transfers)
       {
         if (transfer.ActiveOperationTime < TimeSpan.Zero)
@@ -2675,13 +2618,11 @@ namespace BlackMaple.MachineFramework
             nameof(operation),
             "Basket-station active operation time cannot be negative."
           );
-        var queue = transfer switch
-        {
-          BasketStationTransfer.LoadOntoBasket load => load.SourceQueue,
-          BasketStationTransfer.UnloadFromBasket unload => unload.DestinationQueue,
-          _ => null,
-        };
-        if (queue is not null && string.IsNullOrWhiteSpace(queue))
+        if (
+          transfer
+            is BasketStationTransfer.UnloadFromBasket { DestinationQueue: { } destinationQueue }
+          && string.IsNullOrWhiteSpace(destinationQueue)
+        )
           throw new ArgumentException(
             "A basket-station queue must be null or non-empty.",
             nameof(operation)
@@ -2698,16 +2639,21 @@ namespace BlackMaple.MachineFramework
         using var existingCommand = _connection.CreateCommand();
         existingCommand.Transaction = trans;
         existingCommand.CommandText =
-          "SELECT Fingerprint, OriginalMessage FROM basket_station_operations WHERE ForeignID = $foreign";
+          "SELECT Fingerprint, OriginalMessage, FirstCounter, LastCounter "
+          + "FROM basket_station_operations WHERE ForeignID = $foreign";
         existingCommand.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
         string existingFingerprint = null;
         string existingOriginalMessage = null;
+        long existingFirstCounter = 0;
+        long existingLastCounter = 0;
         using (var reader = existingCommand.ExecuteReader())
         {
           if (reader.Read())
           {
             existingFingerprint = reader.GetString(0);
             existingOriginalMessage = reader.GetString(1);
+            existingFirstCounter = reader.GetInt64(2);
+            existingLastCounter = reader.GetInt64(3);
           }
         }
         if (existingFingerprint is not null)
@@ -2719,19 +2665,24 @@ namespace BlackMaple.MachineFramework
             throw new ConflictRequestException(
               $"Foreign ID {foreignId} already identifies a different basket-station operation."
             );
-          logs = BasketCompletionForForeignId(foreignId, trans);
+          logs = BasketStationOperationForForeignId(
+            foreignId,
+            existingFirstCounter,
+            existingLastCounter,
+            trans
+          );
           trans.Commit();
           return logs;
         }
 
-        ValidateBasketStationSourceQueues(operation, trans);
         var newLogs = new List<LogEntry>();
         var transferMaterialCount = operation.Transfers.Sum(transfer => transfer.Material.Count);
         var activeTimes = operation
           .Transfers.Select(transfer => transfer.ActiveOperationTime)
           .ToImmutableList();
-        var allHaveActive =
-          !activeTimes.IsEmpty && activeTimes.All(active => active > TimeSpan.Zero);
+        var totalActive = activeTimes.All(active => active > TimeSpan.Zero)
+          ? TimeSpan.FromTicks(activeTimes.Sum(active => active.Ticks))
+          : (TimeSpan?)null;
 
         foreach (
           var transfer in operation.Transfers.OfType<BasketStationTransfer.UnloadFromBasket>()
@@ -2744,7 +2695,7 @@ namespace BlackMaple.MachineFramework
               transfer,
               totalElapsed,
               transferMaterialCount,
-              allHaveActive
+              totalActive
             ),
             lulNum,
             timeUTC,
@@ -2789,7 +2740,7 @@ namespace BlackMaple.MachineFramework
         }
 
         RecordExplicitBasketCycleEnds(
-          completion,
+          palletCompletion,
           timeUTC,
           newLogs,
           trans,
@@ -2808,7 +2759,7 @@ namespace BlackMaple.MachineFramework
               transfer,
               totalElapsed,
               transferMaterialCount,
-              allHaveActive
+              totalActive
             ),
             lulNum,
             timeUTC,
@@ -2820,7 +2771,7 @@ namespace BlackMaple.MachineFramework
         }
 
         RecordExplicitBasketCycleStarts(
-          completion,
+          palletCompletion,
           timeUTC,
           newLogs,
           trans,
@@ -2831,10 +2782,18 @@ namespace BlackMaple.MachineFramework
         using var recordOperation = _connection.CreateCommand();
         recordOperation.Transaction = trans;
         recordOperation.CommandText =
-          "INSERT INTO basket_station_operations(ForeignID, Fingerprint, OriginalMessage) VALUES($foreign, $fingerprint, $original)";
+          "INSERT INTO basket_station_operations"
+          + "(ForeignID, Fingerprint, OriginalMessage, FirstCounter, LastCounter) "
+          + "VALUES($foreign, $fingerprint, $original, $firstCounter, $lastCounter)";
         recordOperation.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
         recordOperation.Parameters.Add("fingerprint", SqliteType.Text).Value = fingerprint;
         recordOperation.Parameters.Add("original", SqliteType.Text).Value = originalMessage ?? "";
+        recordOperation.Parameters.Add("firstCounter", SqliteType.Integer).Value = newLogs[
+          0
+        ].Counter;
+        recordOperation.Parameters.Add("lastCounter", SqliteType.Integer).Value = newLogs[
+          ^1
+        ].Counter;
         recordOperation.ExecuteNonQuery();
         trans.Commit();
         logs = newLogs.ToImmutableList();
@@ -2851,58 +2810,32 @@ namespace BlackMaple.MachineFramework
       return logs;
     }
 
-    private static BasketLoadUnloadCompletion BasketStationCompletion(
-      BasketStationLoadUnload operation
+    private static PalletBasketLoadUnloadCompletion ToPalletBasketLoadUnloadCompletion(
+      BasketStationOperation operation
     ) =>
       new()
       {
         Transfers = operation
-          .Transfers.Select<BasketStationTransfer, BasketTransfer>(transfer =>
+          .Transfers.Select<BasketStationTransfer, PalletBasketTransfer>(transfer =>
             transfer switch
             {
-              BasketStationTransfer.LoadOntoBasket load => new BasketTransfer.LoadOntoBasket
+              BasketStationTransfer.LoadOntoBasket load => new PalletBasketTransfer.LoadOntoBasket
               {
                 BasketIdentity = load.BasketIdentity,
                 Material = load.Material,
               },
-              BasketStationTransfer.UnloadFromBasket unload => new BasketTransfer.UnloadFromBasket
-              {
-                BasketIdentity = unload.BasketIdentity,
-                Material = unload.Material,
-              },
+              BasketStationTransfer.UnloadFromBasket unload =>
+                new PalletBasketTransfer.UnloadFromBasket
+                {
+                  BasketIdentity = unload.BasketIdentity,
+                  Material = unload.Material,
+                },
               _ => throw new ArgumentOutOfRangeException(nameof(operation)),
             }
           )
           .ToImmutableList(),
         CycleBoundaries = operation.CycleBoundaries,
       };
-
-    private void ValidateBasketStationSourceQueues(
-      BasketStationLoadUnload operation,
-      IDbTransaction trans
-    )
-    {
-      using var command = _connection.CreateCommand();
-      command.Transaction = (SqliteTransaction)trans;
-      command.CommandText = "SELECT Queue FROM queues WHERE MaterialID = $material";
-      command.Parameters.Add("material", SqliteType.Integer);
-      foreach (
-        var transfer in operation
-          .Transfers.OfType<BasketStationTransfer.LoadOntoBasket>()
-          .Where(transfer => transfer.SourceQueue is not null)
-      )
-      {
-        foreach (var material in transfer.Material)
-        {
-          command.Parameters[0].Value = material.MaterialID;
-          var actualQueue = command.ExecuteScalar() as string;
-          if (actualQueue != transfer.SourceQueue)
-            throw new ConflictRequestException(
-              $"Material {material.MaterialID} is not in expected source queue {transfer.SourceQueue}."
-            );
-        }
-      }
-    }
 
     private void RecordBasketStationTransfer(
       BasketStationTransfer transfer,
@@ -2945,18 +2878,17 @@ namespace BlackMaple.MachineFramework
       BasketStationTransfer transfer,
       TimeSpan totalElapsed,
       int transferMaterialCount,
-      bool allHaveActive
+      TimeSpan? totalActive
     )
     {
-      if (!allHaveActive || transferMaterialCount == 0)
-        return totalElapsed;
-      return TimeSpan.FromSeconds(
-        Math.Round(totalElapsed.TotalSeconds * transfer.Material.Count / transferMaterialCount, 1)
-      );
+      var weight = totalActive is { } active
+        ? (double)transfer.ActiveOperationTime.Ticks / active.Ticks
+        : (double)transfer.Material.Count / transferMaterialCount;
+      return TimeSpan.FromSeconds(Math.Round(totalElapsed.TotalSeconds * weight, 1));
     }
 
     private static string BasketStationFingerprint(
-      BasketStationLoadUnload operation,
+      BasketStationOperation operation,
       int lulNum,
       TimeSpan totalElapsed,
       IReadOnlyDictionary<string, string> externalQueues
@@ -2979,12 +2911,7 @@ namespace BlackMaple.MachineFramework
           fingerprint,
           transfer.ActiveOperationTime.Ticks.ToString(CultureInfo.InvariantCulture)
         );
-        var queue = transfer switch
-        {
-          BasketStationTransfer.LoadOntoBasket load => load.SourceQueue,
-          BasketStationTransfer.UnloadFromBasket unload => unload.DestinationQueue,
-          _ => null,
-        };
+        var queue = (transfer as BasketStationTransfer.UnloadFromBasket)?.DestinationQueue;
         AppendBasketStationFingerprint(fingerprint, queue);
         if (
           transfer is BasketStationTransfer.UnloadFromBasket
@@ -3138,7 +3065,7 @@ namespace BlackMaple.MachineFramework
     }
 
     // Records pallet unload events and queue destinations. Basket destinations are recorded only
-    // from an explicit BasketLoadUnloadCompletion.
+    // from an explicit PalletBasketLoadUnloadCompletion.
     private void RecordUnloadEnd(
       IEnumerable<MaterialToUnloadFromFace> toUnload,
       int lulNum,

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -825,7 +825,9 @@ namespace BlackMaple.MachineFramework
       cmd.Transaction = trans;
       cmd.CommandText =
         "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
-        + "FROM stations WHERE ContainerId IN (SELECT ContainerId FROM current_basket_identity_hints WHERE BasketNum = $num) ORDER BY Counter";
+        + "FROM stations s WHERE ContainerId IN (SELECT ContainerId FROM current_basket_identity_hints WHERE BasketNum = $num) AND "
+        + ignoreInvalidEventCondition
+        + " ORDER BY Counter";
       cmd.Parameters.Add("num", SqliteType.Integer).Value = basketId;
       using var reader = cmd.ExecuteReader();
       logs.AddRange(LoadLog(reader, trans));
@@ -844,7 +846,9 @@ namespace BlackMaple.MachineFramework
 
       cmd.CommandText =
         "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
-        + "FROM stations WHERE ContainerId = $id ORDER BY Counter";
+        + "FROM stations s WHERE ContainerId = $id AND "
+        + ignoreInvalidEventCondition
+        + " ORDER BY Counter";
       using var reader = cmd.ExecuteReader();
       return LoadLog(reader, trans).ToImmutableList();
     }
@@ -883,6 +887,9 @@ namespace BlackMaple.MachineFramework
         "SELECT DISTINCT s.ContainerId FROM stations s "
         + "WHERE s.ContainerId IS NOT NULL "
         + "AND s.StationLoc IN ($loadUnloadType, $locationType, $snapshotType, $cycleType) "
+        + "AND "
+        + ignoreInvalidEventCondition
+        + " "
         + "AND NOT EXISTS(SELECT 1 FROM current_basket_identity_hints h WHERE h.ContainerId = s.ContainerId) "
         + "AND NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = s.ContainerId) "
         + "ORDER BY s.ContainerId";
@@ -2301,11 +2308,16 @@ namespace BlackMaple.MachineFramework
           if (eventTime < firstEventTime)
             firstEventTime = eventTime;
         }
-        if (
-          containerIds.Count == 0
-          && MostRecentBasketCycleStart(boundary.BasketIdentity, trans) is { } cycleStart
-        )
-          firstEventTime = cycleStart;
+        if (containerIds.Count == 0)
+        {
+          var recentCycle = MostRecentBasketCycleEvent(boundary.BasketIdentity, trans);
+          if (recentCycle is { StartOfCycle: true, Invalidated: true })
+            throw new ConflictRequestException(
+              "An explicit basket-cycle end can not close an invalidated basket-cycle start."
+            );
+          if (recentCycle is { StartOfCycle: true })
+            firstEventTime = recentCycle.TimeUTC;
+        }
 
         logs.Add(
           AddLogEntry(
@@ -2347,7 +2359,14 @@ namespace BlackMaple.MachineFramework
       }
     }
 
-    private DateTime? MostRecentBasketCycleStart(
+    private sealed record BasketCycleEventState
+    {
+      public required DateTime TimeUTC { get; init; }
+      public required bool StartOfCycle { get; init; }
+      public required bool Invalidated { get; init; }
+    }
+
+    private BasketCycleEventState MostRecentBasketCycleEvent(
       ContainerIdentity basketIdentity,
       IDbTransaction trans
     )
@@ -2356,16 +2375,25 @@ namespace BlackMaple.MachineFramework
       using var cmd = _connection.CreateCommand();
       ((IDbCommand)cmd).Transaction = trans;
       cmd.CommandText =
-        "SELECT TimeUTC FROM stations WHERE Pallet = $num "
+        "SELECT TimeUTC, Start, EXISTS("
+        + "SELECT 1 FROM program_details d WHERE d.Counter = s.Counter AND d.Key = 'PalletCycleInvalidated'"
+        + ") FROM stations s WHERE Pallet = $num "
         + "AND (($id IS NULL AND ContainerId IS NULL) OR ContainerId = $id) "
-        + "AND StationLoc = $cycleType AND Start = 1 ORDER BY Counter DESC LIMIT 1";
+        + "AND StationLoc = $cycleType ORDER BY Counter DESC LIMIT 1";
       cmd.Parameters.Add("num", SqliteType.Integer).Value = containerNum;
       cmd.Parameters.Add("id", SqliteType.Text).Value = containerId is { } id
         ? id.ToString("D")
         : DBNull.Value;
       cmd.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)LogType.BasketCycle;
-      var start = cmd.ExecuteScalar();
-      return start is null or DBNull ? null : new DateTime((long)start, DateTimeKind.Utc);
+      using var reader = cmd.ExecuteReader();
+      if (!reader.Read())
+        return null;
+      return new BasketCycleEventState
+      {
+        TimeUTC = new DateTime(reader.GetInt64(0), DateTimeKind.Utc),
+        StartOfCycle = reader.GetBoolean(1),
+        Invalidated = reader.GetBoolean(2),
+      };
     }
 
     private void RecordExplicitBasketCycleStarts(
@@ -3403,27 +3431,7 @@ namespace BlackMaple.MachineFramework
           var firstEventTime = timeUTC;
           foreach (var id in ids)
           {
-            using var validate = _connection.CreateCommand();
-            validate.Transaction = trans;
-            validate.CommandText =
-              "SELECT MIN(TimeUTC) FROM stations WHERE ContainerId = $id "
-              + "AND StationLoc IN ($loadUnloadType, $locationType, $snapshotType, $cycleType) AND "
-              + "NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = $id)";
-            validate.Parameters.Add("id", SqliteType.Text).Value = id.ToString("D");
-            validate.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)
-              LogType.BasketLoadUnload;
-            validate.Parameters.Add("locationType", SqliteType.Integer).Value = (int)
-              LogType.BasketInLocation;
-            validate.Parameters.Add("snapshotType", SqliteType.Integer).Value = (int)
-              LogType.BasketContentSnapshot;
-            validate.Parameters.Add("cycleType", SqliteType.Integer).Value = (int)
-              LogType.BasketCycle;
-            var first = validate.ExecuteScalar();
-            if (first is null || first == DBNull.Value)
-              throw new ConflictRequestException(
-                $"Container UUID {id:D} is not an open event fragment."
-              );
-            var eventTime = new DateTime((long)first, DateTimeKind.Utc);
+            var eventTime = EnsureOpenBasketFragment(id, trans);
             if (eventTime < firstEventTime)
               firstEventTime = eventTime;
           }
@@ -4215,8 +4223,11 @@ namespace BlackMaple.MachineFramework
       using var cmd = _connection.CreateCommand();
       ((IDbCommand)cmd).Transaction = trans;
       cmd.CommandText =
-        "SELECT MIN(TimeUTC) FROM stations WHERE ContainerId = $id "
+        "SELECT MIN(TimeUTC) FROM stations s WHERE ContainerId = $id "
         + "AND StationLoc IN ($loadUnloadType, $locationType, $snapshotType, $cycleType) "
+        + "AND "
+        + ignoreInvalidEventCondition
+        + " "
         + "AND NOT EXISTS(SELECT 1 FROM basket_cycle_container_ids f WHERE f.ContainerId = $id)";
       cmd.Parameters.Add("id", SqliteType.Text).Value = containerId.ToString("D");
       cmd.Parameters.Add("loadUnloadType", SqliteType.Integer).Value = (int)

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -37,7 +37,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Data;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using Microsoft.Data.Sqlite;
 
 namespace BlackMaple.MachineFramework
@@ -711,8 +713,10 @@ namespace BlackMaple.MachineFramework
       cmd.Transaction = trans;
       cmd.CommandText =
         "SELECT Counter, Pallet, StationLoc, StationNum, Program, Start, TimeUTC, Result, EndOfRoute, Elapsed, ActiveTime, StationName, ContainerId "
-        + " FROM stations "
+        + " FROM stations s "
         + " WHERE Pallet = $pal AND Counter < $cycleStart "
+        + " AND "
+        + ignoreInvalidEventCondition
         + " AND Counter > COALESCE(("
         + "   SELECT MAX(Counter) FROM stations "
         + "   WHERE Pallet = $pal AND Result = 'PalletCycle' AND Counter < $cycleStart"
@@ -2037,90 +2041,6 @@ namespace BlackMaple.MachineFramework
       return newLogs;
     }
 
-    public IEnumerable<LogEntry> RecordBasketLoadUnloadCompletion(
-      BasketLoadUnloadCompletion basketCompletion,
-      int lulNum,
-      DateTime timeUTC,
-      string foreignId,
-      string originalMessage = null
-    )
-    {
-      if (string.IsNullOrWhiteSpace(foreignId))
-        throw new ArgumentException(
-          "A delayed basket completion requires a foreign ID.",
-          nameof(foreignId)
-        );
-      ArgumentNullException.ThrowIfNull(basketCompletion);
-      ValidateBasketCompletion(basketCompletion, toLoad: null, toUnload: null);
-
-      ImmutableList<LogEntry> logs;
-      var added = false;
-      lock (_cfg)
-      {
-        using var trans = _connection.BeginTransaction();
-        var existing = BasketCompletionForForeignId(foreignId, trans);
-        if (existing.Count > 0)
-        {
-          if (
-            !BasketCompletionMatches(existing, basketCompletion, lulNum)
-            || BasketCompletionOriginalMessage(foreignId, trans) != (originalMessage ?? "")
-          )
-            throw new ConflictRequestException(
-              $"Foreign ID {foreignId} already identifies different basket events."
-            );
-          logs = existing;
-        }
-        else
-        {
-          var newLogs = new List<LogEntry>();
-          RecordBasketTransferEnds<BasketTransfer.UnloadFromBasket>(
-            basketCompletion,
-            lulNum,
-            timeUTC,
-            trans,
-            newLogs,
-            foreignId,
-            originalMessage
-          );
-          RecordExplicitBasketCycleEnds(
-            basketCompletion,
-            timeUTC,
-            newLogs,
-            trans,
-            foreignId,
-            originalMessage
-          );
-          RecordBasketTransferEnds<BasketTransfer.LoadOntoBasket>(
-            basketCompletion,
-            lulNum,
-            timeUTC,
-            trans,
-            newLogs,
-            foreignId,
-            originalMessage
-          );
-          RecordExplicitBasketCycleStarts(
-            basketCompletion,
-            timeUTC,
-            newLogs,
-            trans,
-            foreignId,
-            originalMessage
-          );
-          logs = newLogs.ToImmutableList();
-          added = true;
-        }
-        trans.Commit();
-      }
-
-      if (added)
-      {
-        foreach (var log in logs)
-          _cfg.OnNewLogEntry(log, foreignId, this);
-      }
-      return logs;
-    }
-
     private static void ValidateBasketCompletion(
       BasketLoadUnloadCompletion basketCompletion,
       IReadOnlyList<MaterialToLoadOntoFace> toLoad,
@@ -2207,7 +2127,7 @@ namespace BlackMaple.MachineFramework
             );
           if (
             boundary.BasketIdentity is not ContainerIdentity.Numbered
-            || end.ContainerIds.Any(id => id == Guid.Empty)
+            || end.ReconciledBasketIdentities.Any(id => id == Guid.Empty)
           )
             throw new ArgumentException(
               "A basket cycle end requires a numbered basket identity and may contain only non-empty fragment UUIDs.",
@@ -2247,7 +2167,7 @@ namespace BlackMaple.MachineFramework
             }
           && basketCompletion
             .CycleBoundaries.OfType<BasketCycleBoundary.End>()
-            .FirstOrDefault(end => end.ContainerIds.Contains(containerId))
+            .FirstOrDefault(end => end.ReconciledBasketIdentities.Contains(containerId))
             is { } fragmentEnd
           && transfer.Material.Any(material =>
             !fragmentEnd.Material.Any(cycleMaterial =>
@@ -2359,7 +2279,7 @@ namespace BlackMaple.MachineFramework
       )
       {
         var (containerNum, containerId) = RecordedContainerIdentity(boundary.BasketIdentity);
-        var containerIds = boundary.ContainerIds.OrderBy(id => id).ToImmutableList();
+        var containerIds = boundary.ReconciledBasketIdentities.OrderBy(id => id).ToImmutableList();
         var firstEventTime = timeUTC;
         foreach (var id in containerIds)
         {
@@ -2549,8 +2469,8 @@ namespace BlackMaple.MachineFramework
             _ => "",
           };
           var expectedContainerIds =
-            item.Boundary is BasketCycleBoundary.End end && end.ContainerIds.Count > 0
-              ? end.ContainerIds.OrderBy(id => id).ToImmutableList()
+            item.Boundary is BasketCycleBoundary.End end && end.ReconciledBasketIdentities.Count > 0
+              ? end.ReconciledBasketIdentities.OrderBy(id => id).ToImmutableList()
               : null;
           return log.Identity == identity
             && log.LogType == expectedType
@@ -2571,11 +2491,9 @@ namespace BlackMaple.MachineFramework
     // This includes:
     //   - Pallet to/from queue (material loaded from queue onto pallet, or unloaded from pallet to queue)
     //   - Pallet to/from basket (material transferred between pallet face and basket)
-    // For basket-only operations (basket to/from queue), use RecordBasketOnlyLoadUnload instead.
-    //
     // Basket events are never inferred from event history. Callers that know basket state
-    // synchronously provide an explicit basketCompletion. Delayed reconcilers can use
-    // RecordBasketLoadUnloadCompletion after this method records the pallet events.
+    // synchronously provide an explicit basketCompletion. Delayed evidence and basket-station
+    // queue work are recorded with RecordBasketStationLoadUnload.
     public IEnumerable<LogEntry> RecordLoadUnloadComplete(
       IReadOnlyList<MaterialToLoadOntoFace> toLoad,
       IReadOnlyList<EventLogMaterial> previouslyLoaded,
@@ -2729,829 +2647,428 @@ namespace BlackMaple.MachineFramework
       return newLogs;
     }
 
-    // RecordBasketOnlyLoadUnload is used for basket-only load/unload operations (no pallet involved).
-    // This includes:
-    //   - Basket to/from queue (material loaded from queue onto basket, or unloaded from basket to queue)
-    public IEnumerable<LogEntry> RecordBasketOnlyLoadUnload(
-      MaterialToLoadOntoBasket toLoad,
-      IReadOnlyList<EventLogMaterial> previouslyLoaded,
-      MaterialToUnloadFromBasket toUnload,
+    public IEnumerable<LogEntry> RecordBasketStationLoadUnload(
+      BasketStationLoadUnload operation,
       int lulNum,
-      int basketId,
-      TimeSpan totalElapsed,
-      DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues
-    )
-    {
-      var sendToExternal = new List<MaterialToSendToExternalQueue>();
-
-      var newLogs = AddEntryInTransaction(trans =>
-      {
-        var logs = new List<LogEntry>();
-
-        // Calculate total active time and total material count
-        var totMatCnt = (toLoad?.MaterialIDs.Count ?? 0) + (toUnload?.MaterialIDToQueue.Count ?? 0);
-
-        bool allHaveActive = true;
-        TimeSpan totalActive = TimeSpan.Zero;
-        if (toLoad?.ActiveOperationTime > TimeSpan.Zero)
-        {
-          totalActive += toLoad.ActiveOperationTime;
-        }
-        else
-        {
-          allHaveActive = false;
-        }
-        if (toUnload?.ActiveOperationTime > TimeSpan.Zero)
-        {
-          totalActive += toUnload.ActiveOperationTime;
-        }
-        else
-        {
-          allHaveActive = false;
-        }
-
-        // Process unloads from basket
-        if (toUnload != null)
-        {
-          TimeSpan elapsed = totalElapsed;
-          if (allHaveActive && totalActive > TimeSpan.Zero)
-          {
-            elapsed = TimeSpan.FromSeconds(
-              Math.Round(
-                totalElapsed.TotalSeconds * toUnload.MaterialIDToQueue.Count / totMatCnt,
-                1
-              )
-            );
-          }
-
-          // Create BasketLoadUnload event for unload
-          logs.Add(
-            AddLogEntry(
-              trans,
-              new NewEventLogEntry()
-              {
-                Material = toUnload.MaterialIDToQueue.Keys.Select(m => new EventLogMaterial()
-                {
-                  MaterialID = m,
-                  Face = 0,
-                  Process = toUnload.Process,
-                }),
-                Pallet = basketId,
-                LogType = LogType.BasketLoadUnload,
-                LocationName = "L/U",
-                LocationNum = lulNum,
-                Program = "UNLOAD",
-                StartOfCycle = true,
-                EndTimeUTC = timeUTC,
-                ElapsedTime = elapsed,
-                ActiveOperationTime = toUnload.ActiveOperationTime,
-                Result = "UNLOAD",
-              },
-              toUnload.ForeignID,
-              toUnload.OriginalMessage
-            )
-          );
-
-          // Handle queue destinations
-          foreach (var kv in toUnload.MaterialIDToQueue)
-          {
-            var matId = kv.Key;
-            var queue = kv.Value;
-            var evt = new EventLogMaterial()
-            {
-              MaterialID = matId,
-              Process = toUnload.Process,
-              Face = 0,
-            };
-            if (externalQueues != null && externalQueues.TryGetValue(queue, out var extQueue))
-            {
-              // Look up material details for consistency with pallet unloads
-              var matDetails = GetMaterialDetails(matId, trans);
-              var partName = matDetails != null ? matDetails.PartName : "";
-              var serial = matDetails != null ? matDetails.Serial : "";
-              sendToExternal.Add(
-                new MaterialToSendToExternalQueue()
-                {
-                  Server = extQueue,
-                  PartName = partName,
-                  Queue = queue,
-                  Serial = serial,
-                }
-              );
-            }
-            else
-            {
-              AddToQueue(
-                trans: trans,
-                mat: evt,
-                queue: queue,
-                position: -1,
-                operatorName: null,
-                reason: null,
-                timeUTC: timeUTC
-              );
-            }
-          }
-        }
-
-        // End the previous basket cycle if there was one (looks up material from previous start)
-        RecordBasketCycleEnd(basketId: basketId, timeUTC: timeUTC, logs: logs, trans: trans);
-
-        // Create basket cycle start if basket is now loaded
-        var allLoad = (previouslyLoaded ?? []).Concat(
-          toLoad?.MaterialIDs.Select(mid => new EventLogMaterial()
-          {
-            MaterialID = mid,
-            Process = toLoad.Process,
-            Face = 0,
-          }) ?? []
-        );
-        if (allLoad.Any())
-        {
-          RecordBasketCycleStart(
-            basketId: basketId,
-            mats: allLoad,
-            timeUTC: timeUTC,
-            logs: logs,
-            trans: trans
-          );
-        }
-
-        // Process loads onto basket
-        if (toLoad != null)
-        {
-          TimeSpan elapsed = totalElapsed;
-          if (allHaveActive && totalActive > TimeSpan.Zero)
-          {
-            elapsed = TimeSpan.FromSeconds(
-              Math.Round(totalElapsed.TotalSeconds * toLoad.MaterialIDs.Count / totMatCnt, 1)
-            );
-          }
-
-          // Remove from queues if loading from queue
-          foreach (var matId in toLoad.MaterialIDs)
-          {
-            var mat = new EventLogMaterial()
-            {
-              MaterialID = matId,
-              Process = toLoad.Process,
-              Face = 0,
-            };
-            RemoveFromAllQueues(trans, mat, operatorName: null, reason: null, timeUTC: timeUTC);
-          }
-
-          // Create BasketLoadUnload event for load
-          logs.Add(
-            AddLogEntry(
-              trans,
-              new NewEventLogEntry()
-              {
-                Material = toLoad.MaterialIDs.Select(m => new EventLogMaterial()
-                {
-                  MaterialID = m,
-                  Face = 0,
-                  Process = toLoad.Process,
-                }),
-                Pallet = basketId,
-                LogType = LogType.BasketLoadUnload,
-                LocationName = "L/U",
-                LocationNum = lulNum,
-                Program = "LOAD",
-                StartOfCycle = false,
-                // Add 1 second to be after the basket cycle
-                EndTimeUTC = timeUTC.AddSeconds(1),
-                Result = "LOAD",
-                ElapsedTime = elapsed,
-                ActiveOperationTime = toLoad.ActiveOperationTime,
-              },
-              toLoad.ForeignID,
-              toLoad.OriginalMessage
-            )
-          );
-        }
-
-        return logs;
-      });
-
-      if (sendToExternal.Count > 0)
-      {
-        System.Threading.Tasks.Task.Run(() => SendMaterialToExternalQueue.Post(sendToExternal));
-      }
-
-      return newLogs;
-    }
-
-    // Compatibility entry point for partial numbered basket-only operations.
-    public IEnumerable<LogEntry> RecordPartialBasketOnlyLoadUnload(
-      MaterialToLoadOntoBasket toLoad,
-      MaterialToUnloadFromBasket toUnload,
-      int lulNum,
-      int basketId,
-      TimeSpan totalElapsed,
-      DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues
-    )
-    {
-      return RecordBasketLoadUnload(
-        toLoad,
-        toUnload,
-        lulNum,
-        new ContainerIdentity.Numbered { ContainerNum = basketId },
-        totalElapsed,
-        timeUTC,
-        externalQueues
-      );
-    }
-
-    // Records ordinary basket load/unload evidence and queue changes without emitting BasketCycle
-    // events. UUID integrations finalize the basket cycle separately.
-    public IEnumerable<LogEntry> RecordBasketLoadUnload(
-      MaterialToLoadOntoBasket toLoad,
-      MaterialToUnloadFromBasket toUnload,
-      int lulNum,
-      ContainerIdentity basketIdentity,
       TimeSpan totalElapsed,
       DateTime timeUTC,
       IReadOnlyDictionary<string, string> externalQueues,
-      BasketLoadUnloadCompletion basketCompletion = null
+      string foreignId,
+      string originalMessage = null
     )
     {
-      return RecordBasketLoadUnload(
-        toLoad is null ? [] : [toLoad],
-        toUnload is null ? [] : [toUnload],
-        lulNum,
-        basketIdentity,
-        totalElapsed,
-        timeUTC,
-        externalQueues,
-        basketCompletion
-      );
-    }
-
-    public IEnumerable<LogEntry> RecordBasketLoadUnload(
-      IReadOnlyList<MaterialToLoadOntoBasket> toLoad,
-      IReadOnlyList<MaterialToUnloadFromBasket> toUnload,
-      int lulNum,
-      ContainerIdentity basketIdentity,
-      TimeSpan totalElapsed,
-      DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues,
-      BasketLoadUnloadCompletion basketCompletion
-    )
-    {
-      ArgumentNullException.ThrowIfNull(toLoad);
-      ArgumentNullException.ThrowIfNull(toUnload);
-      var sendToExternal = new List<MaterialToSendToExternalQueue>();
-      var (containerNum, containerId) = RecordedContainerIdentity(basketIdentity);
-      ValidateBasketStationCompletion(basketCompletion, toLoad, toUnload, basketIdentity);
-
-      IReadOnlyList<LogEntry> RecordEvents(IDbTransaction trans)
-      {
-        var logs = new List<LogEntry>();
-
-        // Calculate total active time and total material count
-        var totMatCnt =
-          toLoad.Sum(load => load.MaterialIDs.Count)
-          + toUnload.Sum(unload => unload.MaterialIDToQueue.Count);
-        var allOperations = toLoad
-          .Select(load => load.ActiveOperationTime)
-          .Concat(toUnload.Select(unload => unload.ActiveOperationTime))
-          .ToImmutableList();
-        var allHaveActive = allOperations.All(active => active > TimeSpan.Zero);
-        var totalActive = TimeSpan.FromTicks(allOperations.Sum(active => active.Ticks));
-
-        // Process unloads from basket (no cycle events)
-        foreach (var unload in toUnload)
-        {
-          TimeSpan elapsed = totalElapsed;
-          if (allHaveActive && totalActive > TimeSpan.Zero)
-          {
-            elapsed = TimeSpan.FromSeconds(
-              Math.Round(totalElapsed.TotalSeconds * unload.MaterialIDToQueue.Count / totMatCnt, 1)
-            );
-          }
-
-          // Create BasketLoadUnload event for unload
-          logs.Add(
-            AddLogEntry(
-              trans,
-              new NewEventLogEntry()
-              {
-                Material = unload.MaterialIDToQueue.Keys.Select(m => new EventLogMaterial()
-                {
-                  MaterialID = m,
-                  Face = 0,
-                  Process = unload.Process,
-                }),
-                Pallet = containerNum,
-                ContainerId = containerId,
-                LogType = LogType.BasketLoadUnload,
-                LocationName = "L/U",
-                LocationNum = lulNum,
-                Program = "UNLOAD",
-                StartOfCycle = false,
-                EndTimeUTC = timeUTC,
-                ElapsedTime = elapsed,
-                ActiveOperationTime = unload.ActiveOperationTime,
-                Result = "UNLOAD",
-              },
-              unload.ForeignID,
-              unload.OriginalMessage
-            )
-          );
-
-          // Handle queue destinations
-          foreach (var kv in unload.MaterialIDToQueue)
-          {
-            var matId = kv.Key;
-            var queue = kv.Value;
-            var evt = new EventLogMaterial()
-            {
-              MaterialID = matId,
-              Process = unload.Process,
-              Face = 0,
-            };
-            if (externalQueues != null && externalQueues.TryGetValue(queue, out var extQueue))
-            {
-              var matDetails = GetMaterialDetails(matId, trans);
-              var partName = matDetails != null ? matDetails.PartName : "";
-              var serial = matDetails != null ? matDetails.Serial : "";
-              sendToExternal.Add(
-                new MaterialToSendToExternalQueue()
-                {
-                  Server = extQueue,
-                  PartName = partName,
-                  Queue = queue,
-                  Serial = serial,
-                }
-              );
-            }
-            else
-            {
-              AddToQueue(
-                trans: trans,
-                mat: evt,
-                queue: queue,
-                position: -1,
-                operatorName: null,
-                reason: null,
-                timeUTC: timeUTC
-              );
-            }
-          }
-        }
-
-        if (basketCompletion is not null)
-          RecordExplicitBasketCycleEnds(
-            basketCompletion,
-            timeUTC,
-            logs,
-            trans,
-            toUnload.LastOrDefault()?.ForeignID,
-            toUnload.LastOrDefault()?.OriginalMessage
-          );
-
-        // Process loads onto basket
-        foreach (var load in toLoad)
-        {
-          TimeSpan elapsed = totalElapsed;
-          if (allHaveActive && totalActive > TimeSpan.Zero)
-          {
-            elapsed = TimeSpan.FromSeconds(
-              Math.Round(totalElapsed.TotalSeconds * load.MaterialIDs.Count / totMatCnt, 1)
-            );
-          }
-
-          // Remove from queues if loading from queue
-          foreach (var matId in load.MaterialIDs)
-          {
-            var mat = new EventLogMaterial()
-            {
-              MaterialID = matId,
-              Process = load.Process,
-              Face = 0,
-            };
-            RemoveFromAllQueues(trans, mat, operatorName: null, reason: null, timeUTC: timeUTC);
-          }
-
-          // Create BasketLoadUnload event for load
-          logs.Add(
-            AddLogEntry(
-              trans,
-              new NewEventLogEntry()
-              {
-                Material = load.MaterialIDs.Select(m => new EventLogMaterial()
-                {
-                  MaterialID = m,
-                  Face = 0,
-                  Process = load.Process,
-                }),
-                Pallet = containerNum,
-                ContainerId = containerId,
-                LogType = LogType.BasketLoadUnload,
-                LocationName = "L/U",
-                LocationNum = lulNum,
-                Program = "LOAD",
-                StartOfCycle = false,
-                EndTimeUTC = timeUTC.AddSeconds(1),
-                Result = "LOAD",
-                ElapsedTime = elapsed,
-                ActiveOperationTime = load.ActiveOperationTime,
-              },
-              load.ForeignID,
-              load.OriginalMessage
-            )
-          );
-        }
-
-        if (basketCompletion is not null)
-          RecordExplicitBasketCycleStarts(
-            basketCompletion,
-            timeUTC.AddSeconds(1),
-            logs,
-            trans,
-            toLoad.LastOrDefault()?.ForeignID,
-            toLoad.LastOrDefault()?.OriginalMessage
-          );
-
-        return logs;
-      }
-
-      IEnumerable<LogEntry> newLogs;
-      var added = true;
-      if (basketCompletion is null)
-      {
-        newLogs = AddEntryInTransaction(RecordEvents);
-      }
-      else
-      {
-        var expected = ExpectedBasketStationEvents(
-          basketCompletion,
-          toLoad,
-          toUnload,
-          lulNum,
-          basketIdentity
+      ArgumentNullException.ThrowIfNull(operation);
+      if (string.IsNullOrWhiteSpace(foreignId))
+        throw new ArgumentException(
+          "A basket-station operation requires a foreign ID.",
+          nameof(foreignId)
         );
-        lock (_cfg)
+      if (totalElapsed < TimeSpan.Zero)
+        throw new ArgumentOutOfRangeException(nameof(totalElapsed));
+
+      var completion = BasketStationCompletion(operation);
+      ValidateBasketCompletion(completion, toLoad: null, toUnload: null);
+      foreach (var transfer in operation.Transfers)
+      {
+        if (transfer.ActiveOperationTime < TimeSpan.Zero)
+          throw new ArgumentOutOfRangeException(
+            nameof(operation),
+            "Basket-station active operation time cannot be negative."
+          );
+        var queue = transfer switch
         {
-          using var trans = _connection.BeginTransaction();
-          var existing = ExistingBasketStationEvents(expected, trans);
-          if (existing is not null)
+          BasketStationTransfer.LoadOntoBasket load => load.SourceQueue,
+          BasketStationTransfer.UnloadFromBasket unload => unload.DestinationQueue,
+          _ => null,
+        };
+        if (queue is not null && string.IsNullOrWhiteSpace(queue))
+          throw new ArgumentException(
+            "A basket-station queue must be null or non-empty.",
+            nameof(operation)
+          );
+      }
+
+      var fingerprint = BasketStationFingerprint(operation, lulNum, totalElapsed, externalQueues);
+      var sendToExternal = new List<MaterialToSendToExternalQueue>();
+      ImmutableList<LogEntry> logs;
+      var added = false;
+      lock (_cfg)
+      {
+        using var trans = _connection.BeginTransaction();
+        using var existingCommand = _connection.CreateCommand();
+        existingCommand.Transaction = trans;
+        existingCommand.CommandText =
+          "SELECT Fingerprint, OriginalMessage FROM basket_station_operations WHERE ForeignID = $foreign";
+        existingCommand.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
+        string existingFingerprint = null;
+        string existingOriginalMessage = null;
+        using (var reader = existingCommand.ExecuteReader())
+        {
+          if (reader.Read())
           {
-            newLogs = existing;
-            added = false;
+            existingFingerprint = reader.GetString(0);
+            existingOriginalMessage = reader.GetString(1);
           }
-          else
-          {
-            newLogs = RecordEvents(trans).ToImmutableList();
-          }
+        }
+        if (existingFingerprint is not null)
+        {
+          if (
+            existingFingerprint != fingerprint
+            || existingOriginalMessage != (originalMessage ?? "")
+          )
+            throw new ConflictRequestException(
+              $"Foreign ID {foreignId} already identifies a different basket-station operation."
+            );
+          logs = BasketCompletionForForeignId(foreignId, trans);
           trans.Commit();
+          return logs;
         }
-        if (added)
-        {
-          foreach (var (log, expectedEvent) in newLogs.Zip(expected))
-            _cfg.OnNewLogEntry(log, expectedEvent.ForeignId, this);
-        }
-      }
 
-      if (added && sendToExternal.Count > 0)
-      {
-        System.Threading.Tasks.Task.Run(() => SendMaterialToExternalQueue.Post(sendToExternal));
-      }
-
-      return newLogs;
-    }
-
-    private sealed record ExpectedBasketStationEvent
-    {
-      public required ContainerIdentity Identity { get; init; }
-      public required ImmutableList<EventLogMaterial> Material { get; init; }
-      public required LogType LogType { get; init; }
-      public required bool StartOfCycle { get; init; }
-      public required string Program { get; init; }
-      public required int LocationNum { get; init; }
-      public required ImmutableList<Guid> CycleEndContainerIds { get; init; }
-      public required string ForeignId { get; init; }
-      public required string OriginalMessage { get; init; }
-    }
-
-    private static void ValidateBasketStationCompletion(
-      BasketLoadUnloadCompletion basketCompletion,
-      IReadOnlyList<MaterialToLoadOntoBasket> toLoad,
-      IReadOnlyList<MaterialToUnloadFromBasket> toUnload,
-      ContainerIdentity basketIdentity
-    )
-    {
-      if (basketCompletion is null)
-        return;
-      ValidateBasketCompletion(basketCompletion, toLoad: null, toUnload: null);
-
-      if (
-        toLoad.Any(load => string.IsNullOrWhiteSpace(load.ForeignID))
-        || toUnload.Any(unload => string.IsNullOrWhiteSpace(unload.ForeignID))
-      )
-        throw new ArgumentException(
-          "An atomic basket-station completion requires a foreign ID for each transfer.",
-          nameof(basketCompletion)
-        );
-      var foreignIdsAndMessages = toUnload
-        .Select(unload => (unload.ForeignID, OriginalMessage: unload.OriginalMessage ?? ""))
-        .Concat(
-          toLoad.Select(load => (load.ForeignID, OriginalMessage: load.OriginalMessage ?? ""))
-        )
-        .ToImmutableList();
-      if (
-        foreignIdsAndMessages
-          .GroupBy(operation => operation.ForeignID)
-          .Any(group => group.Select(operation => operation.OriginalMessage).Distinct().Count() > 1)
-      )
-        throw new ArgumentException(
-          "Transfers sharing a foreign ID must have the same original message.",
-          nameof(basketCompletion)
-        );
-
-      var expectedTransfers = toUnload.Count + toLoad.Count;
-      if (basketCompletion.Transfers.Count != expectedTransfers)
-        throw new ArgumentException(
-          "Completion transfers must exactly match the basket-station load and unload.",
-          nameof(basketCompletion)
-        );
-      if (
-        basketCompletion.CycleBoundaries.Count(boundary => boundary is BasketCycleBoundary.Start)
-          > 1
-        || basketCompletion.CycleBoundaries.Count(boundary => boundary is BasketCycleBoundary.End)
-          > 1
-      )
-        throw new ArgumentException(
-          "A basket-station operation can start and end at most one basket cycle.",
-          nameof(basketCompletion)
-        );
-
-      ValidateBasketStationTransfers<BasketTransfer.UnloadFromBasket>(
-        basketCompletion,
-        basketIdentity,
-        toUnload
-          .Select(unload =>
-            unload
-              .MaterialIDToQueue.Keys.Select(materialId => new EventLogMaterial
-              {
-                MaterialID = materialId,
-                Process = unload.Process,
-                Face = 0,
-              })
-              .ToImmutableList()
-          )
-          .ToImmutableList()
-      );
-      ValidateBasketStationTransfers<BasketTransfer.LoadOntoBasket>(
-        basketCompletion,
-        basketIdentity,
-        toLoad
-          .Select(load =>
-            load.MaterialIDs.Select(materialId => new EventLogMaterial
-              {
-                MaterialID = materialId,
-                Process = load.Process,
-                Face = 0,
-              })
-              .ToImmutableList()
-          )
-          .ToImmutableList()
-      );
-
-      foreach (var boundary in basketCompletion.CycleBoundaries)
-      {
-        if (boundary is BasketCycleBoundary.Start)
-        {
-          if (toLoad.Count == 0 || boundary.BasketIdentity != basketIdentity)
-            throw new ArgumentException(
-              "A basket-station cycle start must match its basket load.",
-              nameof(basketCompletion)
-            );
-        }
-        else if (boundary is BasketCycleBoundary.End end)
-        {
-          var matchesUnload =
-            toUnload.Count > 0
-            && (
-              boundary.BasketIdentity == basketIdentity
-              || (
-                basketIdentity is ContainerIdentity.Uuid uuid
-                && end.ContainerIds.Contains(uuid.ContainerId)
-              )
-            );
-          if (!matchesUnload)
-            throw new ArgumentException(
-              "A basket-station cycle end must match its basket unload.",
-              nameof(basketCompletion)
-            );
-        }
-      }
-    }
-
-    private static void ValidateBasketStationTransfers<TTransfer>(
-      BasketLoadUnloadCompletion basketCompletion,
-      ContainerIdentity basketIdentity,
-      ImmutableList<ImmutableList<EventLogMaterial>> expectedMaterial
-    )
-      where TTransfer : BasketTransfer
-    {
-      var transfers = basketCompletion.Transfers.OfType<TTransfer>().ToImmutableList();
-      if (
-        transfers.Count != expectedMaterial.Count
-        || transfers.Any(transfer => transfer.BasketIdentity != basketIdentity)
-        || expectedMaterial.Any(material =>
-          transfers.Count(transfer => SameEventLogMaterial(transfer.Material, material)) != 1
-        )
-      )
-        throw new ArgumentException(
-          "Completion transfer identity and material must exactly match the basket-station operation.",
-          nameof(basketCompletion)
-        );
-    }
-
-    private static bool SameEventLogMaterial(
-      IEnumerable<EventLogMaterial> first,
-      IEnumerable<EventLogMaterial> second
-    )
-    {
-      var firstMaterial = first
-        .Select(material => (material.MaterialID, material.Process, material.Face))
-        .OrderBy(material => material)
-        .ToImmutableList();
-      var secondMaterial = second
-        .Select(material => (material.MaterialID, material.Process, material.Face))
-        .OrderBy(material => material)
-        .ToImmutableList();
-      return firstMaterial.SequenceEqual(secondMaterial);
-    }
-
-    private static ImmutableList<ExpectedBasketStationEvent> ExpectedBasketStationEvents(
-      BasketLoadUnloadCompletion basketCompletion,
-      IReadOnlyList<MaterialToLoadOntoBasket> toLoad,
-      IReadOnlyList<MaterialToUnloadFromBasket> toUnload,
-      int lulNum,
-      ContainerIdentity basketIdentity
-    )
-    {
-      var expected = ImmutableList.CreateBuilder<ExpectedBasketStationEvent>();
-      foreach (var unload in toUnload)
-      {
-        var material = unload
-          .MaterialIDToQueue.Keys.Select(materialId => new EventLogMaterial
-          {
-            MaterialID = materialId,
-            Process = unload.Process,
-            Face = 0,
-          })
+        ValidateBasketStationSourceQueues(operation, trans);
+        var newLogs = new List<LogEntry>();
+        var transferMaterialCount = operation.Transfers.Sum(transfer => transfer.Material.Count);
+        var activeTimes = operation
+          .Transfers.Select(transfer => transfer.ActiveOperationTime)
           .ToImmutableList();
-        expected.Add(
-          new ExpectedBasketStationEvent
-          {
-            Identity = basketIdentity,
-            Material = basketCompletion
-              .Transfers.OfType<BasketTransfer.UnloadFromBasket>()
-              .Single(transfer => SameEventLogMaterial(transfer.Material, material))
-              .Material,
-            LogType = LogType.BasketLoadUnload,
-            StartOfCycle = false,
-            Program = "UNLOAD",
-            LocationNum = lulNum,
-            CycleEndContainerIds = null,
-            ForeignId = unload.ForeignID,
-            OriginalMessage = unload.OriginalMessage ?? "",
-          }
-        );
-      }
-      if (toUnload.Count > 0)
-      {
-        var boundaryOwner = toUnload[^1];
-        foreach (var boundary in basketCompletion.CycleBoundaries.OfType<BasketCycleBoundary.End>())
-          expected.Add(
-            new ExpectedBasketStationEvent
-            {
-              Identity = boundary.BasketIdentity,
-              Material = boundary.Material,
-              LogType = LogType.BasketCycle,
-              StartOfCycle = false,
-              Program = "",
-              LocationNum = 0,
-              CycleEndContainerIds =
-                boundary.ContainerIds.Count == 0
-                  ? null
-                  : boundary.ContainerIds.OrderBy(id => id).ToImmutableList(),
-              ForeignId = boundaryOwner.ForeignID,
-              OriginalMessage = boundaryOwner.OriginalMessage ?? "",
-            }
-          );
-      }
-      foreach (var load in toLoad)
-      {
-        var material = load
-          .MaterialIDs.Select(materialId => new EventLogMaterial
-          {
-            MaterialID = materialId,
-            Process = load.Process,
-            Face = 0,
-          })
-          .ToImmutableList();
-        expected.Add(
-          new ExpectedBasketStationEvent
-          {
-            Identity = basketIdentity,
-            Material = basketCompletion
-              .Transfers.OfType<BasketTransfer.LoadOntoBasket>()
-              .Single(transfer => SameEventLogMaterial(transfer.Material, material))
-              .Material,
-            LogType = LogType.BasketLoadUnload,
-            StartOfCycle = false,
-            Program = "LOAD",
-            LocationNum = lulNum,
-            CycleEndContainerIds = null,
-            ForeignId = load.ForeignID,
-            OriginalMessage = load.OriginalMessage ?? "",
-          }
-        );
-      }
-      if (toLoad.Count > 0)
-      {
-        var boundaryOwner = toLoad[^1];
+        var allHaveActive =
+          !activeTimes.IsEmpty && activeTimes.All(active => active > TimeSpan.Zero);
+
         foreach (
-          var boundary in basketCompletion.CycleBoundaries.OfType<BasketCycleBoundary.Start>()
+          var transfer in operation.Transfers.OfType<BasketStationTransfer.UnloadFromBasket>()
         )
-          expected.Add(
-            new ExpectedBasketStationEvent
-            {
-              Identity = boundary.BasketIdentity,
-              Material = boundary.Material,
-              LogType = LogType.BasketCycle,
-              StartOfCycle = true,
-              Program = "",
-              LocationNum = 0,
-              CycleEndContainerIds = null,
-              ForeignId = boundaryOwner.ForeignID,
-              OriginalMessage = boundaryOwner.OriginalMessage ?? "",
-            }
+        {
+          RecordBasketStationTransfer(
+            transfer,
+            loadOntoBasket: false,
+            BasketStationTransferElapsed(
+              transfer,
+              totalElapsed,
+              transferMaterialCount,
+              allHaveActive
+            ),
+            lulNum,
+            timeUTC,
+            trans,
+            newLogs,
+            foreignId,
+            originalMessage
           );
+          if (transfer.DestinationQueue is null)
+            continue;
+          foreach (var material in transfer.Material)
+          {
+            if (
+              externalQueues is not null
+              && externalQueues.TryGetValue(transfer.DestinationQueue, out var externalServer)
+            )
+            {
+              var details = GetMaterialDetails(material.MaterialID, trans);
+              sendToExternal.Add(
+                new MaterialToSendToExternalQueue
+                {
+                  Server = externalServer,
+                  PartName = details?.PartName ?? "",
+                  Queue = transfer.DestinationQueue,
+                  Serial = details?.Serial ?? "",
+                }
+              );
+            }
+            else
+            {
+              AddToQueue(
+                trans,
+                material,
+                transfer.DestinationQueue,
+                position: -1,
+                operatorName: null,
+                timeUTC,
+                reason: null
+              );
+            }
+          }
+        }
+
+        RecordExplicitBasketCycleEnds(
+          completion,
+          timeUTC,
+          newLogs,
+          trans,
+          foreignId,
+          originalMessage
+        );
+
+        foreach (var transfer in operation.Transfers.OfType<BasketStationTransfer.LoadOntoBasket>())
+        {
+          foreach (var material in transfer.Material)
+            RemoveFromAllQueues(trans, material, operatorName: null, reason: null, timeUTC);
+          RecordBasketStationTransfer(
+            transfer,
+            loadOntoBasket: true,
+            BasketStationTransferElapsed(
+              transfer,
+              totalElapsed,
+              transferMaterialCount,
+              allHaveActive
+            ),
+            lulNum,
+            timeUTC,
+            trans,
+            newLogs,
+            foreignId,
+            originalMessage
+          );
+        }
+
+        RecordExplicitBasketCycleStarts(
+          completion,
+          timeUTC,
+          newLogs,
+          trans,
+          foreignId,
+          originalMessage
+        );
+
+        using var recordOperation = _connection.CreateCommand();
+        recordOperation.Transaction = trans;
+        recordOperation.CommandText =
+          "INSERT INTO basket_station_operations(ForeignID, Fingerprint, OriginalMessage) VALUES($foreign, $fingerprint, $original)";
+        recordOperation.Parameters.Add("foreign", SqliteType.Text).Value = foreignId;
+        recordOperation.Parameters.Add("fingerprint", SqliteType.Text).Value = fingerprint;
+        recordOperation.Parameters.Add("original", SqliteType.Text).Value = originalMessage ?? "";
+        recordOperation.ExecuteNonQuery();
+        trans.Commit();
+        logs = newLogs.ToImmutableList();
+        added = true;
       }
-      return expected.ToImmutable();
+
+      if (added)
+      {
+        foreach (var log in logs)
+          _cfg.OnNewLogEntry(log, foreignId, this);
+        if (sendToExternal.Count > 0)
+          System.Threading.Tasks.Task.Run(() => SendMaterialToExternalQueue.Post(sendToExternal));
+      }
+      return logs;
     }
 
-    private ImmutableList<LogEntry> ExistingBasketStationEvents(
-      ImmutableList<ExpectedBasketStationEvent> expected,
+    private static BasketLoadUnloadCompletion BasketStationCompletion(
+      BasketStationLoadUnload operation
+    ) =>
+      new()
+      {
+        Transfers = operation
+          .Transfers.Select<BasketStationTransfer, BasketTransfer>(transfer =>
+            transfer switch
+            {
+              BasketStationTransfer.LoadOntoBasket load => new BasketTransfer.LoadOntoBasket
+              {
+                BasketIdentity = load.BasketIdentity,
+                Material = load.Material,
+              },
+              BasketStationTransfer.UnloadFromBasket unload => new BasketTransfer.UnloadFromBasket
+              {
+                BasketIdentity = unload.BasketIdentity,
+                Material = unload.Material,
+              },
+              _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+            }
+          )
+          .ToImmutableList(),
+        CycleBoundaries = operation.CycleBoundaries,
+      };
+
+    private void ValidateBasketStationSourceQueues(
+      BasketStationLoadUnload operation,
       IDbTransaction trans
     )
     {
-      var existing = ImmutableList.CreateBuilder<LogEntry>();
-      var missingForeignIds = ImmutableList.CreateBuilder<string>();
-      var foundAny = false;
-      foreach (var foreignId in expected.Select(evt => evt.ForeignId).Distinct())
+      using var command = _connection.CreateCommand();
+      command.Transaction = (SqliteTransaction)trans;
+      command.CommandText = "SELECT Queue FROM queues WHERE MaterialID = $material";
+      command.Parameters.Add("material", SqliteType.Integer);
+      foreach (
+        var transfer in operation
+          .Transfers.OfType<BasketStationTransfer.LoadOntoBasket>()
+          .Where(transfer => transfer.SourceQueue is not null)
+      )
       {
-        var expectedGroup = expected.Where(evt => evt.ForeignId == foreignId).ToImmutableList();
-        var existingGroup = BasketCompletionForForeignId(foreignId, trans);
-        if (existingGroup.Count == 0)
+        foreach (var material in transfer.Material)
         {
-          missingForeignIds.Add(foreignId);
-          continue;
+          command.Parameters[0].Value = material.MaterialID;
+          var actualQueue = command.ExecuteScalar() as string;
+          if (actualQueue != transfer.SourceQueue)
+            throw new ConflictRequestException(
+              $"Material {material.MaterialID} is not in expected source queue {transfer.SourceQueue}."
+            );
         }
-        foundAny = true;
-        if (
-          existingGroup.Count != expectedGroup.Count
-          || BasketCompletionOriginalMessage(foreignId, trans) != expectedGroup[0].OriginalMessage
-          || !existingGroup
-            .Zip(expectedGroup)
-            .All(pair => BasketStationEventMatches(pair.First, pair.Second))
-        )
-          throw new ConflictRequestException(
-            $"Foreign ID {foreignId} already identifies different basket events."
-          );
-        existing.AddRange(existingGroup);
       }
-      if (!foundAny)
-        return null;
-      if (missingForeignIds.Count > 0)
-        throw new ConflictRequestException(
-          $"Foreign ID {missingForeignIds[0]} is missing part of an atomic basket completion."
-        );
-      return existing.OrderBy(log => log.Counter).ToImmutableList();
     }
 
-    private static bool BasketStationEventMatches(
-      LogEntry log,
-      ExpectedBasketStationEvent expected
-    ) =>
-      log.Identity == expected.Identity
-      && log.LogType == expected.LogType
-      && log.StartOfCycle == expected.StartOfCycle
-      && log.Program == expected.Program
-      && log.LocationNum == expected.LocationNum
-      && SameEventLogMaterial(log.Material.Select(EventLogMaterial.FromLogMat), expected.Material)
-      && (
-        expected.CycleEndContainerIds is null
-          ? log.CycleEndContainerIds is null
-          : log.CycleEndContainerIds?.SequenceEqual(expected.CycleEndContainerIds) == true
+    private void RecordBasketStationTransfer(
+      BasketStationTransfer transfer,
+      bool loadOntoBasket,
+      TimeSpan elapsed,
+      int lulNum,
+      DateTime timeUTC,
+      IDbTransaction trans,
+      List<LogEntry> logs,
+      string foreignId,
+      string originalMessage
+    )
+    {
+      var (containerNum, containerId) = RecordedContainerIdentity(transfer.BasketIdentity);
+      logs.Add(
+        AddLogEntry(
+          trans,
+          new NewEventLogEntry
+          {
+            Material = transfer.Material,
+            Pallet = containerNum,
+            ContainerId = containerId,
+            LogType = LogType.BasketLoadUnload,
+            LocationName = "L/U",
+            LocationNum = lulNum,
+            Program = loadOntoBasket ? "LOAD" : "UNLOAD",
+            StartOfCycle = false,
+            EndTimeUTC = timeUTC,
+            Result = loadOntoBasket ? "LOAD" : "UNLOAD",
+            ElapsedTime = elapsed,
+            ActiveOperationTime = transfer.ActiveOperationTime,
+          },
+          foreignId,
+          originalMessage
+        )
       );
+    }
+
+    private static TimeSpan BasketStationTransferElapsed(
+      BasketStationTransfer transfer,
+      TimeSpan totalElapsed,
+      int transferMaterialCount,
+      bool allHaveActive
+    )
+    {
+      if (!allHaveActive || transferMaterialCount == 0)
+        return totalElapsed;
+      return TimeSpan.FromSeconds(
+        Math.Round(totalElapsed.TotalSeconds * transfer.Material.Count / transferMaterialCount, 1)
+      );
+    }
+
+    private static string BasketStationFingerprint(
+      BasketStationLoadUnload operation,
+      int lulNum,
+      TimeSpan totalElapsed,
+      IReadOnlyDictionary<string, string> externalQueues
+    )
+    {
+      var fingerprint = new StringBuilder();
+      AppendBasketStationFingerprint(fingerprint, lulNum.ToString(CultureInfo.InvariantCulture));
+      AppendBasketStationFingerprint(
+        fingerprint,
+        totalElapsed.Ticks.ToString(CultureInfo.InvariantCulture)
+      );
+      foreach (var transfer in operation.Transfers)
+      {
+        AppendBasketStationFingerprint(
+          fingerprint,
+          transfer is BasketStationTransfer.LoadOntoBasket ? "load" : "unload"
+        );
+        AppendBasketStationFingerprint(fingerprint, BasketStationIdentity(transfer.BasketIdentity));
+        AppendBasketStationFingerprint(
+          fingerprint,
+          transfer.ActiveOperationTime.Ticks.ToString(CultureInfo.InvariantCulture)
+        );
+        var queue = transfer switch
+        {
+          BasketStationTransfer.LoadOntoBasket load => load.SourceQueue,
+          BasketStationTransfer.UnloadFromBasket unload => unload.DestinationQueue,
+          _ => null,
+        };
+        AppendBasketStationFingerprint(fingerprint, queue);
+        if (
+          transfer is BasketStationTransfer.UnloadFromBasket
+          && queue is not null
+          && externalQueues is not null
+          && externalQueues.TryGetValue(queue, out var externalServer)
+        )
+          AppendBasketStationFingerprint(fingerprint, externalServer);
+        else
+          AppendBasketStationFingerprint(fingerprint, null);
+        foreach (
+          var material in transfer
+            .Material.OrderBy(material => material.MaterialID)
+            .ThenBy(material => material.Process)
+            .ThenBy(material => material.Face)
+        )
+        {
+          AppendBasketStationFingerprint(
+            fingerprint,
+            material.MaterialID.ToString(CultureInfo.InvariantCulture)
+          );
+          AppendBasketStationFingerprint(
+            fingerprint,
+            material.Process.ToString(CultureInfo.InvariantCulture)
+          );
+          AppendBasketStationFingerprint(
+            fingerprint,
+            material.Face.ToString(CultureInfo.InvariantCulture)
+          );
+        }
+      }
+      foreach (var boundary in operation.CycleBoundaries)
+      {
+        AppendBasketStationFingerprint(
+          fingerprint,
+          boundary is BasketCycleBoundary.Start ? "start" : "end"
+        );
+        AppendBasketStationFingerprint(fingerprint, BasketStationIdentity(boundary.BasketIdentity));
+        foreach (
+          var material in boundary
+            .Material.OrderBy(material => material.MaterialID)
+            .ThenBy(material => material.Process)
+            .ThenBy(material => material.Face)
+        )
+        {
+          AppendBasketStationFingerprint(
+            fingerprint,
+            material.MaterialID.ToString(CultureInfo.InvariantCulture)
+          );
+          AppendBasketStationFingerprint(
+            fingerprint,
+            material.Process.ToString(CultureInfo.InvariantCulture)
+          );
+          AppendBasketStationFingerprint(
+            fingerprint,
+            material.Face.ToString(CultureInfo.InvariantCulture)
+          );
+        }
+        foreach (
+          var containerId in (
+            boundary as BasketCycleBoundary.End
+          )?.ReconciledBasketIdentities.OrderBy(id => id) ?? Enumerable.Empty<Guid>()
+        )
+          AppendBasketStationFingerprint(fingerprint, containerId.ToString("D"));
+      }
+      return fingerprint.ToString();
+    }
+
+    private static string BasketStationIdentity(ContainerIdentity identity) =>
+      identity switch
+      {
+        ContainerIdentity.Numbered numbered => $"numbered:{numbered.ContainerNum}",
+        ContainerIdentity.Uuid uuid => $"uuid:{uuid.ContainerId:D}",
+        _ => "none",
+      };
+
+    private static void AppendBasketStationFingerprint(StringBuilder fingerprint, string value)
+    {
+      value ??= "";
+      fingerprint
+        .Append(value.Length.ToString(CultureInfo.InvariantCulture))
+        .Append(':')
+        .Append(value);
+    }
 
     public IEnumerable<LogEntry> RecordEmptyPallet(
       int pallet,

--- a/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
@@ -153,7 +153,7 @@ namespace BlackMaple.MachineFramework
       TimeSpan totalElapsed,
       DateTime timeUTC,
       IReadOnlyDictionary<string, string> externalQueues,
-      BasketLoadUnloadCompletion basketCompletion = null
+      PalletBasketLoadUnloadCompletion palletBasketCompletion = null
     );
 
     // The main method for recording a completed pallet load/unload, which combines
@@ -171,7 +171,7 @@ namespace BlackMaple.MachineFramework
       TimeSpan totalElapsed,
       DateTime timeUTC,
       IReadOnlyDictionary<string, string> externalQueues,
-      BasketLoadUnloadCompletion basketCompletion = null
+      PalletBasketLoadUnloadCompletion palletBasketCompletion = null
     );
 
     // Atomically records one completed basket-station operation. Each transfer owns its basket
@@ -180,10 +180,13 @@ namespace BlackMaple.MachineFramework
     // idempotency key. An identical retry returns the original event group; changed durable input
     // throws ConflictRequestException. timeUTC is intentionally excluded from retry comparison.
     //
+    // totalElapsed is apportioned among transfers in proportion to ActiveOperationTime when every
+    // transfer has a positive expected time. Otherwise, it is apportioned by material count.
+    //
     // Local queue changes are part of the database transaction. Delivery to a configured external
     // queue is best-effort after commit and is not covered by the atomic retry contract.
-    IEnumerable<LogEntry> RecordBasketStationLoadUnload(
-      BasketStationLoadUnload operation,
+    IEnumerable<LogEntry> RecordBasketStationOperation(
+      BasketStationOperation operation,
       int lulNum,
       TimeSpan totalElapsed,
       DateTime timeUTC,
@@ -786,16 +789,20 @@ namespace BlackMaple.MachineFramework
     public string Queue { get; init; }
   }
 
-  public abstract record BasketTransfer
+  /// <summary>
+  /// Basket-side evidence for material transferred during a pallet load/unload. Timing is recorded
+  /// on the corresponding pallet event.
+  /// </summary>
+  public abstract record PalletBasketTransfer
   {
-    private BasketTransfer() { }
+    private PalletBasketTransfer() { }
 
     public required ContainerIdentity BasketIdentity { get; init; }
     public required ImmutableList<EventLogMaterial> Material { get; init; }
 
-    public sealed record LoadOntoBasket : BasketTransfer;
+    public sealed record LoadOntoBasket : PalletBasketTransfer;
 
-    public sealed record UnloadFromBasket : BasketTransfer;
+    public sealed record UnloadFromBasket : PalletBasketTransfer;
   }
 
   public abstract record BasketCycleBoundary
@@ -821,9 +828,9 @@ namespace BlackMaple.MachineFramework
     public sealed record Start : BasketCycleBoundary;
   }
 
-  public record BasketLoadUnloadCompletion
+  public sealed record PalletBasketLoadUnloadCompletion
   {
-    public required ImmutableList<BasketTransfer> Transfers { get; init; }
+    public required ImmutableList<PalletBasketTransfer> Transfers { get; init; }
     public required ImmutableList<BasketCycleBoundary> CycleBoundaries { get; init; }
   }
 
@@ -833,16 +840,14 @@ namespace BlackMaple.MachineFramework
 
     public required ContainerIdentity BasketIdentity { get; init; }
     public required ImmutableList<EventLogMaterial> Material { get; init; }
+
+    /// <summary>
+    /// Expected accounting time for this entire transfer, including every material in
+    /// <see cref="Material"/>.
+    /// </summary>
     public required TimeSpan ActiveOperationTime { get; init; }
 
-    public sealed record LoadOntoBasket : BasketStationTransfer
-    {
-      /// <summary>
-      /// The local queue expected to contain the material, or null when loading material which is
-      /// not queued. The material is removed from all local queues when the operation commits.
-      /// </summary>
-      public string SourceQueue { get; init; }
-    }
+    public sealed record LoadOntoBasket : BasketStationTransfer;
 
     public sealed record UnloadFromBasket : BasketStationTransfer
     {
@@ -854,7 +859,7 @@ namespace BlackMaple.MachineFramework
     }
   }
 
-  public sealed record BasketStationLoadUnload
+  public sealed record BasketStationOperation
   {
     public required ImmutableList<BasketStationTransfer> Transfers { get; init; }
     public required ImmutableList<BasketCycleBoundary> CycleBoundaries { get; init; }

--- a/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
@@ -174,70 +174,22 @@ namespace BlackMaple.MachineFramework
       BasketLoadUnloadCompletion basketCompletion = null
     );
 
-    // Records explicit basket transfer evidence and cycle boundaries atomically without duplicating
-    // pallet events. This supports integrations which reconstruct basket state after pallet
-    // completion. foreignId is required: an identical retry returns the original event group, while
-    // reuse for different evidence throws ConflictRequestException.
-    IEnumerable<LogEntry> RecordBasketLoadUnloadCompletion(
-      BasketLoadUnloadCompletion basketCompletion,
+    // Atomically records one completed basket-station operation. Each transfer owns its basket
+    // identity so a physical turnover can unload one UUID episode and load another. Queue changes,
+    // operation timing, transfer evidence, and complete-content cycle boundaries share one
+    // idempotency key. An identical retry returns the original event group; changed durable input
+    // throws ConflictRequestException. timeUTC is intentionally excluded from retry comparison.
+    //
+    // Local queue changes are part of the database transaction. Delivery to a configured external
+    // queue is best-effort after commit and is not covered by the atomic retry contract.
+    IEnumerable<LogEntry> RecordBasketStationLoadUnload(
+      BasketStationLoadUnload operation,
       int lulNum,
+      TimeSpan totalElapsed,
       DateTime timeUTC,
+      IReadOnlyDictionary<string, string> externalQueues,
       string foreignId,
       string originalMessage = null
-    );
-
-    // RecordPartialBasketOnlyLoadUnload is for partial basket-only operations.
-    // Records BasketLoadUnload events but NO BasketCycle events.  Material loaded here
-    // should be later passed into an explicit BasketLoadUnloadCompletion or `previouslyLoaded`
-    // in `RecordBasketOnlyLoadUnload`.
-    IEnumerable<LogEntry> RecordPartialBasketOnlyLoadUnload(
-      MaterialToLoadOntoBasket toLoad,
-      MaterialToUnloadFromBasket toUnload,
-      int lulNum,
-      int basketId,
-      TimeSpan totalElapsed,
-      DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues
-    );
-
-    // Records basket-station queue changes and ordinary basket load/unload evidence. When an
-    // explicit completion is supplied, its transfers must exactly describe toLoad/toUnload and are
-    // used only for validation; the ordinary events are emitted once, followed by matching cycle
-    // boundaries in the same transaction. Each supplied transfer requires the corresponding
-    // toLoad/toUnload ForeignID so an identical retry can return the committed event group.
-    IEnumerable<LogEntry> RecordBasketLoadUnload(
-      MaterialToLoadOntoBasket toLoad,
-      MaterialToUnloadFromBasket toUnload,
-      int lulNum,
-      ContainerIdentity basketIdentity,
-      TimeSpan totalElapsed,
-      DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues,
-      BasketLoadUnloadCompletion basketCompletion = null
-    );
-    IEnumerable<LogEntry> RecordBasketLoadUnload(
-      IReadOnlyList<MaterialToLoadOntoBasket> toLoad,
-      IReadOnlyList<MaterialToUnloadFromBasket> toUnload,
-      int lulNum,
-      ContainerIdentity basketIdentity,
-      TimeSpan totalElapsed,
-      DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues,
-      BasketLoadUnloadCompletion basketCompletion
-    );
-
-    // RecordBasketOnlyLoadUnload is used for basket-only load/unload operations (no pallet involved).
-    // This is used for material loaded from queue onto basket, or unloaded from basket to queue.
-    // Emits BasketCycle events (end of previous cycle if any, start of new cycle with material).
-    IEnumerable<LogEntry> RecordBasketOnlyLoadUnload(
-      MaterialToLoadOntoBasket toLoad,
-      IReadOnlyList<EventLogMaterial> previouslyLoaded,
-      MaterialToUnloadFromBasket toUnload,
-      int lulNum,
-      int basketId,
-      TimeSpan totalElapsed,
-      DateTime timeUTC,
-      IReadOnlyDictionary<string, string> externalQueues
     );
 
     IEnumerable<LogEntry> RecordEmptyPallet(
@@ -860,10 +812,10 @@ namespace BlackMaple.MachineFramework
     public sealed record End : BasketCycleBoundary
     {
       /// <summary>
-      /// UUID fragments finalized by this numbered basket end. Leave empty for a numbered cycle
-      /// which has no UUID fragments.
+      /// Durable UUID basket identities reconciled into this numbered cycle. Leave empty when every
+      /// event in the cycle was already recorded with the numbered identity.
       /// </summary>
-      public required ImmutableHashSet<Guid> ContainerIds { get; init; }
+      public required ImmutableHashSet<Guid> ReconciledBasketIdentities { get; init; }
     }
 
     public sealed record Start : BasketCycleBoundary;
@@ -875,6 +827,39 @@ namespace BlackMaple.MachineFramework
     public required ImmutableList<BasketCycleBoundary> CycleBoundaries { get; init; }
   }
 
+  public abstract record BasketStationTransfer
+  {
+    private BasketStationTransfer() { }
+
+    public required ContainerIdentity BasketIdentity { get; init; }
+    public required ImmutableList<EventLogMaterial> Material { get; init; }
+    public required TimeSpan ActiveOperationTime { get; init; }
+
+    public sealed record LoadOntoBasket : BasketStationTransfer
+    {
+      /// <summary>
+      /// The local queue expected to contain the material, or null when loading material which is
+      /// not queued. The material is removed from all local queues when the operation commits.
+      /// </summary>
+      public string SourceQueue { get; init; }
+    }
+
+    public sealed record UnloadFromBasket : BasketStationTransfer
+    {
+      /// <summary>
+      /// The local or configured external destination queue, or null when the material is
+      /// transferred directly without entering a queue.
+      /// </summary>
+      public string DestinationQueue { get; init; }
+    }
+  }
+
+  public sealed record BasketStationLoadUnload
+  {
+    public required ImmutableList<BasketStationTransfer> Transfers { get; init; }
+    public required ImmutableList<BasketCycleBoundary> CycleBoundaries { get; init; }
+  }
+
   public record MaterialToUnloadFromFace
   {
     public required ImmutableDictionary<
@@ -882,25 +867,6 @@ namespace BlackMaple.MachineFramework
       UnloadDestination
     > MaterialIDToDestination { get; init; }
     public required int FaceNum { get; init; }
-    public required int Process { get; init; }
-    public required TimeSpan ActiveOperationTime { get; init; }
-    public string ForeignID { get; init; } = null;
-    public string OriginalMessage { get; init; } = null;
-  }
-
-  // Parameter types for basket-only load/unload operations (no pallet involved)
-  public record MaterialToLoadOntoBasket
-  {
-    public required ImmutableList<long> MaterialIDs { get; init; }
-    public required int Process { get; init; }
-    public required TimeSpan ActiveOperationTime { get; init; }
-    public string ForeignID { get; init; } = null;
-    public string OriginalMessage { get; init; } = null;
-  }
-
-  public record MaterialToUnloadFromBasket
-  {
-    public required ImmutableDictionary<long, string> MaterialIDToQueue { get; init; }
     public required int Process { get; init; }
     public required TimeSpan ActiveOperationTime { get; init; }
     public string ForeignID { get; init; } = null;

--- a/server/lib/BlackMaple.MachineFramework/db/Schema.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/Schema.cs
@@ -41,7 +41,7 @@ namespace BlackMaple.MachineFramework
 {
   internal static class DatabaseSchema
   {
-    private const int Version = 42;
+    private const int Version = 43;
 
     #region Create
     public static void CreateTables(SqliteConnection connection, SerialSettings settings)
@@ -110,6 +110,10 @@ namespace BlackMaple.MachineFramework
 
         cmd.CommandText =
           "CREATE INDEX stations_foreignid ON stations(ForeignID) WHERE ForeignID IS NOT NULL";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText =
+          "CREATE TABLE basket_station_operations(ForeignID TEXT PRIMARY KEY, Fingerprint TEXT NOT NULL, OriginalMessage TEXT NOT NULL)";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText = "CREATE INDEX stations_material_idx ON stations_mat(MaterialID)";
@@ -537,6 +541,9 @@ namespace BlackMaple.MachineFramework
 
           if (curVersion < 42)
             Ver41ToVer42(trans);
+
+          if (curVersion < 43)
+            Ver42ToVer43(trans);
 
           //update the version in the database
           cmd.Transaction = trans;
@@ -1356,6 +1363,15 @@ namespace BlackMaple.MachineFramework
       cmd.ExecuteNonQuery();
       cmd.CommandText =
         "CREATE INDEX basket_cycle_container_ids_cycle ON basket_cycle_container_ids(CycleCounter, ContainerId)";
+      cmd.ExecuteNonQuery();
+    }
+
+    private static void Ver42ToVer43(IDbTransaction trans)
+    {
+      using var cmd = trans.Connection.CreateCommand();
+      cmd.Transaction = trans;
+      cmd.CommandText =
+        "CREATE TABLE basket_station_operations(ForeignID TEXT PRIMARY KEY, Fingerprint TEXT NOT NULL, OriginalMessage TEXT NOT NULL)";
       cmd.ExecuteNonQuery();
     }
 

--- a/server/lib/BlackMaple.MachineFramework/db/Schema.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/Schema.cs
@@ -113,7 +113,7 @@ namespace BlackMaple.MachineFramework
         cmd.ExecuteNonQuery();
 
         cmd.CommandText =
-          "CREATE TABLE basket_station_operations(ForeignID TEXT PRIMARY KEY, Fingerprint TEXT NOT NULL, OriginalMessage TEXT NOT NULL)";
+          "CREATE TABLE basket_station_operations(ForeignID TEXT PRIMARY KEY, Fingerprint TEXT NOT NULL, OriginalMessage TEXT NOT NULL, FirstCounter INTEGER NOT NULL, LastCounter INTEGER NOT NULL)";
         cmd.ExecuteNonQuery();
 
         cmd.CommandText = "CREATE INDEX stations_material_idx ON stations_mat(MaterialID)";
@@ -1371,7 +1371,7 @@ namespace BlackMaple.MachineFramework
       using var cmd = trans.Connection.CreateCommand();
       cmd.Transaction = trans;
       cmd.CommandText =
-        "CREATE TABLE basket_station_operations(ForeignID TEXT PRIMARY KEY, Fingerprint TEXT NOT NULL, OriginalMessage TEXT NOT NULL)";
+        "CREATE TABLE basket_station_operations(ForeignID TEXT PRIMARY KEY, Fingerprint TEXT NOT NULL, OriginalMessage TEXT NOT NULL, FirstCounter INTEGER NOT NULL, LastCounter INTEGER NOT NULL)";
       cmd.ExecuteNonQuery();
     }
 

--- a/server/test/BasketStationTestExtensions.cs
+++ b/server/test/BasketStationTestExtensions.cs
@@ -35,7 +35,7 @@ internal static class BasketStationTestExtensions
     TimeSpan totalElapsed,
     DateTime timeUTC,
     IReadOnlyDictionary<string, string> externalQueues,
-    BasketLoadUnloadCompletion basketCompletion = null
+    PalletBasketLoadUnloadCompletion palletBasketCompletion = null
   ) =>
     repository.RecordTestBasketLoadUnload(
       toLoad is null ? [] : [toLoad],
@@ -45,7 +45,7 @@ internal static class BasketStationTestExtensions
       totalElapsed,
       timeUTC,
       externalQueues,
-      basketCompletion
+      palletBasketCompletion
     );
 
   public static IEnumerable<LogEntry> RecordTestBasketLoadUnload(
@@ -57,7 +57,7 @@ internal static class BasketStationTestExtensions
     TimeSpan totalElapsed,
     DateTime timeUTC,
     IReadOnlyDictionary<string, string> externalQueues,
-    BasketLoadUnloadCompletion basketCompletion
+    PalletBasketLoadUnloadCompletion palletBasketCompletion
   )
   {
     var transfers = ImmutableList.CreateBuilder<BasketStationTransfer>();
@@ -66,7 +66,7 @@ internal static class BasketStationTestExtensions
       var material = Material(
         unload.MaterialIDToQueue.Keys,
         unload.Process,
-        basketCompletion?.Transfers.OfType<BasketTransfer.UnloadFromBasket>()
+        palletBasketCompletion?.Transfers.OfType<PalletBasketTransfer.UnloadFromBasket>()
       );
       transfers.Add(
         new BasketStationTransfer.UnloadFromBasket
@@ -74,7 +74,7 @@ internal static class BasketStationTestExtensions
           BasketIdentity =
             MatchingIdentity(
               material,
-              basketCompletion?.Transfers.OfType<BasketTransfer.UnloadFromBasket>()
+              palletBasketCompletion?.Transfers.OfType<PalletBasketTransfer.UnloadFromBasket>()
             ) ?? basketIdentity,
           Material = material,
           ActiveOperationTime = unload.ActiveOperationTime,
@@ -87,7 +87,7 @@ internal static class BasketStationTestExtensions
       var material = Material(
         load.MaterialIDs,
         load.Process,
-        basketCompletion?.Transfers.OfType<BasketTransfer.LoadOntoBasket>()
+        palletBasketCompletion?.Transfers.OfType<PalletBasketTransfer.LoadOntoBasket>()
       );
       transfers.Add(
         new BasketStationTransfer.LoadOntoBasket
@@ -95,7 +95,7 @@ internal static class BasketStationTestExtensions
           BasketIdentity =
             MatchingIdentity(
               material,
-              basketCompletion?.Transfers.OfType<BasketTransfer.LoadOntoBasket>()
+              palletBasketCompletion?.Transfers.OfType<PalletBasketTransfer.LoadOntoBasket>()
             ) ?? basketIdentity,
           Material = material,
           ActiveOperationTime = load.ActiveOperationTime,
@@ -109,11 +109,11 @@ internal static class BasketStationTestExtensions
       .Where(id => !string.IsNullOrWhiteSpace(id))
       .Distinct()
       .ToImmutableList();
-    return repository.RecordBasketStationLoadUnload(
-      new BasketStationLoadUnload
+    return repository.RecordBasketStationOperation(
+      new BasketStationOperation
       {
         Transfers = transfers.ToImmutable(),
-        CycleBoundaries = basketCompletion?.CycleBoundaries ?? [],
+        CycleBoundaries = palletBasketCompletion?.CycleBoundaries ?? [],
       },
       lulNum,
       totalElapsed,
@@ -129,38 +129,39 @@ internal static class BasketStationTestExtensions
     );
   }
 
-  public static IEnumerable<LogEntry> RecordTestBasketCompletion(
+  public static IEnumerable<LogEntry> RecordTestPalletBasketCompletion(
     this IRepository repository,
-    BasketLoadUnloadCompletion basketCompletion,
+    PalletBasketLoadUnloadCompletion palletBasketCompletion,
     int lulNum,
     DateTime timeUTC,
     string foreignId,
     string originalMessage = null
   ) =>
-    repository.RecordBasketStationLoadUnload(
-      new BasketStationLoadUnload
+    repository.RecordBasketStationOperation(
+      new BasketStationOperation
       {
-        Transfers = basketCompletion
-          .Transfers.Select<BasketTransfer, BasketStationTransfer>(transfer =>
+        Transfers = palletBasketCompletion
+          .Transfers.Select<PalletBasketTransfer, BasketStationTransfer>(transfer =>
             transfer switch
             {
-              BasketTransfer.LoadOntoBasket load => new BasketStationTransfer.LoadOntoBasket
+              PalletBasketTransfer.LoadOntoBasket load => new BasketStationTransfer.LoadOntoBasket
               {
                 BasketIdentity = load.BasketIdentity,
                 Material = load.Material,
                 ActiveOperationTime = TimeSpan.Zero,
               },
-              BasketTransfer.UnloadFromBasket unload => new BasketStationTransfer.UnloadFromBasket
-              {
-                BasketIdentity = unload.BasketIdentity,
-                Material = unload.Material,
-                ActiveOperationTime = TimeSpan.Zero,
-              },
-              _ => throw new ArgumentOutOfRangeException(nameof(basketCompletion)),
+              PalletBasketTransfer.UnloadFromBasket unload =>
+                new BasketStationTransfer.UnloadFromBasket
+                {
+                  BasketIdentity = unload.BasketIdentity,
+                  Material = unload.Material,
+                  ActiveOperationTime = TimeSpan.Zero,
+                },
+              _ => throw new ArgumentOutOfRangeException(nameof(palletBasketCompletion)),
             }
           )
           .ToImmutableList(),
-        CycleBoundaries = basketCompletion.CycleBoundaries,
+        CycleBoundaries = palletBasketCompletion.CycleBoundaries,
       },
       lulNum,
       TimeSpan.Zero,
@@ -189,7 +190,7 @@ internal static class BasketStationTestExtensions
         new BasketStationTransfer.UnloadFromBasket
         {
           BasketIdentity = identity,
-          Material = Material<BasketTransfer>(
+          Material = Material<PalletBasketTransfer>(
             toUnload.MaterialIDToQueue.Keys,
             toUnload.Process,
             null
@@ -203,7 +204,7 @@ internal static class BasketStationTestExtensions
         new BasketStationTransfer.LoadOntoBasket
         {
           BasketIdentity = identity,
-          Material = Material<BasketTransfer>(toLoad.MaterialIDs, toLoad.Process, null),
+          Material = Material<PalletBasketTransfer>(toLoad.MaterialIDs, toLoad.Process, null),
           ActiveOperationTime = toLoad.ActiveOperationTime,
         }
       );
@@ -238,8 +239,8 @@ internal static class BasketStationTestExtensions
 
     var foreignId =
       toUnload?.ForeignID ?? toLoad?.ForeignID ?? $"test-basket-only:{Guid.NewGuid():N}";
-    return repository.RecordBasketStationLoadUnload(
-      new BasketStationLoadUnload
+    return repository.RecordBasketStationOperation(
+      new BasketStationOperation
       {
         Transfers = transfers.ToImmutable(),
         CycleBoundaries = boundaries.ToImmutable(),
@@ -258,7 +259,7 @@ internal static class BasketStationTestExtensions
     int process,
     IEnumerable<TTransfer> completedTransfers
   )
-    where TTransfer : BasketTransfer
+    where TTransfer : PalletBasketTransfer
   {
     var ids = materialIds.ToImmutableHashSet();
     return completedTransfers
@@ -282,7 +283,7 @@ internal static class BasketStationTestExtensions
     ImmutableList<EventLogMaterial> material,
     IEnumerable<TTransfer> completedTransfers
   )
-    where TTransfer : BasketTransfer =>
+    where TTransfer : PalletBasketTransfer =>
     completedTransfers
       ?.SingleOrDefault(transfer =>
         transfer

--- a/server/test/BasketStationTestExtensions.cs
+++ b/server/test/BasketStationTestExtensions.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using BlackMaple.MachineFramework;
+
+namespace BlackMaple.FMSInsight.Tests;
+
+internal sealed record TestMaterialToLoadOntoBasket
+{
+  public required ImmutableList<long> MaterialIDs { get; init; }
+  public required int Process { get; init; }
+  public required TimeSpan ActiveOperationTime { get; init; }
+  public string ForeignID { get; init; }
+  public string OriginalMessage { get; init; }
+}
+
+internal sealed record TestMaterialToUnloadFromBasket
+{
+  public required ImmutableDictionary<long, string> MaterialIDToQueue { get; init; }
+  public required int Process { get; init; }
+  public required TimeSpan ActiveOperationTime { get; init; }
+  public string ForeignID { get; init; }
+  public string OriginalMessage { get; init; }
+}
+
+internal static class BasketStationTestExtensions
+{
+  public static IEnumerable<LogEntry> RecordTestBasketLoadUnload(
+    this IRepository repository,
+    TestMaterialToLoadOntoBasket toLoad,
+    TestMaterialToUnloadFromBasket toUnload,
+    int lulNum,
+    ContainerIdentity basketIdentity,
+    TimeSpan totalElapsed,
+    DateTime timeUTC,
+    IReadOnlyDictionary<string, string> externalQueues,
+    BasketLoadUnloadCompletion basketCompletion = null
+  ) =>
+    repository.RecordTestBasketLoadUnload(
+      toLoad is null ? [] : [toLoad],
+      toUnload is null ? [] : [toUnload],
+      lulNum,
+      basketIdentity,
+      totalElapsed,
+      timeUTC,
+      externalQueues,
+      basketCompletion
+    );
+
+  public static IEnumerable<LogEntry> RecordTestBasketLoadUnload(
+    this IRepository repository,
+    IReadOnlyList<TestMaterialToLoadOntoBasket> toLoad,
+    IReadOnlyList<TestMaterialToUnloadFromBasket> toUnload,
+    int lulNum,
+    ContainerIdentity basketIdentity,
+    TimeSpan totalElapsed,
+    DateTime timeUTC,
+    IReadOnlyDictionary<string, string> externalQueues,
+    BasketLoadUnloadCompletion basketCompletion
+  )
+  {
+    var transfers = ImmutableList.CreateBuilder<BasketStationTransfer>();
+    foreach (var unload in toUnload)
+    {
+      var material = Material(
+        unload.MaterialIDToQueue.Keys,
+        unload.Process,
+        basketCompletion?.Transfers.OfType<BasketTransfer.UnloadFromBasket>()
+      );
+      transfers.Add(
+        new BasketStationTransfer.UnloadFromBasket
+        {
+          BasketIdentity =
+            MatchingIdentity(
+              material,
+              basketCompletion?.Transfers.OfType<BasketTransfer.UnloadFromBasket>()
+            ) ?? basketIdentity,
+          Material = material,
+          ActiveOperationTime = unload.ActiveOperationTime,
+          DestinationQueue = unload.MaterialIDToQueue.Values.Distinct().SingleOrDefault(),
+        }
+      );
+    }
+    foreach (var load in toLoad)
+    {
+      var material = Material(
+        load.MaterialIDs,
+        load.Process,
+        basketCompletion?.Transfers.OfType<BasketTransfer.LoadOntoBasket>()
+      );
+      transfers.Add(
+        new BasketStationTransfer.LoadOntoBasket
+        {
+          BasketIdentity =
+            MatchingIdentity(
+              material,
+              basketCompletion?.Transfers.OfType<BasketTransfer.LoadOntoBasket>()
+            ) ?? basketIdentity,
+          Material = material,
+          ActiveOperationTime = load.ActiveOperationTime,
+        }
+      );
+    }
+
+    var operationIds = toUnload
+      .Select(unload => unload.ForeignID)
+      .Concat(toLoad.Select(load => load.ForeignID))
+      .Where(id => !string.IsNullOrWhiteSpace(id))
+      .Distinct()
+      .ToImmutableList();
+    return repository.RecordBasketStationLoadUnload(
+      new BasketStationLoadUnload
+      {
+        Transfers = transfers.ToImmutable(),
+        CycleBoundaries = basketCompletion?.CycleBoundaries ?? [],
+      },
+      lulNum,
+      totalElapsed,
+      timeUTC,
+      externalQueues,
+      operationIds.IsEmpty
+        ? $"test-basket-station:{Guid.NewGuid():N}"
+        : string.Join("|", operationIds),
+      toUnload
+        .Select(unload => unload.OriginalMessage)
+        .Concat(toLoad.Select(load => load.OriginalMessage))
+        .FirstOrDefault(message => message is not null)
+    );
+  }
+
+  public static IEnumerable<LogEntry> RecordTestBasketCompletion(
+    this IRepository repository,
+    BasketLoadUnloadCompletion basketCompletion,
+    int lulNum,
+    DateTime timeUTC,
+    string foreignId,
+    string originalMessage = null
+  ) =>
+    repository.RecordBasketStationLoadUnload(
+      new BasketStationLoadUnload
+      {
+        Transfers = basketCompletion
+          .Transfers.Select<BasketTransfer, BasketStationTransfer>(transfer =>
+            transfer switch
+            {
+              BasketTransfer.LoadOntoBasket load => new BasketStationTransfer.LoadOntoBasket
+              {
+                BasketIdentity = load.BasketIdentity,
+                Material = load.Material,
+                ActiveOperationTime = TimeSpan.Zero,
+              },
+              BasketTransfer.UnloadFromBasket unload => new BasketStationTransfer.UnloadFromBasket
+              {
+                BasketIdentity = unload.BasketIdentity,
+                Material = unload.Material,
+                ActiveOperationTime = TimeSpan.Zero,
+              },
+              _ => throw new ArgumentOutOfRangeException(nameof(basketCompletion)),
+            }
+          )
+          .ToImmutableList(),
+        CycleBoundaries = basketCompletion.CycleBoundaries,
+      },
+      lulNum,
+      TimeSpan.Zero,
+      timeUTC,
+      ImmutableDictionary<string, string>.Empty,
+      foreignId,
+      originalMessage
+    );
+
+  public static IEnumerable<LogEntry> RecordTestBasketOnlyLoadUnload(
+    this IRepository repository,
+    TestMaterialToLoadOntoBasket toLoad,
+    IReadOnlyList<EventLogMaterial> previouslyLoaded,
+    TestMaterialToUnloadFromBasket toUnload,
+    int lulNum,
+    int basketId,
+    TimeSpan totalElapsed,
+    DateTime timeUTC,
+    IReadOnlyDictionary<string, string> externalQueues
+  )
+  {
+    var identity = new ContainerIdentity.Numbered { ContainerNum = basketId };
+    var transfers = ImmutableList.CreateBuilder<BasketStationTransfer>();
+    if (toUnload is not null)
+      transfers.Add(
+        new BasketStationTransfer.UnloadFromBasket
+        {
+          BasketIdentity = identity,
+          Material = Material<BasketTransfer>(
+            toUnload.MaterialIDToQueue.Keys,
+            toUnload.Process,
+            null
+          ),
+          ActiveOperationTime = toUnload.ActiveOperationTime,
+          DestinationQueue = toUnload.MaterialIDToQueue.Values.Distinct().SingleOrDefault(),
+        }
+      );
+    if (toLoad is not null)
+      transfers.Add(
+        new BasketStationTransfer.LoadOntoBasket
+        {
+          BasketIdentity = identity,
+          Material = Material<BasketTransfer>(toLoad.MaterialIDs, toLoad.Process, null),
+          ActiveOperationTime = toLoad.ActiveOperationTime,
+        }
+      );
+
+    var boundaries = ImmutableList.CreateBuilder<BasketCycleBoundary>();
+    var lastCycle = repository
+      .CurrentBasketLog(basketId, includeLastCycleEvt: true)
+      .LastOrDefault(log => log.LogType == LogType.BasketCycle);
+    if (lastCycle?.StartOfCycle == true)
+      boundaries.Add(
+        new BasketCycleBoundary.End
+        {
+          BasketIdentity = identity,
+          Material = lastCycle.Material.Select(EventLogMaterial.FromLogMat).ToImmutableList(),
+          ReconciledBasketIdentities = [],
+        }
+      );
+    var nextContents = (previouslyLoaded ?? [])
+      .Concat(
+        toLoad?.MaterialIDs.Select(id => new EventLogMaterial
+        {
+          MaterialID = id,
+          Process = toLoad.Process,
+          Face = 0,
+        }) ?? []
+      )
+      .ToImmutableList();
+    if (!nextContents.IsEmpty)
+      boundaries.Add(
+        new BasketCycleBoundary.Start { BasketIdentity = identity, Material = nextContents }
+      );
+
+    var foreignId =
+      toUnload?.ForeignID ?? toLoad?.ForeignID ?? $"test-basket-only:{Guid.NewGuid():N}";
+    return repository.RecordBasketStationLoadUnload(
+      new BasketStationLoadUnload
+      {
+        Transfers = transfers.ToImmutable(),
+        CycleBoundaries = boundaries.ToImmutable(),
+      },
+      lulNum,
+      totalElapsed,
+      timeUTC,
+      externalQueues,
+      foreignId,
+      toUnload?.OriginalMessage ?? toLoad?.OriginalMessage
+    );
+  }
+
+  private static ImmutableList<EventLogMaterial> Material<TTransfer>(
+    IEnumerable<long> materialIds,
+    int process,
+    IEnumerable<TTransfer> completedTransfers
+  )
+    where TTransfer : BasketTransfer
+  {
+    var ids = materialIds.ToImmutableHashSet();
+    return completedTransfers
+        ?.SingleOrDefault(transfer =>
+          transfer
+            .Material.Select(material => material.MaterialID)
+            .ToImmutableHashSet()
+            .SetEquals(ids)
+        )
+        ?.Material
+      ?? ids.Select(id => new EventLogMaterial
+        {
+          MaterialID = id,
+          Process = process,
+          Face = 0,
+        })
+        .ToImmutableList();
+  }
+
+  private static ContainerIdentity MatchingIdentity<TTransfer>(
+    ImmutableList<EventLogMaterial> material,
+    IEnumerable<TTransfer> completedTransfers
+  )
+    where TTransfer : BasketTransfer =>
+    completedTransfers
+      ?.SingleOrDefault(transfer =>
+        transfer
+          .Material.Select(item => item.MaterialID)
+          .ToImmutableHashSet()
+          .SetEquals(material.Select(item => item.MaterialID))
+      )
+      ?.BasketIdentity;
+}

--- a/server/test/ContainerIdentitySpec.cs
+++ b/server/test/ContainerIdentitySpec.cs
@@ -132,6 +132,175 @@ public sealed class ContainerIdentitySpec : IDisposable
   }
 
   [Test]
+  public async Task InvalidatedUuidBasketEventsAreNotCurrentOrOpen()
+  {
+    var time = new DateTime(2026, 7, 27, 10, 0, 0, DateTimeKind.Utc);
+    var id = Guid.NewGuid();
+    var identity = new ContainerIdentity.Uuid { ContainerId = id };
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 1);
+    QueueMaterial(repository, materialId, "raw", time);
+    repository.RecordBasketStationOperation(
+      LoadOntoBasketOperation(identity, materialId),
+      lulNum: 2,
+      totalElapsed: TimeSpan.FromMinutes(1),
+      timeUTC: time.AddMinutes(1),
+      externalQueues: ImmutableDictionary<string, string>.Empty,
+      foreignId: "uuid-initial-load"
+    );
+
+    repository.InvalidatePalletCycle(materialId, process: 1, "operator", time.AddMinutes(2));
+
+    await Assert.That(repository.CurrentBasketLog(identity)).IsEmpty();
+    await Assert.That(repository.GetUnresolvedOpenBasketContainerIds()).DoesNotContain(id);
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketCycleEnd(
+        basketId: 7,
+        mats:
+        [
+          new EventLogMaterial
+          {
+            MaterialID = materialId,
+            Process = 1,
+            Face = 0,
+          },
+        ],
+        containerIds: ImmutableHashSet.Create(id),
+        timeUTC: time.AddMinutes(3),
+        foreignId: "invalidated-uuid-finalization"
+      )
+    );
+  }
+
+  [Test]
+  public async Task InvalidatedHintedUuidEventsDoNotLeakIntoNumberedBasket()
+  {
+    var time = new DateTime(2026, 7, 27, 10, 30, 0, DateTimeKind.Utc);
+    var id = Guid.NewGuid();
+    var uuidIdentity = new ContainerIdentity.Uuid { ContainerId = id };
+    var numberedIdentity = new ContainerIdentity.Numbered { ContainerNum = 8 };
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 1);
+    QueueMaterial(repository, materialId, "raw", time);
+    repository.RecordBasketStationOperation(
+      LoadOntoBasketOperation(uuidIdentity, materialId),
+      lulNum: 2,
+      totalElapsed: TimeSpan.FromMinutes(1),
+      timeUTC: time.AddMinutes(1),
+      externalQueues: ImmutableDictionary<string, string>.Empty,
+      foreignId: "hinted-uuid-load"
+    );
+    repository.RecordBasketIdentityHint(id, 8, time.AddMinutes(2));
+
+    repository.InvalidatePalletCycle(materialId, process: 1, "operator", time.AddMinutes(3));
+
+    await Assert
+      .That(repository.CurrentBasketLog(uuidIdentity).Select(log => log.LogType))
+      .IsEquivalentTo([LogType.BasketIdentityHint]);
+    await Assert
+      .That(repository.CurrentBasketLog(numberedIdentity).Select(log => log.LogType))
+      .IsEquivalentTo([LogType.BasketIdentityHint]);
+  }
+
+  [Test]
+  public async Task ExplicitBasketEndRejectsInvalidatedStart()
+  {
+    var time = new DateTime(2026, 7, 27, 11, 0, 0, DateTimeKind.Utc);
+    var identity = new ContainerIdentity.Numbered { ContainerNum = 5 };
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 1);
+    QueueMaterial(repository, materialId, "raw", time);
+    repository.RecordBasketStationOperation(
+      LoadOntoBasketOperation(identity, materialId),
+      lulNum: 2,
+      totalElapsed: TimeSpan.FromMinutes(1),
+      timeUTC: time.AddMinutes(1),
+      externalQueues: ImmutableDictionary<string, string>.Empty,
+      foreignId: "numbered-initial-load"
+    );
+    repository.InvalidatePalletCycle(materialId, process: 1, "operator", time.AddMinutes(2));
+
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketStationOperation(
+        new BasketStationOperation
+        {
+          Transfers = [],
+          CycleBoundaries =
+          [
+            new BasketCycleBoundary.End
+            {
+              BasketIdentity = identity,
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = materialId,
+                  Process = 1,
+                  Face = 0,
+                },
+              ],
+              ReconciledBasketIdentities = [],
+            },
+          ],
+        },
+        lulNum: 2,
+        totalElapsed: TimeSpan.Zero,
+        timeUTC: time.AddMinutes(3),
+        externalQueues: ImmutableDictionary<string, string>.Empty,
+        foreignId: "invalidated-numbered-end"
+      )
+    );
+    await Assert.That(repository.CurrentBasketLog(5, includeLastCycleEvt: true)).IsEmpty();
+  }
+
+  [Test]
+  public async Task InvalidatedBasketMaterialCanBeRescannedAndLoadedAsFreshProcess()
+  {
+    var time = new DateTime(2026, 7, 27, 12, 0, 0, DateTimeKind.Utc);
+    var identity = new ContainerIdentity.Numbered { ContainerNum = 6 };
+    using var repository = _repositoryConfig.OpenConnection();
+    var materialId = repository.AllocateMaterialID("job", "part", 1);
+    QueueMaterial(repository, materialId, "raw", time);
+    repository.RecordBasketStationOperation(
+      LoadOntoBasketOperation(identity, materialId),
+      lulNum: 2,
+      totalElapsed: TimeSpan.FromMinutes(1),
+      timeUTC: time.AddMinutes(1),
+      externalQueues: ImmutableDictionary<string, string>.Empty,
+      foreignId: "first-attempt"
+    );
+    repository.InvalidatePalletCycle(materialId, process: 1, "operator", time.AddMinutes(2));
+
+    QueueMaterial(repository, materialId, "rework", time.AddMinutes(3), "operator", "Rescan");
+    var freshLogs = repository
+      .RecordBasketStationOperation(
+        LoadOntoBasketOperation(identity, materialId),
+        lulNum: 2,
+        totalElapsed: TimeSpan.FromMinutes(2),
+        timeUTC: time.AddMinutes(4),
+        externalQueues: ImmutableDictionary<string, string>.Empty,
+        foreignId: "second-attempt"
+      )
+      .Where(log => log.LogType is LogType.BasketLoadUnload or LogType.BasketCycle)
+      .ToImmutableList();
+
+    await Assert.That(freshLogs).Count().IsEqualTo(2);
+    await Assert
+      .That(
+        repository
+          .GetLogForMaterial(materialId, includeInvalidatedCycles: false)
+          .Where(log => log.LogType is LogType.BasketLoadUnload or LogType.BasketCycle)
+          .Select(log => log.Counter)
+      )
+      .IsEquivalentTo(freshLogs.Select(log => log.Counter));
+    await Assert.That(repository.NextProcessForQueuedMaterial(materialId)).IsEqualTo(2);
+    await Assert.That(repository.GetMaterialInAllQueues()).IsEmpty();
+    await Assert
+      .That(repository.CurrentBasketLog(identity, includeLastCycleEvt: true).Single().Counter)
+      .IsEqualTo(freshLogs.Single(log => log.LogType == LogType.BasketCycle).Counter);
+  }
+
+  [Test]
   public async Task BasketStationOperationRecordsEachTransferOnceBeforeItsBoundary()
   {
     using var repository = _repositoryConfig.OpenConnection();
@@ -1949,4 +2118,67 @@ public sealed class ContainerIdentitySpec : IDisposable
     }
     await Assert.That(exception).IsTypeOf<TException>();
   }
+
+  private static BasketStationOperation LoadOntoBasketOperation(
+    ContainerIdentity identity,
+    long materialId
+  ) =>
+    new()
+    {
+      Transfers =
+      [
+        new BasketStationTransfer.LoadOntoBasket
+        {
+          BasketIdentity = identity,
+          Material =
+          [
+            new EventLogMaterial
+            {
+              MaterialID = materialId,
+              Process = 1,
+              Face = 0,
+            },
+          ],
+          ActiveOperationTime = TimeSpan.FromMinutes(1),
+        },
+      ],
+      CycleBoundaries =
+      [
+        new BasketCycleBoundary.Start
+        {
+          BasketIdentity = identity,
+          Material =
+          [
+            new EventLogMaterial
+            {
+              MaterialID = materialId,
+              Process = 1,
+              Face = 0,
+            },
+          ],
+        },
+      ],
+    };
+
+  private static void QueueMaterial(
+    IRepository repository,
+    long materialId,
+    string queue,
+    DateTime time,
+    string operatorName = null,
+    string reason = null
+  ) =>
+    repository.RecordAddMaterialToQueue(
+      new EventLogMaterial
+      {
+        MaterialID = materialId,
+        Process = 0,
+        Face = 0,
+      },
+      queue,
+      -1,
+      operatorName,
+      reason,
+      time
+    );
 }

--- a/server/test/ContainerIdentitySpec.cs
+++ b/server/test/ContainerIdentitySpec.cs
@@ -132,7 +132,7 @@ public sealed class ContainerIdentitySpec : IDisposable
   }
 
   [Test]
-  public async Task BasketStationCompletionRecordsEachTransferOnceBeforeItsBoundary()
+  public async Task BasketStationOperationRecordsEachTransferOnceBeforeItsBoundary()
   {
     using var repository = _repositoryConfig.OpenConnection();
     var unloadedMaterialId = repository.AllocateMaterialID("job", "part", 2);
@@ -151,11 +151,11 @@ public sealed class ContainerIdentitySpec : IDisposable
       DateTime.UtcNow
     );
     var basketIdentity = new ContainerIdentity.Numbered { ContainerNum = 5 };
-    var completion = new BasketLoadUnloadCompletion
+    var completion = new PalletBasketLoadUnloadCompletion
     {
       Transfers =
       [
-        new BasketTransfer.UnloadFromBasket
+        new PalletBasketTransfer.UnloadFromBasket
         {
           BasketIdentity = basketIdentity,
           Material =
@@ -168,7 +168,7 @@ public sealed class ContainerIdentitySpec : IDisposable
             },
           ],
         },
-        new BasketTransfer.LoadOntoBasket
+        new PalletBasketTransfer.LoadOntoBasket
         {
           BasketIdentity = basketIdentity,
           Material =
@@ -240,7 +240,7 @@ public sealed class ContainerIdentitySpec : IDisposable
         totalElapsed: TimeSpan.FromMinutes(2),
         timeUTC: DateTime.UtcNow,
         externalQueues: ImmutableDictionary<string, string>.Empty,
-        basketCompletion: completion
+        palletBasketCompletion: completion
       )
       .ToImmutableList();
     var retry = repository
@@ -252,7 +252,7 @@ public sealed class ContainerIdentitySpec : IDisposable
         totalElapsed: TimeSpan.FromMinutes(2),
         timeUTC: DateTime.UtcNow.AddMinutes(1),
         externalQueues: ImmutableDictionary<string, string>.Empty,
-        basketCompletion: completion
+        palletBasketCompletion: completion
       )
       .ToImmutableList();
 
@@ -322,7 +322,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       time.AddMinutes(-5)
     );
 
-    BasketStationLoadUnload Operation(
+    BasketStationOperation Operation(
       string destinationQueue = "outgoing",
       TimeSpan? loadActive = null
     ) =>
@@ -358,7 +358,6 @@ public sealed class ContainerIdentitySpec : IDisposable
               },
             ],
             ActiveOperationTime = loadActive ?? TimeSpan.FromSeconds(30),
-            SourceQueue = "incoming",
           },
         ],
         CycleBoundaries =
@@ -393,8 +392,14 @@ public sealed class ContainerIdentitySpec : IDisposable
         ],
       };
 
+    var earlierSharedId = repository.RecordGeneralMessage(
+      mats: [],
+      program: "Earlier",
+      result: "",
+      foreignId: "different-identity-turnover"
+    );
     var first = repository
-      .RecordBasketStationLoadUnload(
+      .RecordBasketStationOperation(
         Operation(),
         lulNum: 4,
         totalElapsed: TimeSpan.FromMinutes(2),
@@ -404,8 +409,14 @@ public sealed class ContainerIdentitySpec : IDisposable
         originalMessage: "confirmed work"
       )
       .ToImmutableList();
+    var laterSharedId = repository.RecordGeneralMessage(
+      mats: [],
+      program: "Later",
+      result: "",
+      foreignId: "different-identity-turnover"
+    );
     var retry = repository
-      .RecordBasketStationLoadUnload(
+      .RecordBasketStationOperation(
         Operation(),
         lulNum: 4,
         totalElapsed: TimeSpan.FromMinutes(2),
@@ -428,11 +439,21 @@ public sealed class ContainerIdentitySpec : IDisposable
         }
       );
     await Assert.That(first.Select(log => log.EndTimeUTC).Distinct()).Count().IsEqualTo(1);
+    var unload = first.Single(log => log.Program == "UNLOAD");
+    var load = first.Single(log => log.Program == "LOAD");
+    await Assert.That(unload.ActiveOperationTime).IsEqualTo(TimeSpan.FromSeconds(20));
+    await Assert.That(unload.ElapsedTime).IsEqualTo(TimeSpan.FromSeconds(48));
+    await Assert.That(load.ActiveOperationTime).IsEqualTo(TimeSpan.FromSeconds(30));
+    await Assert.That(load.ElapsedTime).IsEqualTo(TimeSpan.FromSeconds(72));
     await Assert
       .That(retry.Select(log => log.Counter).SequenceEqual(first.Select(log => log.Counter)))
       .IsTrue();
+    await Assert
+      .That(retry.Select(log => log.Counter))
+      .DoesNotContain(earlierSharedId.Counter)
+      .And.DoesNotContain(laterSharedId.Counter);
     await AssertThrows<ConflictRequestException>(() =>
-      repository.RecordBasketStationLoadUnload(
+      repository.RecordBasketStationOperation(
         Operation(destinationQueue: "changed"),
         4,
         TimeSpan.FromMinutes(2),
@@ -443,7 +464,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
     );
     await AssertThrows<ConflictRequestException>(() =>
-      repository.RecordBasketStationLoadUnload(
+      repository.RecordBasketStationOperation(
         Operation(loadActive: TimeSpan.FromSeconds(31)),
         4,
         TimeSpan.FromMinutes(2),
@@ -454,7 +475,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
     );
     await AssertThrows<ConflictRequestException>(() =>
-      repository.RecordBasketStationLoadUnload(
+      repository.RecordBasketStationOperation(
         Operation(),
         4,
         TimeSpan.FromMinutes(3),
@@ -465,7 +486,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
     );
     await AssertThrows<ConflictRequestException>(() =>
-      repository.RecordBasketStationLoadUnload(
+      repository.RecordBasketStationOperation(
         Operation(),
         4,
         TimeSpan.FromMinutes(2),
@@ -478,7 +499,74 @@ public sealed class ContainerIdentitySpec : IDisposable
   }
 
   [Test]
-  public async Task BasketStationCompletionRollsBackAndRetryIsIdempotent()
+  public async Task BasketStationElapsedFallsBackToPerMaterialWeightsWhenActiveTimeIsMissing()
+  {
+    using var repository = _repositoryConfig.OpenConnection();
+    var firstUnload = repository.AllocateMaterialID("job", "part", 1);
+    var secondUnload = repository.AllocateMaterialID("job", "part", 1);
+    var loadMaterial = repository.AllocateMaterialID("job", "part", 1);
+
+    var logs = repository
+      .RecordBasketStationOperation(
+        new BasketStationOperation
+        {
+          Transfers =
+          [
+            new BasketStationTransfer.UnloadFromBasket
+            {
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 8 },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = firstUnload,
+                  Process = 1,
+                  Face = 0,
+                },
+                new EventLogMaterial
+                {
+                  MaterialID = secondUnload,
+                  Process = 1,
+                  Face = 0,
+                },
+              ],
+              ActiveOperationTime = TimeSpan.FromSeconds(20),
+            },
+            new BasketStationTransfer.LoadOntoBasket
+            {
+              BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 8 },
+              Material =
+              [
+                new EventLogMaterial
+                {
+                  MaterialID = loadMaterial,
+                  Process = 1,
+                  Face = 0,
+                },
+              ],
+              ActiveOperationTime = TimeSpan.Zero,
+            },
+          ],
+          CycleBoundaries = [],
+        },
+        lulNum: 4,
+        totalElapsed: TimeSpan.FromMinutes(2),
+        DateTime.UtcNow,
+        externalQueues: ImmutableDictionary<string, string>.Empty,
+        foreignId: "missing-active-time"
+      )
+      .ToImmutableList();
+
+    var unload = logs.Single(log => log.Program == "UNLOAD");
+    var load = logs.Single(log => log.Program == "LOAD");
+    await Assert.That(unload.ActiveOperationTime).IsEqualTo(TimeSpan.FromSeconds(20));
+    await Assert.That(unload.ElapsedTime).IsEqualTo(TimeSpan.FromSeconds(80));
+    await Assert.That(load.ActiveOperationTime).IsEqualTo(TimeSpan.Zero);
+    await Assert.That(load.ElapsedTime).IsEqualTo(TimeSpan.FromSeconds(40));
+  }
+
+  [Test]
+  public async Task BasketStationOperationRollsBackAndRetryIsIdempotent()
   {
     using var repository = _repositoryConfig.OpenConnection();
     var materialId = repository.AllocateMaterialID("job", "part", 1);
@@ -504,11 +592,11 @@ public sealed class ContainerIdentitySpec : IDisposable
       ForeignID = "retry-basket-station-load",
       OriginalMessage = "robot completion",
     };
-    var completion = new BasketLoadUnloadCompletion
+    var completion = new PalletBasketLoadUnloadCompletion
     {
       Transfers =
       [
-        new BasketTransfer.LoadOntoBasket
+        new PalletBasketTransfer.LoadOntoBasket
         {
           BasketIdentity = basketIdentity,
           Material =
@@ -618,7 +706,7 @@ public sealed class ContainerIdentitySpec : IDisposable
   }
 
   [Test]
-  public async Task MultiProcessBasketStationCompletionIsOrderedAtomicAndIdempotent()
+  public async Task MultiProcessBasketStationOperationIsOrderedAtomicAndIdempotent()
   {
     using var repository = _repositoryConfig.OpenConnection();
     var unloadProcessOne = repository.AllocateMaterialID("job", "part", 3);
@@ -690,26 +778,26 @@ public sealed class ContainerIdentitySpec : IDisposable
         ForeignID = "multi-load-three",
       },
     };
-    var completion = new BasketLoadUnloadCompletion
+    var completion = new PalletBasketLoadUnloadCompletion
     {
       Transfers =
       [
-        new BasketTransfer.UnloadFromBasket
+        new PalletBasketTransfer.UnloadFromBasket
         {
           BasketIdentity = basketIdentity,
           Material = Material(unloadProcessOne, 1, 0),
         },
-        new BasketTransfer.UnloadFromBasket
+        new PalletBasketTransfer.UnloadFromBasket
         {
           BasketIdentity = basketIdentity,
           Material = Material(unloadProcessTwo, 2, 0),
         },
-        new BasketTransfer.LoadOntoBasket
+        new PalletBasketTransfer.LoadOntoBasket
         {
           BasketIdentity = basketIdentity,
           Material = Material(loadProcessTwo, 2, 0),
         },
-        new BasketTransfer.LoadOntoBasket
+        new PalletBasketTransfer.LoadOntoBasket
         {
           BasketIdentity = basketIdentity,
           Material = Material(loadProcessThree, 3, 0),
@@ -849,11 +937,11 @@ public sealed class ContainerIdentitySpec : IDisposable
       }
     );
 
-    var completion = new BasketLoadUnloadCompletion
+    var completion = new PalletBasketLoadUnloadCompletion
     {
       Transfers =
       [
-        new BasketTransfer.LoadOntoBasket
+        new PalletBasketTransfer.LoadOntoBasket
         {
           BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
           Material = [completeContents[1]],
@@ -869,7 +957,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       ],
     };
     var logs = repository
-      .RecordTestBasketCompletion(
+      .RecordTestPalletBasketCompletion(
         completion,
         lulNum: 4,
         timeUTC: completionTime,
@@ -904,7 +992,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
       .IsEquivalentTo(new[] { (existingMaterialId, 2, 3), (loadedMaterialId, 2, 7) });
     var retry = repository
-      .RecordTestBasketCompletion(
+      .RecordTestPalletBasketCompletion(
         completion,
         lulNum: 4,
         timeUTC: completionTime.AddMinutes(1),
@@ -916,7 +1004,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       .That(retry.Select(log => log.Counter))
       .IsEquivalentTo(logs.Select(log => log.Counter));
     await AssertThrows<ConflictRequestException>(() =>
-      repository.RecordTestBasketCompletion(
+      repository.RecordTestPalletBasketCompletion(
         completion,
         lulNum: 4,
         timeUTC: completionTime,
@@ -968,12 +1056,12 @@ public sealed class ContainerIdentitySpec : IDisposable
     }
 
     await AssertThrows<SqliteException>(() =>
-      repository.RecordTestBasketCompletion(
-        new BasketLoadUnloadCompletion
+      repository.RecordTestPalletBasketCompletion(
+        new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.LoadOntoBasket
+            new PalletBasketTransfer.LoadOntoBasket
             {
               BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
               Material =
@@ -1050,16 +1138,16 @@ public sealed class ContainerIdentitySpec : IDisposable
       firstEvidenceTime.AddMinutes(1),
       foreignId: "second-fragment"
     );
-    var completion = new BasketLoadUnloadCompletion
+    var completion = new PalletBasketLoadUnloadCompletion
     {
       Transfers =
       [
-        new BasketTransfer.UnloadFromBasket
+        new PalletBasketTransfer.UnloadFromBasket
         {
           BasketIdentity = new ContainerIdentity.Uuid { ContainerId = first },
           Material = firstContents,
         },
-        new BasketTransfer.UnloadFromBasket
+        new PalletBasketTransfer.UnloadFromBasket
         {
           BasketIdentity = new ContainerIdentity.Uuid { ContainerId = second },
           Material = secondContents,
@@ -1077,7 +1165,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     };
 
     var logs = repository
-      .RecordTestBasketCompletion(
+      .RecordTestPalletBasketCompletion(
         completion,
         lulNum: 3,
         timeUTC: firstEvidenceTime.AddMinutes(10),
@@ -1085,7 +1173,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
       .ToImmutableList();
     var retry = repository
-      .RecordTestBasketCompletion(
+      .RecordTestPalletBasketCompletion(
         completion,
         lulNum: 3,
         timeUTC: firstEvidenceTime.AddMinutes(11),
@@ -1117,7 +1205,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       new ContainerIdentity.Uuid { ContainerId = fragment },
       DateTime.UtcNow
     );
-    var completion = new BasketLoadUnloadCompletion
+    var completion = new PalletBasketLoadUnloadCompletion
     {
       Transfers = [],
       CycleBoundaries =
@@ -1131,7 +1219,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       ],
     };
 
-    repository.RecordTestBasketCompletion(
+    repository.RecordTestPalletBasketCompletion(
       completion,
       lulNum: 3,
       timeUTC: DateTime.UtcNow,
@@ -1139,7 +1227,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     );
 
     await AssertThrows<ConflictRequestException>(() =>
-      repository.RecordTestBasketCompletion(
+      repository.RecordTestPalletBasketCompletion(
         completion,
         lulNum: 3,
         timeUTC: DateTime.UtcNow,
@@ -1157,12 +1245,12 @@ public sealed class ContainerIdentitySpec : IDisposable
     var unrelatedMaterial = repository.AllocateMaterialID("job", "part", 1);
 
     await AssertThrows<ArgumentException>(() =>
-      repository.RecordTestBasketCompletion(
-        new BasketLoadUnloadCompletion
+      repository.RecordTestPalletBasketCompletion(
+        new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.UnloadFromBasket
+            new PalletBasketTransfer.UnloadFromBasket
             {
               BasketIdentity = new ContainerIdentity.Uuid { ContainerId = fragment },
               Material =
@@ -1203,7 +1291,7 @@ public sealed class ContainerIdentitySpec : IDisposable
   }
 
   [Test]
-  public async Task PartialPalletUnloadAcceptsExplicitUuidBasketTransferWithoutStartingCycle()
+  public async Task PartialPalletUnloadAcceptsExplicitUuidPalletBasketTransferWithoutStartingCycle()
   {
     var basketId = Guid.NewGuid();
     using var repository = _repositoryConfig.OpenConnection();
@@ -1230,11 +1318,11 @@ public sealed class ContainerIdentitySpec : IDisposable
         totalElapsed: TimeSpan.Zero,
         timeUTC: DateTime.UtcNow,
         externalQueues: ImmutableDictionary<string, string>.Empty,
-        basketCompletion: new BasketLoadUnloadCompletion
+        palletBasketCompletion: new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.LoadOntoBasket
+            new PalletBasketTransfer.LoadOntoBasket
             {
               BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
               Material =
@@ -1263,7 +1351,7 @@ public sealed class ContainerIdentitySpec : IDisposable
   }
 
   [Test]
-  public async Task PartialPalletUnloadRejectsBasketTransferForDifferentProcess()
+  public async Task PartialPalletUnloadRejectsPalletBasketTransferForDifferentProcess()
   {
     var basketId = Guid.NewGuid();
     using var repository = _repositoryConfig.OpenConnection();
@@ -1290,11 +1378,11 @@ public sealed class ContainerIdentitySpec : IDisposable
         totalElapsed: TimeSpan.Zero,
         timeUTC: DateTime.UtcNow,
         externalQueues: ImmutableDictionary<string, string>.Empty,
-        basketCompletion: new BasketLoadUnloadCompletion
+        palletBasketCompletion: new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.LoadOntoBasket
+            new PalletBasketTransfer.LoadOntoBasket
             {
               BasketIdentity = new ContainerIdentity.Uuid { ContainerId = basketId },
               Material =
@@ -1324,12 +1412,12 @@ public sealed class ContainerIdentitySpec : IDisposable
     var identity = new ContainerIdentity.Uuid { ContainerId = basketId };
 
     await AssertThrows<ArgumentException>(() =>
-      repository.RecordTestBasketCompletion(
-        new BasketLoadUnloadCompletion
+      repository.RecordTestPalletBasketCompletion(
+        new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.LoadOntoBasket
+            new PalletBasketTransfer.LoadOntoBasket
             {
               BasketIdentity = identity,
               Material =
@@ -1369,7 +1457,7 @@ public sealed class ContainerIdentitySpec : IDisposable
   }
 
   [Test]
-  public async Task PalletUnloadWithoutQueueRequiresMatchingBasketTransfer()
+  public async Task PalletUnloadWithoutQueueRequiresMatchingPalletBasketTransfer()
   {
     using var repository = _repositoryConfig.OpenConnection();
     var materialId = repository.AllocateMaterialID("job", "part", 1);

--- a/server/test/ContainerIdentitySpec.cs
+++ b/server/test/ContainerIdentitySpec.cs
@@ -110,8 +110,8 @@ public sealed class ContainerIdentitySpec : IDisposable
     using var repository = _repositoryConfig.OpenConnection();
     var materialId = repository.AllocateMaterialID("job", "part", 1);
     var logs = repository
-      .RecordBasketLoadUnload(
-        new MaterialToLoadOntoBasket
+      .RecordTestBasketLoadUnload(
+        new TestMaterialToLoadOntoBasket
         {
           MaterialIDs = [materialId],
           Process = 1,
@@ -196,7 +196,7 @@ public sealed class ContainerIdentitySpec : IDisposable
               Face = 4,
             },
           ],
-          ContainerIds = [],
+          ReconciledBasketIdentities = [],
         },
         new BasketCycleBoundary.Start
         {
@@ -213,14 +213,14 @@ public sealed class ContainerIdentitySpec : IDisposable
         },
       ],
     };
-    var toLoad = new MaterialToLoadOntoBasket
+    var toLoad = new TestMaterialToLoadOntoBasket
     {
       MaterialIDs = [loadedMaterialId],
       Process = 2,
       ActiveOperationTime = TimeSpan.FromMinutes(1),
       ForeignID = "basket-station-load",
     };
-    var toUnload = new MaterialToUnloadFromBasket
+    var toUnload = new TestMaterialToUnloadFromBasket
     {
       MaterialIDToQueue = ImmutableDictionary<long, string>.Empty.Add(
         unloadedMaterialId,
@@ -232,7 +232,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     };
 
     var logs = repository
-      .RecordBasketLoadUnload(
+      .RecordTestBasketLoadUnload(
         toLoad,
         toUnload,
         lulNum: 4,
@@ -244,7 +244,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
       .ToImmutableList();
     var retry = repository
-      .RecordBasketLoadUnload(
+      .RecordTestBasketLoadUnload(
         toLoad,
         toUnload,
         lulNum: 4,
@@ -287,66 +287,194 @@ public sealed class ContainerIdentitySpec : IDisposable
   }
 
   [Test]
-  public async Task BasketStationCompletionRejectsTransferIdentityAndMaterialMismatch()
+  public async Task BasketStationTurnoverSupportsDifferentIdentitiesAndCompleteRetryFingerprint()
   {
     using var repository = _repositoryConfig.OpenConnection();
-    var materialId = repository.AllocateMaterialID("job", "part", 1);
-    var basketIdentity = new ContainerIdentity.Uuid { ContainerId = Guid.NewGuid() };
-    var toLoad = new MaterialToLoadOntoBasket
-    {
-      MaterialIDs = [materialId],
-      Process = 1,
-      ActiveOperationTime = TimeSpan.Zero,
-      ForeignID = "invalid-basket-station-load",
-    };
+    var unloadedMaterialId = repository.AllocateMaterialID("job", "part", 2);
+    var loadedMaterialId = repository.AllocateMaterialID("job", "part", 2);
+    var unloadIdentity = new ContainerIdentity.Uuid { ContainerId = Guid.NewGuid() };
+    var loadIdentity = new ContainerIdentity.Uuid { ContainerId = Guid.NewGuid() };
+    var time = new DateTime(2026, 7, 27, 12, 0, 0, DateTimeKind.Utc);
+    repository.RecordBasketContentSnapshot(
+      [
+        new EventLogMaterial
+        {
+          MaterialID = unloadedMaterialId,
+          Process = 1,
+          Face = 2,
+        },
+      ],
+      unloadIdentity,
+      time.AddMinutes(-10)
+    );
+    repository.RecordBasketContentSnapshot([], loadIdentity, time.AddMinutes(-1));
+    repository.RecordAddMaterialToQueue(
+      new EventLogMaterial
+      {
+        MaterialID = loadedMaterialId,
+        Process = 1,
+        Face = 0,
+      },
+      "incoming",
+      -1,
+      operatorName: null,
+      reason: null,
+      time.AddMinutes(-5)
+    );
 
-    BasketLoadUnloadCompletion Completion(ContainerIdentity identity, long transferredMaterialId) =>
+    BasketStationLoadUnload Operation(
+      string destinationQueue = "outgoing",
+      TimeSpan? loadActive = null
+    ) =>
       new()
       {
         Transfers =
         [
-          new BasketTransfer.LoadOntoBasket
+          new BasketStationTransfer.UnloadFromBasket
           {
-            BasketIdentity = identity,
+            BasketIdentity = unloadIdentity,
             Material =
             [
               new EventLogMaterial
               {
-                MaterialID = transferredMaterialId,
+                MaterialID = unloadedMaterialId,
                 Process = 1,
-                Face = 0,
+                Face = 2,
+              },
+            ],
+            ActiveOperationTime = TimeSpan.FromSeconds(20),
+            DestinationQueue = destinationQueue,
+          },
+          new BasketStationTransfer.LoadOntoBasket
+          {
+            BasketIdentity = loadIdentity,
+            Material =
+            [
+              new EventLogMaterial
+              {
+                MaterialID = loadedMaterialId,
+                Process = 2,
+                Face = 7,
+              },
+            ],
+            ActiveOperationTime = loadActive ?? TimeSpan.FromSeconds(30),
+            SourceQueue = "incoming",
+          },
+        ],
+        CycleBoundaries =
+        [
+          new BasketCycleBoundary.End
+          {
+            BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 5 },
+            Material =
+            [
+              new EventLogMaterial
+              {
+                MaterialID = unloadedMaterialId,
+                Process = 1,
+                Face = 2,
+              },
+            ],
+            ReconciledBasketIdentities = [unloadIdentity.ContainerId],
+          },
+          new BasketCycleBoundary.Start
+          {
+            BasketIdentity = loadIdentity,
+            Material =
+            [
+              new EventLogMaterial
+              {
+                MaterialID = loadedMaterialId,
+                Process = 2,
+                Face = 7,
               },
             ],
           },
         ],
-        CycleBoundaries = [],
       };
 
-    await AssertThrows<ArgumentException>(() =>
-      repository.RecordBasketLoadUnload(
-        toLoad,
-        toUnload: null,
-        lulNum: 1,
-        basketIdentity,
-        TimeSpan.Zero,
-        DateTime.UtcNow,
+    var first = repository
+      .RecordBasketStationLoadUnload(
+        Operation(),
+        lulNum: 4,
+        totalElapsed: TimeSpan.FromMinutes(2),
+        time,
         ImmutableDictionary<string, string>.Empty,
-        Completion(new ContainerIdentity.Uuid { ContainerId = Guid.NewGuid() }, materialId)
+        foreignId: "different-identity-turnover",
+        originalMessage: "confirmed work"
+      )
+      .ToImmutableList();
+    var retry = repository
+      .RecordBasketStationLoadUnload(
+        Operation(),
+        lulNum: 4,
+        totalElapsed: TimeSpan.FromMinutes(2),
+        time.AddMinutes(1),
+        ImmutableDictionary<string, string>.Empty,
+        foreignId: "different-identity-turnover",
+        originalMessage: "confirmed work"
+      )
+      .ToImmutableList();
+
+    await Assert
+      .That(first.Select(log => log.Identity))
+      .IsEquivalentTo(
+        new ContainerIdentity[]
+        {
+          unloadIdentity,
+          new ContainerIdentity.Numbered { ContainerNum = 5 },
+          loadIdentity,
+          loadIdentity,
+        }
+      );
+    await Assert.That(first.Select(log => log.EndTimeUTC).Distinct()).Count().IsEqualTo(1);
+    await Assert
+      .That(retry.Select(log => log.Counter).SequenceEqual(first.Select(log => log.Counter)))
+      .IsTrue();
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketStationLoadUnload(
+        Operation(destinationQueue: "changed"),
+        4,
+        TimeSpan.FromMinutes(2),
+        time,
+        ImmutableDictionary<string, string>.Empty,
+        "different-identity-turnover",
+        "confirmed work"
       )
     );
-    await AssertThrows<ArgumentException>(() =>
-      repository.RecordBasketLoadUnload(
-        toLoad,
-        toUnload: null,
-        lulNum: 1,
-        basketIdentity,
-        TimeSpan.Zero,
-        DateTime.UtcNow,
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketStationLoadUnload(
+        Operation(loadActive: TimeSpan.FromSeconds(31)),
+        4,
+        TimeSpan.FromMinutes(2),
+        time,
         ImmutableDictionary<string, string>.Empty,
-        Completion(basketIdentity, materialId + 1)
+        "different-identity-turnover",
+        "confirmed work"
       )
     );
-    await Assert.That(repository.GetRecentLog(0)).IsEmpty();
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketStationLoadUnload(
+        Operation(),
+        4,
+        TimeSpan.FromMinutes(3),
+        time,
+        ImmutableDictionary<string, string>.Empty,
+        "different-identity-turnover",
+        "confirmed work"
+      )
+    );
+    await AssertThrows<ConflictRequestException>(() =>
+      repository.RecordBasketStationLoadUnload(
+        Operation(),
+        4,
+        TimeSpan.FromMinutes(2),
+        time,
+        ImmutableDictionary<string, string>.Empty.Add("outgoing", "https://example.invalid"),
+        "different-identity-turnover",
+        "confirmed work"
+      )
+    );
   }
 
   [Test]
@@ -368,7 +496,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       DateTime.UtcNow
     );
     var basketIdentity = new ContainerIdentity.Uuid { ContainerId = Guid.NewGuid() };
-    var toLoad = new MaterialToLoadOntoBasket
+    var toLoad = new TestMaterialToLoadOntoBasket
     {
       MaterialIDs = [materialId],
       Process = 1,
@@ -423,7 +551,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     }
 
     await AssertThrows<SqliteException>(() =>
-      repository.RecordBasketLoadUnload(
+      repository.RecordTestBasketLoadUnload(
         toLoad,
         toUnload: null,
         lulNum: 2,
@@ -449,7 +577,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       dropTrigger.ExecuteNonQuery();
     }
     var first = repository
-      .RecordBasketLoadUnload(
+      .RecordTestBasketLoadUnload(
         toLoad,
         toUnload: null,
         lulNum: 2,
@@ -461,7 +589,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
       .ToImmutableList();
     var retry = repository
-      .RecordBasketLoadUnload(
+      .RecordTestBasketLoadUnload(
         toLoad,
         toUnload: null,
         lulNum: 2,
@@ -524,7 +652,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       ];
     var toUnload = new[]
     {
-      new MaterialToUnloadFromBasket
+      new TestMaterialToUnloadFromBasket
       {
         MaterialIDToQueue = ImmutableDictionary<long, string>.Empty.Add(
           unloadProcessOne,
@@ -534,7 +662,7 @@ public sealed class ContainerIdentitySpec : IDisposable
         ActiveOperationTime = TimeSpan.FromSeconds(10),
         ForeignID = "multi-unload-one",
       },
-      new MaterialToUnloadFromBasket
+      new TestMaterialToUnloadFromBasket
       {
         MaterialIDToQueue = ImmutableDictionary<long, string>.Empty.Add(
           unloadProcessTwo,
@@ -547,14 +675,14 @@ public sealed class ContainerIdentitySpec : IDisposable
     };
     var toLoad = new[]
     {
-      new MaterialToLoadOntoBasket
+      new TestMaterialToLoadOntoBasket
       {
         MaterialIDs = [loadProcessTwo],
         Process = 2,
         ActiveOperationTime = TimeSpan.FromSeconds(30),
         ForeignID = "multi-load-two",
       },
-      new MaterialToLoadOntoBasket
+      new TestMaterialToLoadOntoBasket
       {
         MaterialIDs = [loadProcessThree],
         Process = 3,
@@ -593,7 +721,7 @@ public sealed class ContainerIdentitySpec : IDisposable
         {
           BasketIdentity = basketIdentity,
           Material = [.. Material(unloadProcessOne, 1, 3), .. Material(unloadProcessTwo, 2, 4)],
-          ContainerIds = [],
+          ReconciledBasketIdentities = [],
         },
         new BasketCycleBoundary.Start
         {
@@ -614,7 +742,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     }
 
     await AssertThrows<SqliteException>(() =>
-      repository.RecordBasketLoadUnload(
+      repository.RecordTestBasketLoadUnload(
         toLoad,
         toUnload,
         lulNum: 3,
@@ -640,7 +768,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       dropTrigger.ExecuteNonQuery();
     }
     var first = repository
-      .RecordBasketLoadUnload(
+      .RecordTestBasketLoadUnload(
         toLoad,
         toUnload,
         lulNum: 3,
@@ -652,7 +780,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
       .ToImmutableList();
     var retry = repository
-      .RecordBasketLoadUnload(
+      .RecordTestBasketLoadUnload(
         toLoad,
         toUnload,
         lulNum: 3,
@@ -741,7 +869,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       ],
     };
     var logs = repository
-      .RecordBasketLoadUnloadCompletion(
+      .RecordTestBasketCompletion(
         completion,
         lulNum: 4,
         timeUTC: completionTime,
@@ -776,7 +904,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
       .IsEquivalentTo(new[] { (existingMaterialId, 2, 3), (loadedMaterialId, 2, 7) });
     var retry = repository
-      .RecordBasketLoadUnloadCompletion(
+      .RecordTestBasketCompletion(
         completion,
         lulNum: 4,
         timeUTC: completionTime.AddMinutes(1),
@@ -788,7 +916,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       .That(retry.Select(log => log.Counter))
       .IsEquivalentTo(logs.Select(log => log.Counter));
     await AssertThrows<ConflictRequestException>(() =>
-      repository.RecordBasketLoadUnloadCompletion(
+      repository.RecordTestBasketCompletion(
         completion,
         lulNum: 4,
         timeUTC: completionTime,
@@ -840,7 +968,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     }
 
     await AssertThrows<SqliteException>(() =>
-      repository.RecordBasketLoadUnloadCompletion(
+      repository.RecordTestBasketCompletion(
         new BasketLoadUnloadCompletion
         {
           Transfers =
@@ -943,13 +1071,13 @@ public sealed class ContainerIdentitySpec : IDisposable
         {
           BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 9 },
           Material = [.. firstContents, .. secondContents],
-          ContainerIds = [first, second],
+          ReconciledBasketIdentities = [first, second],
         },
       ],
     };
 
     var logs = repository
-      .RecordBasketLoadUnloadCompletion(
+      .RecordTestBasketCompletion(
         completion,
         lulNum: 3,
         timeUTC: firstEvidenceTime.AddMinutes(10),
@@ -957,7 +1085,7 @@ public sealed class ContainerIdentitySpec : IDisposable
       )
       .ToImmutableList();
     var retry = repository
-      .RecordBasketLoadUnloadCompletion(
+      .RecordTestBasketCompletion(
         completion,
         lulNum: 3,
         timeUTC: firstEvidenceTime.AddMinutes(11),
@@ -998,12 +1126,12 @@ public sealed class ContainerIdentitySpec : IDisposable
         {
           BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 9 },
           Material = [],
-          ContainerIds = [fragment],
+          ReconciledBasketIdentities = [fragment],
         },
       ],
     };
 
-    repository.RecordBasketLoadUnloadCompletion(
+    repository.RecordTestBasketCompletion(
       completion,
       lulNum: 3,
       timeUTC: DateTime.UtcNow,
@@ -1011,7 +1139,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     );
 
     await AssertThrows<ConflictRequestException>(() =>
-      repository.RecordBasketLoadUnloadCompletion(
+      repository.RecordTestBasketCompletion(
         completion,
         lulNum: 3,
         timeUTC: DateTime.UtcNow,
@@ -1029,7 +1157,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     var unrelatedMaterial = repository.AllocateMaterialID("job", "part", 1);
 
     await AssertThrows<ArgumentException>(() =>
-      repository.RecordBasketLoadUnloadCompletion(
+      repository.RecordTestBasketCompletion(
         new BasketLoadUnloadCompletion
         {
           Transfers =
@@ -1062,7 +1190,7 @@ public sealed class ContainerIdentitySpec : IDisposable
                   Face = 2,
                 },
               ],
-              ContainerIds = [fragment],
+              ReconciledBasketIdentities = [fragment],
             },
           ],
         },
@@ -1196,7 +1324,7 @@ public sealed class ContainerIdentitySpec : IDisposable
     var identity = new ContainerIdentity.Uuid { ContainerId = basketId };
 
     await AssertThrows<ArgumentException>(() =>
-      repository.RecordBasketLoadUnloadCompletion(
+      repository.RecordTestBasketCompletion(
         new BasketLoadUnloadCompletion
         {
           Transfers =

--- a/server/test/JobLogTest.cs
+++ b/server/test/JobLogTest.cs
@@ -6752,11 +6752,11 @@ namespace BlackMaple.FMSInsight.Tests
         totalElapsed: TimeSpan.FromMinutes(20),
         timeUTC: start.AddMinutes(30),
         externalQueues: null,
-        basketCompletion: new BasketLoadUnloadCompletion
+        palletBasketCompletion: new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.LoadOntoBasket
+            new PalletBasketTransfer.LoadOntoBasket
             {
               BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
               Material = basket3Contents,
@@ -6827,11 +6827,11 @@ namespace BlackMaple.FMSInsight.Tests
         totalElapsed: TimeSpan.FromMinutes(8),
         timeUTC: start.AddMinutes(50),
         externalQueues: null,
-        basketCompletion: new BasketLoadUnloadCompletion
+        palletBasketCompletion: new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.UnloadFromBasket
+            new PalletBasketTransfer.UnloadFromBasket
             {
               BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
               Material = basket3ProcessTwoContents,
@@ -7323,11 +7323,11 @@ namespace BlackMaple.FMSInsight.Tests
         totalElapsed: TimeSpan.FromMinutes(20),
         timeUTC: start.AddMinutes(30),
         externalQueues: null,
-        basketCompletion: new BasketLoadUnloadCompletion
+        palletBasketCompletion: new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.LoadOntoBasket
+            new PalletBasketTransfer.LoadOntoBasket
             {
               BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
               Material =
@@ -7485,11 +7485,11 @@ namespace BlackMaple.FMSInsight.Tests
         totalElapsed: TimeSpan.FromMinutes(3),
         timeUTC: start.AddMinutes(10),
         externalQueues: null,
-        basketCompletion: new BasketLoadUnloadCompletion
+        palletBasketCompletion: new PalletBasketLoadUnloadCompletion
         {
           Transfers =
           [
-            new BasketTransfer.UnloadFromBasket
+            new PalletBasketTransfer.UnloadFromBasket
             {
               BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 55 },
               Material =

--- a/server/test/JobLogTest.cs
+++ b/server/test/JobLogTest.cs
@@ -6525,8 +6525,6 @@ namespace BlackMaple.FMSInsight.Tests
       );
 
       var start = DateTime.UtcNow.AddHours(-5);
-      var basket1Events = new List<LogEntry>();
-
       // Add material to queues first so we can load them onto baskets
       _jobLog.RecordAddMaterialToQueue(
         new EventLogMaterial()
@@ -6555,10 +6553,10 @@ namespace BlackMaple.FMSInsight.Tests
         start.AddMinutes(-10)
       );
 
-      // Load material onto basket 1 using RecordBasketOnlyLoadUnload
+      // Load material onto basket 1 using RecordTestBasketOnlyLoadUnload
       // This creates both BasketLoadUnload and BasketCycle events
-      var loadLogs = _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [mat1.MaterialID, mat2.MaterialID],
           Process = 1,
@@ -6572,9 +6570,6 @@ namespace BlackMaple.FMSInsight.Tests
         timeUTC: start,
         externalQueues: null
       );
-      // Add only the BasketLoadUnload events (not the cycle) to basket1Events
-      basket1Events.AddRange(loadLogs.Where(e => e.LogType == LogType.BasketLoadUnload));
-
       // Also test BasketInLocation, but it's not included in CurrentBasketLog
       var arriveEvt = _jobLog.RecordBasketArriveLocation(
         mats: new[] { mat1, mat2 }.Select(EventLogMaterial.FromLogMat),
@@ -6583,20 +6578,23 @@ namespace BlackMaple.FMSInsight.Tests
         locationPosition: 3,
         timeUTC: start.AddMinutes(5)
       );
-      basket1Events.Add(arriveEvt);
-
-      // CurrentBasketLog should return events since last basket cycle (the cycle start is not included by default)
-      var currentLog = _jobLog.CurrentBasketLog(1);
-      currentLog.EventsShouldBe(basket1Events);
+      // The complete-content cycle start follows its grounding load, so only the later location
+      // evidence appears in the default current log.
+      _jobLog.CurrentBasketLog(1).EventsShouldBe([arriveEvt]);
+      var currentLog = _jobLog.CurrentBasketLog(1, includeLastCycleEvt: true);
+      currentLog.Count.ShouldBe(2);
+      currentLog[0].LogType.ShouldBe(LogType.BasketCycle);
+      currentLog[0].StartOfCycle.ShouldBeTrue();
+      currentLog[1].Counter.ShouldBe(arriveEvt.Counter);
       _jobLog.CurrentBasketLog(2).ShouldBeEmpty();
 
-      // Use RecordBasketOnlyLoadUnload to create basket cycle end (unload from basket to queue)
+      // Use RecordTestBasketOnlyLoadUnload to create basket cycle end (unload from basket to queue)
       // This will emit both BasketLoadUnload UNLOAD and BasketCycle end events
       var cycleTime = start.AddMinutes(20);
-      var cycleLogs = _jobLog.RecordBasketOnlyLoadUnload(
+      var cycleLogs = _jobLog.RecordTestBasketOnlyLoadUnload(
         toLoad: null,
         previouslyLoaded: null,
-        toUnload: new MaterialToUnloadFromBasket()
+        toUnload: new TestMaterialToUnloadFromBasket()
         {
           MaterialIDToQueue = new Dictionary<long, string>()
           {
@@ -6845,7 +6843,7 @@ namespace BlackMaple.FMSInsight.Tests
             {
               BasketIdentity = new ContainerIdentity.Numbered { ContainerNum = 3 },
               Material = basket3ProcessTwoContents,
-              ContainerIds = [],
+              ReconciledBasketIdentities = [],
             },
           ],
         }
@@ -6926,9 +6924,9 @@ namespace BlackMaple.FMSInsight.Tests
         start
       );
 
-      // Load from queue to basket using RecordBasketOnlyLoadUnload
-      var loadLogs = _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      // Load from queue to basket using RecordTestBasketOnlyLoadUnload
+      var loadLogs = _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [mat1.MaterialID],
           Process = 1,
@@ -6960,11 +6958,11 @@ namespace BlackMaple.FMSInsight.Tests
       var queuedMats = _jobLog.GetMaterialInAllQueues();
       queuedMats.Count(m => m.MaterialID == mat1.MaterialID).ShouldBe(0);
 
-      // Now unload from basket back to queue using RecordBasketOnlyLoadUnload
-      var unloadLogs = _jobLog.RecordBasketOnlyLoadUnload(
+      // Now unload from basket back to queue using RecordTestBasketOnlyLoadUnload
+      var unloadLogs = _jobLog.RecordTestBasketOnlyLoadUnload(
         toLoad: null,
         previouslyLoaded: null,
-        toUnload: new MaterialToUnloadFromBasket()
+        toUnload: new TestMaterialToUnloadFromBasket()
         {
           MaterialIDToQueue = new Dictionary<long, string>()
           {
@@ -7040,8 +7038,8 @@ namespace BlackMaple.FMSInsight.Tests
       );
 
       // Load mat3 onto basket 5 first
-      _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [mat3.MaterialID],
           Process = 1,
@@ -7059,8 +7057,8 @@ namespace BlackMaple.FMSInsight.Tests
       // Now do a simultaneous load and unload operation:
       // - Load mat1 and mat2 from queue onto basket 5
       // - Unload mat3 from basket 5 to queue
-      var logs = _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      var logs = _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [mat1.MaterialID, mat2.MaterialID],
           Process = 1,
@@ -7075,7 +7073,7 @@ namespace BlackMaple.FMSInsight.Tests
             Face = 0,
           },
         ],
-        toUnload: new MaterialToUnloadFromBasket()
+        toUnload: new TestMaterialToUnloadFromBasket()
         {
           MaterialIDToQueue = new Dictionary<long, string>()
           {
@@ -7125,9 +7123,9 @@ namespace BlackMaple.FMSInsight.Tests
       queued.Count(m => m.MaterialID == mat2.MaterialID).ShouldBe(0);
 
       // Verify CurrentBasketLog
-      var basket5Log = _jobLog.CurrentBasketLog(5);
+      var basket5Log = _jobLog.CurrentBasketLog(5, includeLastCycleEvt: true);
       basket5Log.Count.ShouldBeGreaterThan(0);
-      basket5Log.Any(e => e.LogType == LogType.BasketLoadUnload).ShouldBeTrue();
+      basket5Log.ShouldHaveSingleItem().StartOfCycle.ShouldBeTrue();
     }
 
     [Test]
@@ -7154,9 +7152,9 @@ namespace BlackMaple.FMSInsight.Tests
         start
       );
 
-      // Load from queue to basket using RecordBasketOnlyLoadUnload
-      _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      // Load from queue to basket using RecordTestBasketOnlyLoadUnload
+      _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [mat1.MaterialID],
           Process = 1,
@@ -7240,8 +7238,8 @@ namespace BlackMaple.FMSInsight.Tests
       // Create material and load it onto a basket
       var m1 = _jobLog.AllocateMaterialID("U1", "Part1", 1);
 
-      _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [m1],
           Process = 1,
@@ -7257,7 +7255,7 @@ namespace BlackMaple.FMSInsight.Tests
       );
 
       // Verify CurrentBasketLog returns events
-      var logBefore = _jobLog.CurrentBasketLog(55);
+      var logBefore = _jobLog.CurrentBasketLog(55, includeLastCycleEvt: true);
       logBefore.ShouldNotBeEmpty();
 
       // Invalidate the cycle
@@ -7394,8 +7392,8 @@ namespace BlackMaple.FMSInsight.Tests
       var m1 = _jobLog.AllocateMaterialID("U1", "Part1", 1);
 
       // Load material onto basket to create a basket cycle START
-      _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [m1],
           Process = 1,
@@ -7443,8 +7441,8 @@ namespace BlackMaple.FMSInsight.Tests
       _jobLog.CreateMaterialID(1, "uniq1", "part1", 2);
 
       // Load material onto basket to create a basket cycle START
-      _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [mat1.MaterialID],
           Process = 1,
@@ -7519,7 +7517,7 @@ namespace BlackMaple.FMSInsight.Tests
                   Face = 0,
                 },
               ],
-              ContainerIds = [],
+              ReconciledBasketIdentities = [],
             },
           ],
         }
@@ -7537,8 +7535,8 @@ namespace BlackMaple.FMSInsight.Tests
       _jobLog.CreateMaterialID(2, "uniq2", "part2", 2);
 
       // Load material onto basket
-      _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [mat2.MaterialID],
           Process = 1,
@@ -7612,8 +7610,8 @@ namespace BlackMaple.FMSInsight.Tests
       );
 
       // Load material onto basket from queue - creates basket cycle START
-      _jobLog.RecordBasketOnlyLoadUnload(
-        toLoad: new MaterialToLoadOntoBasket()
+      _jobLog.RecordTestBasketOnlyLoadUnload(
+        toLoad: new TestMaterialToLoadOntoBasket()
         {
           MaterialIDs = [mat1.MaterialID],
           Process = 1,


### PR DESCRIPTION
Replace overlapping basket-station APIs with one UUID-aware operation carrying queue and timing data. Persist a canonical retry fingerprint, use counter ordering at a shared timestamp, and reconcile UUID basket identities explicitly at numbered cycle end.