### PR TITLE
Enforce exclusive material operations

### DIFF
--- a/client/insight/src/cell-status/material-details.ts
+++ b/client/insight/src/cell-status/material-details.ts
@@ -584,6 +584,27 @@ export function useSignalForQuarantine(): [
   return [callback, updating];
 }
 
+export function useQuarantineQueuedMaterial(): [
+  (matId: number, operator: string | null, reason: string) => Promise<void>,
+  boolean,
+] {
+  const [updating, setUpdating] = useState<boolean>(false);
+  const callback = useCallback(async (matId: number, operator: string | null, reason: string) => {
+    setUpdating(true);
+    try {
+      await JobsBackend.quarantineQueuedMaterial(
+        matId,
+        operator,
+        reason === "" ? undefined : reason,
+      );
+    } finally {
+      setUpdating(false);
+    }
+  }, []);
+
+  return [callback, updating];
+}
+
 export interface AddExistingMaterialToQueueData {
   readonly materialId: number;
   readonly queue: string;

--- a/client/insight/src/components/station-monitor/CancelLoadButton.tsx
+++ b/client/insight/src/components/station-monitor/CancelLoadButton.tsx
@@ -18,6 +18,7 @@ import {
 import { currentOperator } from "../../data/operators.js";
 import { JobsBackend } from "../../network/backend.js";
 import { ApiException, CancelLoadRequest, IInProcessMaterial } from "../../network/api.js";
+import { canCancelLoad } from "../../data/material-operation-policy.js";
 
 type CancelLoadSnapshot = {
   readonly material: Readonly<IInProcessMaterial>;
@@ -44,7 +45,7 @@ export function CancelLoadButton({
 
   const cancellationId = material?.action.loadCancellationId ?? null;
   const currentSnapshot: CancelLoadSnapshot | null =
-    material === null || cancellationId === null
+    material === null || cancellationId === null || !canCancelLoad(material)
       ? null
       : {
           material,

--- a/client/insight/src/components/station-monitor/InvalidateCycle.tsx
+++ b/client/insight/src/components/station-monitor/InvalidateCycle.tsx
@@ -34,14 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import { Box, Button, ListItemIcon, ListItemText, ListSubheader, Stack } from "@mui/material";
 import { MenuItem } from "@mui/material";
 import { TextField } from "@mui/material";
-import {
-  ActionType,
-  IActiveJob,
-  IInProcessMaterial,
-  ILogEntry,
-  LocType,
-  LogType,
-} from "../../network/api.js";
+import { IActiveJob, IInProcessMaterial, ILogEntry, LocType, LogType } from "../../network/api.js";
 import { JobsBackend } from "../../network/backend.js";
 import { HashMap, LazySeq } from "@seedtactics/immutable-collections";
 import { currentStatus } from "../../cell-status/current-status.js";
@@ -61,6 +54,10 @@ import { last30Jobs } from "../../cell-status/scheduled-jobs.js";
 import { PartIdenticon } from "./Material.js";
 import { isLogEntryInvalidated } from "../LogEntry.js";
 import { ApiException } from "../../network/api.js";
+import {
+  canInvalidateMaterial,
+  isActiveLoadStationOperation,
+} from "../../data/material-operation-policy.js";
 
 export type InvalidateCycleState = {
   readonly process: number | null;
@@ -124,12 +121,20 @@ function InvalidateSelect(props: InvalidateCycleProps) {
 
   const hasProc = lastMat !== null && lastMat.process >= 1;
   const hasChangeMat = castings.length > 0 || jobs.length > 0;
+  const selectedCasting =
+    props.st?.changeRawMat !== null &&
+    props.st?.changeRawMat !== undefined &&
+    castings.includes(props.st.changeRawMat);
+  const selectedJob =
+    props.st?.changeJobUnique !== null &&
+    props.st?.changeJobUnique !== undefined &&
+    jobs.some((job) => job.jobUnique === props.st?.changeJobUnique);
 
   function change(e: string) {
     props.setState({
       updating: false,
       error: null,
-      process: e.startsWith("proc") ? parseInt(e.substring(4)) : null,
+      process: e.startsWith("proc") ? parseInt(e.substring(4)) : 1,
       changeRawMat: e.startsWith("rawMat") ? e.substring(6) : null,
       changeJobUnique: e.startsWith("job") ? e.substring(3) : null,
     });
@@ -138,24 +143,24 @@ function InvalidateSelect(props: InvalidateCycleProps) {
   return (
     <TextField
       value={
-        props.st?.process && hasProc
-          ? "proc" + props.st.process.toString()
-          : props.st?.changeRawMat
-            ? "rawMat" + props.st.changeRawMat
-            : props.st?.changeJobUnique
-              ? "job" + props.st.changeJobUnique
+        selectedCasting
+          ? "rawMat" + props.st.changeRawMat
+          : selectedJob
+            ? "job" + props.st.changeJobUnique
+            : props.st?.process && hasProc
+              ? "proc" + props.st.process.toString()
               : ""
       }
       select
       onChange={(e) => change(e.target.value)}
       variant="outlined"
       label={
-        props.st?.process || !hasChangeMat
-          ? "Invalidate Process"
-          : props.st?.changeRawMat
-            ? "Change Raw Material"
-            : props.st?.changeJobUnique
-              ? "Change Assigned Job"
+        props.st?.changeRawMat
+          ? "Change Raw Material"
+          : props.st?.changeJobUnique
+            ? "Change Assigned Job"
+            : props.st?.process || !hasChangeMat
+              ? "Invalidate Process"
               : !hasProc
                 ? "Change Assignment"
                 : ""
@@ -165,14 +170,19 @@ function InvalidateSelect(props: InvalidateCycleProps) {
         hasProc && hasChangeMat
           ? [<ListSubheader key={"procheader"}>Invalidate Selected Process</ListSubheader>]
           : [],
-        lastMat
-          ? LazySeq.ofRange(1, lastMat.process + 1)
-              .map((p) => (
-                <MenuItem key={p} value={"proc" + p.toString()}>
-                  Invalidate Process {p}
-                </MenuItem>
-              ))
-              .toRArray()
+        hasProc
+          ? [
+              <MenuItem key={lastMat.process} value={"proc" + lastMat.process.toString()}>
+                Invalidate Process {lastMat.process}
+              </MenuItem>,
+              ...(lastMat.process > 1
+                ? [
+                    <MenuItem key="all" value="proc1">
+                      Invalidate All Processes
+                    </MenuItem>,
+                  ]
+                : []),
+            ]
           : [],
         hasProc && hasChangeMat
           ? [<ListSubheader key="matheader">Change Material Type</ListSubheader>]
@@ -181,7 +191,7 @@ function InvalidateSelect(props: InvalidateCycleProps) {
           ? [
               ...castings.map((c) => (
                 <MenuItem key={"rawMat" + c} value={"rawMat" + c}>
-                  Invalidate Everything And Change to {c}
+                  Invalidate Everything and Change to {c}
                 </MenuItem>
               )),
               ...jobs.map(({ jobUnique, job }) => (
@@ -192,7 +202,7 @@ function InvalidateSelect(props: InvalidateCycleProps) {
                     </ListItemIcon>
                   ) : undefined}
                   <ListItemText
-                    primary={"Invalidate Everything And Change To Job " + jobUnique}
+                    primary={"Invalidate Everything and Change to Job " + jobUnique}
                     secondary={job?.partName}
                   />
                 </MenuItem>
@@ -220,12 +230,15 @@ export function InvalidateCycleDialogContent(props: InvalidateCycleProps) {
 
   if (!show) return <div />;
 
-  const process =
-    props.st.process ?? (props.st.changeRawMat || props.st.changeJobUnique ? null : undefined);
-  const affected =
-    process === undefined
-      ? HashMap.empty<number, string | null>()
-      : affectedMaterialForInvalidation(events, curMat.materialID, process);
+  const hasSelection =
+    props.st.process !== null ||
+    props.st.changeRawMat !== null ||
+    props.st.changeJobUnique !== null;
+  const previewProcess =
+    props.st.changeRawMat !== null || props.st.changeJobUnique !== null ? null : props.st.process;
+  const affected = hasSelection
+    ? affectedMaterialForInvalidation(events, curMat.materialID, previewProcess)
+    : HashMap.empty<number, string | null>();
   const affectedLabels = [...affected].map(([materialId, serial]) => ({
     materialId,
     serial,
@@ -283,8 +296,7 @@ export function InvalidateCycleDialogButton(
   if (!props.loadStation && !fmsInfo.allowInvalidateMaterialOnQueuesPage) return null;
   if (curMat === null) return null;
 
-  if (inProcMat && inProcMat.location.type === LocType.OnPallet) return null;
-  if (inProcMat && inProcMat.location.type === LocType.InQueue) return null;
+  if (!canInvalidateMaterial(inProcMat)) return null;
 
   const allowChange =
     possibleNew !== null &&
@@ -358,12 +370,16 @@ export function InvalidateCycleDialogButton(
               props.st.changeJobUnique === null)
           }
         >
-          {props.st.process !== null
-            ? "Invalidate Process " + props.st.process.toString()
-            : props.st.changeJobUnique !== null
-              ? "Invalidate And Change To Job " + props.st.changeJobUnique
-              : props.st.changeRawMat !== null
-                ? "Invalidate And Change To " + props.st.changeRawMat
+          {props.st.changeJobUnique !== null
+            ? "Invalidate Everything and Change to Job " + props.st.changeJobUnique
+            : props.st.changeRawMat !== null
+              ? "Invalidate Everything and Change to " + props.st.changeRawMat
+              : props.st.process !== null
+                ? props.st.process === 1
+                  ? lastMat && lastMat.process > 1
+                    ? "Invalidate All Processes"
+                    : "Invalidate Process 1"
+                  : "Invalidate Process " + props.st.process.toString()
                 : "Invalidate Cycle"}
         </Button>
       ) : undefined}
@@ -486,9 +502,7 @@ export function SwapMaterialButtons(
   if (
     !curMat ||
     curMat.location.type !== LocType.OnPallet ||
-    curMat.action.type === ActionType.Loading ||
-    curMat.action.type === ActionType.UnloadToCompletedMaterial ||
-    curMat.action.type === ActionType.UnloadToInProcess
+    isActiveLoadStationOperation(curMat)
   ) {
     return null;
   }

--- a/client/insight/src/components/station-monitor/LoadStation.tsx
+++ b/client/insight/src/components/station-monitor/LoadStation.tsx
@@ -82,6 +82,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { PrintLabelButton } from "./PrintedLabel.js";
 import { hideNonLoadingMaterialOnLoadStation } from "../../data/queue-material.js";
 import { basketDisplayName, loadStationDisplayName } from "../../cell-status/station-cycles.js";
+import { canAddOrMoveMaterialToQueue } from "../../data/material-operation-policy.js";
 import {
   BasketLoadStationWorkflow,
   SubmitBasketLoadStationCommand,
@@ -1024,12 +1025,7 @@ function AddMatButton({
   const [addExistingMat, addingExistingMat] = matDetails.useAddExistingMaterialToQueue();
   const [addError, setAddError] = useState<string | null>(null);
 
-  if (
-    !existingMat ||
-    inProcMat?.location.type === api.LocType.OnPallet ||
-    inProcMat?.action.type === api.ActionType.Loading ||
-    inProcMat?.action.type === api.ActionType.LoadingToBasket
-  ) {
+  if (!existingMat || !canAddOrMoveMaterialToQueue(inProcMat)) {
     return null;
   }
   if (queues.length === 0) return null;

--- a/client/insight/src/components/station-monitor/Material.test.tsx
+++ b/client/insight/src/components/station-monitor/Material.test.tsx
@@ -134,6 +134,9 @@ const jobBackend: JobAPI = {
   signalMaterialForQuarantine() {
     return unexpectedCall("JobAPI.signalMaterialForQuarantine");
   },
+  quarantineQueuedMaterial() {
+    return unexpectedCall("JobAPI.quarantineQueuedMaterial");
+  },
   cancelLoad() {
     return unexpectedCall("JobAPI.cancelLoad");
   },

--- a/client/insight/src/components/station-monitor/Material.tsx
+++ b/client/insight/src/components/station-monitor/Material.tsx
@@ -82,6 +82,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { last30Rebookings } from "../../cell-status/rebookings.js";
 import { fmsInformation } from "../../network/server-settings.js";
 import { basketDisplayName } from "../../cell-status/station-cycles.js";
+import { materialOperationState } from "../../data/material-operation-policy.js";
 
 export class PartIdenticon extends PureComponent<{
   part: string;
@@ -990,6 +991,29 @@ function RebookingNote() {
   return null;
 }
 
+function MaterialOperationNotice() {
+  const material = useAtomValue(matDetails.inProcessMaterialInDialog);
+  if (material === null) return null;
+
+  if (material.quarantineAfterUnload) {
+    return (
+      <Typography variant="caption" component="p">
+        Quarantine requested
+      </Typography>
+    );
+  }
+
+  const state = materialOperationState(material);
+  if (state.kind !== "ActiveLoadStationOperation" || state.cancellationId !== null) return null;
+
+  return (
+    <Typography variant="caption" component="p">
+      This material is part of the current load/unload operation. Complete the operation or cancel
+      it at the machine control before making other changes.
+    </Typography>
+  );
+}
+
 export const MaterialDetailContent = memo(function MaterialDetailContent({
   highlightProcsGreaterOrEqualTo,
 }: {
@@ -1026,6 +1050,7 @@ export const MaterialDetailContent = memo(function MaterialDetailContent({
   return (
     <>
       <div style={{ marginLeft: "1em" }}>
+        <MaterialOperationNotice />
         <div>
           <small>Workorder: {mat?.workorderId ?? "none"}</small>
         </div>

--- a/client/insight/src/components/station-monitor/QuarantineButton.tsx
+++ b/client/insight/src/components/station-monitor/QuarantineButton.tsx
@@ -69,14 +69,21 @@ import {
 
 type QuarantineMaterialTypes = "Remove" | "Scrap" | "SignalForScrap";
 
+type QuarantineOperation = "DeferredQuarantine" | "DirectQuarantine" | "RemoveFromSystem";
+
+type QuarantineSnapshot = {
+  readonly material: Readonly<IInProcessMaterial>;
+  readonly materialId: number;
+  readonly operation: QuarantineOperation;
+  readonly destination: string | null;
+  readonly operator: string | null;
+};
+
 type QuarantineMaterialData = {
   readonly type: QuarantineMaterialTypes;
   readonly material: Readonly<IInProcessMaterial>;
-  readonly quarantine: (reason: string) => Promise<void>;
-  readonly removing: boolean;
   readonly quarantineQueueDestination: string | null;
-  readonly removeFromQueues: (() => Promise<void>) | null;
-  readonly removingFromQueues: boolean;
+  readonly canRemoveFromQueues: boolean;
 };
 
 function hasSupportedQuarantineExit(
@@ -92,15 +99,10 @@ function hasSupportedQuarantineExit(
   return material.process === job.procsAndPaths.length || Boolean(path.outputQueue);
 }
 
-function useQuarantineMaterial(ignoreOperator: boolean): QuarantineMaterialData | null {
+function useQuarantineMaterial(): QuarantineMaterialData | null {
   const fmsInfo = useAtomValue(fmsInformation);
-  const [removeFromQueue, removingFromQueue] = useRemoveFromQueue();
-  const [signalQuarantine, signalingQuarantine] = useSignalForQuarantine();
-  const [quarantineQueued, quarantiningQueued] = useQuarantineQueuedMaterial();
   const inProcMat = useAtomValue(inProcessMaterialInDialog);
   const curSt = useAtomValue(currentStatus);
-  let operator = useAtomValue(currentOperator);
-  if (ignoreOperator) operator = null;
 
   if (inProcMat === null || inProcMat.materialID < 0) return null;
 
@@ -140,11 +142,8 @@ function useQuarantineMaterial(ignoreOperator: boolean): QuarantineMaterialData 
     return {
       type: "Remove",
       material: inProcMat,
-      quarantine: () => removeFromQueue(inProcMat.materialID, operator),
-      removing: removingFromQueue,
       quarantineQueueDestination: null,
-      removeFromQueues: null,
-      removingFromQueues: removingFromQueue,
+      canRemoveFromQueues: false,
     };
   }
 
@@ -178,20 +177,12 @@ function useQuarantineMaterial(ignoreOperator: boolean): QuarantineMaterialData 
     return {
       type,
       material: inProcMat,
-      quarantine:
-        type === "SignalForScrap"
-          ? async (reason) => signalQuarantine(inProcMat.materialID, operator, reason)
-          : async (reason) => quarantineQueued(inProcMat.materialID, operator, reason),
-      removing: type === "SignalForScrap" ? signalingQuarantine : quarantiningQueued,
       quarantineQueueDestination: quarantineQueue,
-      removeFromQueues:
+      canRemoveFromQueues:
         inProcMat.location.type === LocType.InQueue &&
         inProcMat.location.currentQueue !== undefined &&
         !quarantineQueues.has(inProcMat.location.currentQueue) &&
-        canRemoveFromQueue(inProcMat)
-          ? () => removeFromQueue(inProcMat.materialID, operator)
-          : null,
-      removingFromQueues: removingFromQueue,
+        canRemoveFromQueue(inProcMat),
     };
   } else {
     return null;
@@ -276,53 +267,97 @@ export function QuarantineMatButton({
   const [open, setOpen] = useState(false);
   const [reason, setReason] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const q = useQuarantineMaterial(!!ignoreOperator);
+  const [updating, setUpdating] = useState(false);
+  const [snapshot, setSnapshot] = useState<QuarantineSnapshot | null>(null);
+  const q = useQuarantineMaterial();
+  const [removeFromQueue, removingFromQueue] = useRemoveFromQueue();
+  const [signalQuarantine, signalingQuarantine] = useSignalForQuarantine();
+  const [quarantineQueued, quarantiningQueued] = useQuarantineQueuedMaterial();
+  const currentOperatorValue = useAtomValue(currentOperator);
+  const operator = ignoreOperator ? null : currentOperatorValue;
   const setMatToShow = useSetAtom(materialDialogOpen);
 
+  const currentSnapshot: QuarantineSnapshot | null =
+    q === null
+      ? null
+      : {
+          material: q.material,
+          materialId: q.material.materialID,
+          operation:
+            q.type === "SignalForScrap"
+              ? "DeferredQuarantine"
+              : q.type === "Scrap"
+                ? "DirectQuarantine"
+                : "RemoveFromSystem",
+          destination: q.quarantineQueueDestination,
+          operator,
+        };
+  const displayedSnapshot = snapshot ?? currentSnapshot;
+
   function openQuarantine() {
+    if (currentSnapshot === null) return;
     setError(null);
     setReason("");
+    setSnapshot(currentSnapshot);
     setOpen(true);
   }
 
-  if (q === null) return null;
+  function closeQuarantine() {
+    if (updating) return;
+    setOpen(false);
+    setSnapshot(null);
+  }
+
+  if (displayedSnapshot === null) return null;
 
   let title: string;
   let btnTxt: string;
 
-  switch (q.type) {
-    case "Remove":
+  switch (displayedSnapshot.operation) {
+    case "RemoveFromSystem":
       title = "Remove from system";
       btnTxt = "Remove";
       break;
-    case "Scrap":
-      title = q.quarantineQueueDestination
-        ? `Move to ${q.quarantineQueueDestination}`
+    case "DirectQuarantine":
+      title = displayedSnapshot.destination
+        ? `Move to ${displayedSnapshot.destination}`
         : "Remove from queue and treat as scrap";
-      btnTxt = q.quarantineQueueDestination ? "Quarantine" : "Scrap";
+      btnTxt = displayedSnapshot.destination ? "Quarantine" : "Scrap";
       break;
-    case "SignalForScrap":
-      title = q.quarantineQueueDestination
-        ? `The current automated operation will continue. When the material leaves automation control, move it to ${q.quarantineQueueDestination}`
+    case "DeferredQuarantine":
+      title = displayedSnapshot.destination
+        ? `The current automated operation will continue. When the material leaves automation control, move it to ${displayedSnapshot.destination}`
         : "The current automated operation will continue. When the material leaves automation control, remove it from normal production flow as scrap";
-      btnTxt = q.quarantineQueueDestination ? "Quarantine" : "Scrap";
+      btnTxt = displayedSnapshot.destination ? "Quarantine" : "Scrap";
       break;
   }
 
   async function quarantine() {
-    if (!q) return;
+    if (snapshot === null) return;
+    setUpdating(true);
     setError(null);
     try {
-      await q.quarantine(reason);
+      switch (snapshot.operation) {
+        case "DeferredQuarantine":
+          await signalQuarantine(snapshot.materialId, snapshot.operator, reason);
+          break;
+        case "DirectQuarantine":
+          await quarantineQueued(snapshot.materialId, snapshot.operator, reason);
+          break;
+        case "RemoveFromSystem":
+          await removeFromQueue(snapshot.materialId, snapshot.operator);
+          break;
+      }
       setOpen(false);
+      setSnapshot(null);
       setReason("");
-      if (q.type === "Remove") {
+      if (snapshot.operation === "RemoveFromSystem") {
         setMatToShow({
           type: "MatSummary",
           summary: {
-            materialID: q.material.materialID,
-            partName: q.material.partName,
-            serial: q.material.serial,
+            materialID: snapshot.materialId,
+            partName: snapshot.material.partName,
+            serial: snapshot.material.serial,
           },
         });
       } else {
@@ -333,24 +368,38 @@ export function QuarantineMatButton({
       setError(
         ApiException.isApiException(e) ? e.response : e instanceof Error ? e.message : String(e),
       );
+    } finally {
+      setUpdating(false);
     }
   }
 
+  const removing =
+    updating ||
+    (displayedSnapshot.operation === "DeferredQuarantine"
+      ? signalingQuarantine
+      : displayedSnapshot.operation === "DirectQuarantine"
+        ? quarantiningQueued
+        : removingFromQueue);
+  const removeFromQueues =
+    q?.canRemoveFromQueues === true ? () => removeFromQueue(q.material.materialID, operator) : null;
+
   return (
     <>
-      <Tooltip title={title}>
-        <Button color="primary" disabled={q.removing} onClick={openQuarantine}>
-          {btnTxt}
-        </Button>
-      </Tooltip>
-      {q.removeFromQueues ? (
+      {q ? (
+        <Tooltip title={title}>
+          <Button color="primary" disabled={removing} onClick={openQuarantine}>
+            {btnTxt}
+          </Button>
+        </Tooltip>
+      ) : null}
+      {removeFromQueues && q ? (
         <RemoveFromQueuesButton
           material={q.material}
-          removeFromQueues={q.removeFromQueues}
-          removing={q.removingFromQueues}
+          removeFromQueues={removeFromQueues}
+          removing={removingFromQueue}
         />
       ) : null}
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog open={open && snapshot !== null} onClose={closeQuarantine}>
         <DialogTitle>Quarantine Material</DialogTitle>
         <DialogContent>
           <p>{title}</p>
@@ -365,10 +414,10 @@ export function QuarantineMatButton({
           {error ? <p role="alert">{error}</p> : null}
         </DialogContent>
         <DialogActions>
-          <Button color="primary" disabled={q.removing} onClick={quarantine}>
+          <Button color="primary" disabled={removing} onClick={quarantine}>
             {btnTxt}
           </Button>
-          <Button color="secondary" onClick={() => setOpen(false)}>
+          <Button color="secondary" disabled={removing} onClick={closeQuarantine}>
             Cancel
           </Button>
         </DialogActions>

--- a/client/insight/src/components/station-monitor/QuarantineButton.tsx
+++ b/client/insight/src/components/station-monitor/QuarantineButton.tsx
@@ -46,19 +46,26 @@ import { currentStatus } from "../../cell-status/current-status.js";
 import {
   inProcessMaterialInDialog,
   materialDialogOpen,
+  useQuarantineQueuedMaterial,
   useRemoveFromQueue,
   useSignalForQuarantine,
 } from "../../cell-status/material-details.js";
 import { currentOperator } from "../../data/operators.js";
 import {
-  ActionType,
   ApiException,
+  ICurrentStatus,
   IInProcessMaterial,
   LocType,
   QueueRole,
 } from "../../network/api.js";
 import { fmsInformation } from "../../network/server-settings.js";
 import { useAtomValue, useSetAtom } from "jotai";
+import {
+  canDirectlyQuarantine,
+  canRemoveFromQueue,
+  canSignalQuarantine,
+  isActiveLoadStationOperation,
+} from "../../data/material-operation-policy.js";
 
 type QuarantineMaterialTypes = "Remove" | "Scrap" | "SignalForScrap";
 
@@ -72,16 +79,34 @@ type QuarantineMaterialData = {
   readonly removingFromQueues: boolean;
 };
 
+function hasSupportedQuarantineExit(
+  material: Readonly<IInProcessMaterial>,
+  status: Readonly<ICurrentStatus>,
+): boolean {
+  const job = status.jobs[material.jobUnique];
+  if (!job) return false;
+
+  const path = job.procsAndPaths[material.process - 1]?.paths[material.path - 1];
+  if (!path) return false;
+
+  return material.process === job.procsAndPaths.length || Boolean(path.outputQueue);
+}
+
 function useQuarantineMaterial(ignoreOperator: boolean): QuarantineMaterialData | null {
   const fmsInfo = useAtomValue(fmsInformation);
   const [removeFromQueue, removingFromQueue] = useRemoveFromQueue();
   const [signalQuarantine, signalingQuarantine] = useSignalForQuarantine();
+  const [quarantineQueued, quarantiningQueued] = useQuarantineQueuedMaterial();
   const inProcMat = useAtomValue(inProcessMaterialInDialog);
   const curSt = useAtomValue(currentStatus);
   let operator = useAtomValue(currentOperator);
   if (ignoreOperator) operator = null;
 
   if (inProcMat === null || inProcMat.materialID < 0) return null;
+
+  if (isActiveLoadStationOperation(inProcMat)) return null;
+
+  if (inProcMat.quarantineAfterUnload) return null;
 
   const quarantineQueue = fmsInfo.quarantineQueue?.length ? fmsInfo.quarantineQueue : null;
 
@@ -127,53 +152,43 @@ function useQuarantineMaterial(ignoreOperator: boolean): QuarantineMaterialData 
 
   switch (inProcMat.location.type) {
     case LocType.OnPallet:
-      if (inProcMat.action.type === ActionType.Loading) {
-        return null;
-      }
-      // Check that the job outputs to a queue, only then can signaling for quarantine work
-      const job = curSt.jobs[inProcMat.jobUnique];
-      if (!job) return null;
-      const path = job.procsAndPaths?.[inProcMat.process - 1]?.paths?.[inProcMat.path - 1];
-      if (inProcMat.process != job.procsAndPaths.length && (!path || !path.outputQueue)) {
+    case LocType.InBasket:
+      if (!canSignalQuarantine(inProcMat) || !hasSupportedQuarantineExit(inProcMat, curSt)) {
         return null;
       }
       type = "SignalForScrap";
       break;
 
     case LocType.InQueue:
+      if (!canDirectlyQuarantine(inProcMat)) return null;
       if (
-        inProcMat.action.type === ActionType.Loading ||
-        inProcMat.action.type === ActionType.LoadingToBasket
+        inProcMat.location.currentQueue === undefined ||
+        quarantineQueues.has(inProcMat.location.currentQueue)
       ) {
         return null;
       }
       type = "Scrap";
       break;
 
-    case LocType.InBasket:
-      if (inProcMat.action.type === ActionType.Loading) {
-        return null;
-      }
-      type = "Scrap";
-      break;
-
     case LocType.Free:
-      type = "Scrap";
-      break;
+      return null;
   }
 
   if (type) {
     return {
       type,
       material: inProcMat,
-      quarantine: async (reason) => signalQuarantine(inProcMat.materialID, operator, reason),
-      removing: signalingQuarantine,
+      quarantine:
+        type === "SignalForScrap"
+          ? async (reason) => signalQuarantine(inProcMat.materialID, operator, reason)
+          : async (reason) => quarantineQueued(inProcMat.materialID, operator, reason),
+      removing: type === "SignalForScrap" ? signalingQuarantine : quarantiningQueued,
       quarantineQueueDestination: quarantineQueue,
       removeFromQueues:
         inProcMat.location.type === LocType.InQueue &&
         inProcMat.location.currentQueue !== undefined &&
-        activeQueues.has(inProcMat.location.currentQueue) &&
-        inProcMat.action.type === ActionType.Waiting
+        !quarantineQueues.has(inProcMat.location.currentQueue) &&
+        canRemoveFromQueue(inProcMat)
           ? () => removeFromQueue(inProcMat.materialID, operator)
           : null,
       removingFromQueues: removingFromQueue,
@@ -216,22 +231,31 @@ function RemoveFromQueuesButton({
     }
   }
 
+  function openRemoval() {
+    setError(null);
+    setOpen(true);
+  }
+
   return (
     <>
-      <Tooltip title="Remove from all queues">
-        <Button color="primary" disabled={removing} onClick={() => setOpen(true)}>
-          Remove from Queues
+      <Tooltip title="Remove from the current queue so it can be rescanned">
+        <Button color="primary" disabled={removing} onClick={openRemoval}>
+          Remove from Queue
         </Button>
       </Tooltip>
       <Dialog open={open} onClose={() => setOpen(false)}>
-        <DialogTitle>Remove Material from Queues</DialogTitle>
+        <DialogTitle>Remove Material from Queue</DialogTitle>
         <DialogContent>
-          <p>The material will be removed from all queues.</p>
+          <p>
+            Remove this material from its current queue. Its production history will remain
+            available. You can scan it again to correct its history or assignment and then add it
+            back to a queue.
+          </p>
           {error ? <p role="alert">{error}</p> : null}
         </DialogContent>
         <DialogActions>
           <Button color="primary" disabled={removing} onClick={remove}>
-            Remove from Queues
+            Remove from Queue
           </Button>
           <Button color="secondary" disabled={removing} onClick={() => setOpen(false)}>
             Cancel
@@ -255,6 +279,12 @@ export function QuarantineMatButton({
   const q = useQuarantineMaterial(!!ignoreOperator);
   const setMatToShow = useSetAtom(materialDialogOpen);
 
+  function openQuarantine() {
+    setError(null);
+    setReason("");
+    setOpen(true);
+  }
+
   if (q === null) return null;
 
   let title: string;
@@ -268,13 +298,13 @@ export function QuarantineMatButton({
     case "Scrap":
       title = q.quarantineQueueDestination
         ? `Move to ${q.quarantineQueueDestination}`
-        : "Remove from queue";
-      btnTxt = q.quarantineQueueDestination ? "Quarantine" : "Remove";
+        : "Remove from queue and treat as scrap";
+      btnTxt = q.quarantineQueueDestination ? "Quarantine" : "Scrap";
       break;
     case "SignalForScrap":
       title = q.quarantineQueueDestination
-        ? `After unload, move to ${q.quarantineQueueDestination}`
-        : "After unload, remove the part as scrap";
+        ? `The current automated operation will continue. When the material leaves automation control, move it to ${q.quarantineQueueDestination}`
+        : "The current automated operation will continue. When the material leaves automation control, remove it from normal production flow as scrap";
       btnTxt = q.quarantineQueueDestination ? "Quarantine" : "Scrap";
       break;
   }
@@ -309,7 +339,7 @@ export function QuarantineMatButton({
   return (
     <>
       <Tooltip title={title}>
-        <Button color="primary" disabled={q.removing} onClick={() => setOpen(true)}>
+        <Button color="primary" disabled={q.removing} onClick={openQuarantine}>
           {btnTxt}
         </Button>
       </Tooltip>

--- a/client/insight/src/components/station-monitor/QueuesAddMaterial.tsx
+++ b/client/insight/src/components/station-monitor/QueuesAddMaterial.tsx
@@ -60,6 +60,7 @@ import { currentOperator } from "../../data/operators.js";
 import { fmsInformation } from "../../network/server-settings.js";
 import { useAddNewCastingToQueue } from "../../cell-status/material-details.js";
 import { useAtomValue, useSetAtom } from "jotai";
+import { canAddOrMoveMaterialToQueue } from "../../data/material-operation-policy.js";
 
 export type AddMaterialState = {
   readonly toQueue: string | null;
@@ -72,19 +73,15 @@ function useAllowAddToQueue(queueNames: ReadonlyArray<string>): boolean {
   const inProcMat = useAtomValue(matDetails.inProcessMaterialInDialog);
   const possibleNewMats = useAtomValue(matDetails.barcodePotentialNewMaterial);
 
-  const curInQueueOnScreen =
-    inProcMat !== null &&
-    inProcMat.location.type === api.LocType.InQueue &&
-    inProcMat.location.currentQueue &&
-    queueNames.includes(inProcMat.location.currentQueue);
-  if (curInQueueOnScreen) return false;
+  if (!canAddOrMoveMaterialToQueue(inProcMat)) return false;
 
-  if (inProcMat?.location.type === api.LocType.OnPallet) return false;
   if (
-    inProcMat?.action.type === api.ActionType.Loading ||
-    inProcMat?.action.type === api.ActionType.LoadingToBasket
-  )
+    inProcMat?.location.type === api.LocType.InQueue &&
+    inProcMat.location.currentQueue !== undefined &&
+    queueNames.includes(inProcMat.location.currentQueue)
+  ) {
     return false;
+  }
 
   if (existingMat === null && !possibleNewMats) {
     return false;

--- a/client/insight/src/data/material-operation-policy.test.ts
+++ b/client/insight/src/data/material-operation-policy.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  ActionType,
+  InProcessMaterial,
+  InProcessMaterialAction,
+  InProcessMaterialLocation,
+  LocType,
+} from "../network/api.js";
+import {
+  canAddOrMoveMaterialToQueue,
+  canCancelLoad,
+  canDirectlyQuarantine,
+  canInvalidateMaterial,
+  canRemoveFromQueue,
+  canSignalQuarantine,
+  isActiveLoadStationOperation,
+  materialOperationState,
+} from "./material-operation-policy.js";
+
+function material(
+  location: LocType,
+  action: ActionType,
+  loadCancellationId?: string,
+): InProcessMaterial {
+  return new InProcessMaterial({
+    materialID: 1,
+    jobUnique: "job",
+    partName: "part",
+    process: 1,
+    path: 1,
+    signaledInspections: [],
+    location: new InProcessMaterialLocation({ type: location, currentQueue: "queue" }),
+    action: new InProcessMaterialAction({ type: action, loadCancellationId }),
+  });
+}
+
+describe("materialOperationState", () => {
+  it.each([
+    ActionType.Loading,
+    ActionType.UnloadToInProcess,
+    ActionType.UnloadToCompletedMaterial,
+    ActionType.LoadingToBasket,
+  ])("classifies %s as active load-station work", (action) => {
+    const state = materialOperationState(material(LocType.Free, action));
+    expect(state).toEqual({ kind: "ActiveLoadStationOperation", cancellationId: null });
+    expect(isActiveLoadStationOperation(material(LocType.Free, action))).toBe(true);
+  });
+
+  it("classifies a nonblank cancellation id as active load-station work for any action", () => {
+    expect(
+      materialOperationState(material(LocType.OnPallet, ActionType.Machining, "operation-1")),
+    ).toEqual({ kind: "ActiveLoadStationOperation", cancellationId: "operation-1" });
+  });
+
+  it("does not treat a blank cancellation id as cancellation capability", () => {
+    expect(materialOperationState(material(LocType.OnPallet, ActionType.Waiting, "  "))).toEqual({
+      kind: "AutomationControlled",
+    });
+    expect(canCancelLoad(material(LocType.OnPallet, ActionType.Waiting, "  "))).toBe(false);
+  });
+
+  it("classifies waiting material in a queue as human-controlled", () => {
+    expect(materialOperationState(material(LocType.InQueue, ActionType.Waiting))).toEqual({
+      kind: "HumanControlledQueue",
+    });
+  });
+
+  it.each([LocType.OnPallet, LocType.InBasket])(
+    "classifies waiting material at %s as automation-controlled",
+    (location) => {
+      expect(materialOperationState(material(location, ActionType.Waiting))).toEqual({
+        kind: "AutomationControlled",
+      });
+    },
+  );
+
+  it("classifies machining material as automation-controlled", () => {
+    expect(materialOperationState(material(LocType.Free, ActionType.Machining))).toEqual({
+      kind: "AutomationControlled",
+    });
+  });
+
+  it("classifies other free material as an add-to-queue proposal", () => {
+    expect(materialOperationState(material(LocType.Free, ActionType.Waiting))).toEqual({
+      kind: "AddToQueueProposal",
+    });
+  });
+});
+
+describe("material operation permissions", () => {
+  const activeWithCancellation = material(LocType.InQueue, ActionType.Loading, "load-1");
+  const activeWithoutCancellation = material(LocType.InQueue, ActionType.Loading);
+  const automated = material(LocType.OnPallet, ActionType.Waiting);
+  const queued = material(LocType.InQueue, ActionType.Waiting);
+  const proposal = material(LocType.Free, ActionType.Waiting);
+
+  it("allows cancellation only for active work with a nonblank cancellation id", () => {
+    expect(canCancelLoad(activeWithCancellation)).toBe(true);
+    expect(canCancelLoad(activeWithoutCancellation)).toBe(false);
+    expect(canCancelLoad(null)).toBe(false);
+  });
+
+  it("allows deferred quarantine only for automation-controlled material", () => {
+    expect(canSignalQuarantine(automated)).toBe(true);
+    expect(canSignalQuarantine(queued)).toBe(false);
+    expect(canSignalQuarantine(activeWithCancellation)).toBe(false);
+    expect(canSignalQuarantine(null)).toBe(false);
+  });
+
+  it("allows direct quarantine and queue removal only for human-controlled queue material", () => {
+    expect(canDirectlyQuarantine(queued)).toBe(true);
+    expect(canRemoveFromQueue(queued)).toBe(true);
+    expect(canDirectlyQuarantine(automated)).toBe(false);
+    expect(canRemoveFromQueue(activeWithCancellation)).toBe(false);
+  });
+
+  it("allows invalidation and queue addition for proposals and absent current material", () => {
+    expect(canInvalidateMaterial(proposal)).toBe(true);
+    expect(canAddOrMoveMaterialToQueue(proposal)).toBe(true);
+    expect(canInvalidateMaterial(null)).toBe(true);
+    expect(canAddOrMoveMaterialToQueue(null)).toBe(true);
+  });
+
+  it("allows queue movement for human-controlled queued material", () => {
+    expect(canAddOrMoveMaterialToQueue(queued)).toBe(true);
+    expect(canInvalidateMaterial(queued)).toBe(false);
+  });
+
+  it("blocks proposal operations for material under active or automated control", () => {
+    for (const controlled of [activeWithCancellation, activeWithoutCancellation, automated]) {
+      expect(canInvalidateMaterial(controlled)).toBe(false);
+      expect(canAddOrMoveMaterialToQueue(controlled)).toBe(false);
+    }
+  });
+});

--- a/client/insight/src/data/material-operation-policy.ts
+++ b/client/insight/src/data/material-operation-policy.ts
@@ -1,0 +1,123 @@
+/* Copyright (c) 2026, John Lenz
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of John Lenz, Black Maple Software, SeedTactics,
+      nor the names of other contributors may be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { ActionType, IInProcessMaterial, LocType } from "../network/api.js";
+
+export type MaterialOperationState =
+  | {
+      readonly kind: "ActiveLoadStationOperation";
+      readonly cancellationId: string | null;
+    }
+  | {
+      readonly kind: "AutomationControlled";
+    }
+  | {
+      readonly kind: "HumanControlledQueue";
+    }
+  | {
+      readonly kind: "AddToQueueProposal";
+    };
+
+type MaterialForPolicy = Readonly<IInProcessMaterial> | null;
+
+function nonBlankCancellationId(material: Readonly<IInProcessMaterial>): string | null {
+  const cancellationId = material.action.loadCancellationId;
+  return cancellationId !== undefined && cancellationId.trim() !== "" ? cancellationId : null;
+}
+
+function hasLoadStationAction(material: Readonly<IInProcessMaterial>): boolean {
+  switch (material.action.type) {
+    case ActionType.Loading:
+    case ActionType.UnloadToInProcess:
+    case ActionType.UnloadToCompletedMaterial:
+    case ActionType.LoadingToBasket:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function materialOperationState(
+  material: Readonly<IInProcessMaterial>,
+): MaterialOperationState {
+  const cancellationId = nonBlankCancellationId(material);
+  if (cancellationId !== null || hasLoadStationAction(material)) {
+    return { kind: "ActiveLoadStationOperation", cancellationId };
+  }
+
+  if (material.location.type === LocType.InQueue && material.action.type === ActionType.Waiting) {
+    return { kind: "HumanControlledQueue" };
+  }
+
+  if (
+    material.location.type === LocType.OnPallet ||
+    material.location.type === LocType.InBasket ||
+    material.action.type === ActionType.Machining
+  ) {
+    return { kind: "AutomationControlled" };
+  }
+
+  return { kind: "AddToQueueProposal" };
+}
+
+export function isActiveLoadStationOperation(material: Readonly<IInProcessMaterial>): boolean {
+  return materialOperationState(material).kind === "ActiveLoadStationOperation";
+}
+
+export function canCancelLoad(material: MaterialForPolicy): boolean {
+  if (material === null) return false;
+  const state = materialOperationState(material);
+  return state.kind === "ActiveLoadStationOperation" && state.cancellationId !== null;
+}
+
+export function canSignalQuarantine(material: MaterialForPolicy): boolean {
+  return material !== null && materialOperationState(material).kind === "AutomationControlled";
+}
+
+export function canDirectlyQuarantine(material: MaterialForPolicy): boolean {
+  return material !== null && materialOperationState(material).kind === "HumanControlledQueue";
+}
+
+export function canRemoveFromQueue(material: MaterialForPolicy): boolean {
+  return canDirectlyQuarantine(material);
+}
+
+export function canInvalidateMaterial(material: MaterialForPolicy): boolean {
+  return material === null || materialOperationState(material).kind === "AddToQueueProposal";
+}
+
+export function canAddOrMoveMaterialToQueue(material: MaterialForPolicy): boolean {
+  if (material === null) return true;
+
+  const state = materialOperationState(material);
+  return state.kind === "AddToQueueProposal" || state.kind === "HumanControlledQueue";
+}

--- a/client/insight/src/network/api.ts
+++ b/client/insight/src/network/api.ts
@@ -1039,6 +1039,14 @@ export class JobsClient {
       return response.text().then((_responseText) => {
         return;
       });
+    } else if (status === 400) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
+    } else if (status === 409) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
     } else if (status !== 200 && status !== 204) {
       return response.text().then((_responseText) => {
         return throwException(
@@ -1092,6 +1100,75 @@ export class JobsClient {
       return response.text().then((_responseText) => {
         return;
       });
+    } else if (status === 400) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
+    } else if (status === 409) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
+    } else if (status !== 200 && status !== 204) {
+      return response.text().then((_responseText) => {
+        return throwException(
+          "An unexpected server error occurred.",
+          status,
+          _responseText,
+          _headers,
+        );
+      });
+    }
+    return Promise.resolve<void>(null as any);
+  }
+
+  quarantineQueuedMaterial(
+    materialId: number,
+    operName: string | null | undefined,
+    reason: string | undefined,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    let url_ = this.baseUrl + "/api/v1/jobs/material/{materialId}/quarantine-queued?";
+    if (materialId === undefined || materialId === null)
+      throw new globalThis.Error("The parameter 'materialId' must be defined.");
+    url_ = url_.replace("{materialId}", encodeURIComponent("" + materialId));
+    if (operName !== undefined && operName !== null)
+      url_ += "operName=" + encodeURIComponent("" + operName) + "&";
+    url_ = url_.replace(/[?&]$/, "");
+
+    const content_ = JSON.stringify(reason);
+
+    let options_: RequestInit = {
+      body: content_,
+      method: "PUT",
+      signal,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    return this.http.fetch(url_, options_).then((_response: Response) => {
+      return this.processQuarantineQueuedMaterial(_response);
+    });
+  }
+
+  protected processQuarantineQueuedMaterial(response: Response): Promise<void> {
+    const status = response.status;
+    let _headers: any = {};
+    if (response.headers && response.headers.forEach) {
+      response.headers.forEach((v: any, k: any) => (_headers[k] = v));
+    }
+    if (status === 200) {
+      return response.text().then((_responseText) => {
+        return;
+      });
+    } else if (status === 400) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
+    } else if (status === 409) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
     } else if (status !== 200 && status !== 204) {
       return response.text().then((_responseText) => {
         return throwException(
@@ -1144,6 +1221,18 @@ export class JobsClient {
     if (status === 200) {
       return response.text().then((_responseText) => {
         return;
+      });
+    } else if (status === 400) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
+    } else if (status === 409) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
+    } else if (status === 500) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
       });
     } else if (status !== 200 && status !== 204) {
       return response.text().then((_responseText) => {
@@ -1208,6 +1297,14 @@ export class JobsClient {
           _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
         result200 = MaterialDetails.fromJS(resultData200);
         return result200;
+      });
+    } else if (status === 400) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
+      });
+    } else if (status === 409) {
+      return response.text().then((_responseText) => {
+        return throwException("A server side error occurred.", status, _responseText, _headers);
       });
     } else if (status !== 200 && status !== 204) {
       return response.text().then((_responseText) => {

--- a/client/insight/src/network/backend-mock.ts
+++ b/client/insight/src/network/backend-mock.ts
@@ -267,6 +267,9 @@ export function registerMockBackend(
     signalMaterialForQuarantine(): Promise<void> {
       return Promise.resolve();
     },
+    quarantineQueuedMaterial(): Promise<void> {
+      return Promise.resolve();
+    },
     cancelLoad(): Promise<void> {
       return Promise.resolve();
     },

--- a/client/insight/src/network/backend.ts
+++ b/client/insight/src/network/backend.ts
@@ -73,6 +73,11 @@ export interface JobAPI {
     operName: string | null,
     reason: string | undefined,
   ): Promise<void>;
+  quarantineQueuedMaterial(
+    materialId: number,
+    operName: string | null,
+    reason: string | undefined,
+  ): Promise<void>;
   cancelLoad(
     materialId: number,
     operName: string | null,

--- a/client/insight/test/integration/cancel-load.spec.tsx
+++ b/client/insight/test/integration/cancel-load.spec.tsx
@@ -1,7 +1,16 @@
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { CancelLoadButton } from "../../src/components/station-monitor/CancelLoadButton.js";
+import { QuarantineMatButton } from "../../src/components/station-monitor/QuarantineButton.js";
+import { MaterialDialog } from "../../src/components/station-monitor/Material.js";
+import { AddToQueueButton } from "../../src/components/station-monitor/QueuesAddMaterial.js";
+import {
+  InvalidateCycleDialogButton,
+  type InvalidateCycleState,
+  SwapMaterialButtons,
+  type SwapMaterialState,
+} from "../../src/components/station-monitor/InvalidateCycle.js";
 import { onLoadCurrentSt } from "../../src/cell-status/loading.js";
 import { materialDialogOpen } from "../../src/cell-status/material-details.js";
 import { registerNetworkBackend } from "../../src/network/backend.js";
@@ -54,6 +63,33 @@ async function renderCancelLoadButton(
   );
 }
 
+function MutatingMaterialActions() {
+  const [swapState, setSwapState] = useState<SwapMaterialState>(null);
+  const [invalidateState, setInvalidateState] = useState<InvalidateCycleState | null>(null);
+
+  return (
+    <MaterialDialog
+      buttons={
+        <>
+          <QuarantineMatButton />
+          <CancelLoadButton />
+          <AddToQueueButton
+            st={{ toQueue: null, enteredOperator: null, newMaterialTy: null }}
+            queueNames={["Queue B"]}
+            onClose={() => {}}
+          />
+          <SwapMaterialButtons st={swapState} setState={setSwapState} onClose={() => {}} />
+          <InvalidateCycleDialogButton
+            st={invalidateState}
+            setState={setInvalidateState}
+            onClose={() => {}}
+          />
+        </>
+      }
+    />
+  );
+}
+
 describe("cancel load", () => {
   test("is only available for an instruction with a cancellation ID", async () => {
     const material = loadingMaterial({ materialId: 101, serial: "SERIAL-101" });
@@ -62,6 +98,46 @@ describe("cancel load", () => {
     await expect
       .element(screen.getByRole("button", { name: "Cancel the displayed load instruction" }))
       .not.toBeInTheDocument();
+  });
+
+  test("blocks competing actions and explains machine-control cancellation", async () => {
+    const material = loadingMaterial({ materialId: 101, serial: "SERIAL-101" });
+    vi.spyOn(window, "fetch").mockImplementation(async () => new Response("[]", { status: 200 }));
+    registerNetworkBackend();
+
+    const screen = await renderInsightPage(<MutatingMaterialActions />, {
+      currentStatus: createCurrentStatus({ material: [material] }),
+      fmsInfo: {
+        allowInvalidateMaterialOnQueuesPage: true,
+        allowSwapSerialAtLoadStation: true,
+      },
+      seedStore: (store) => store.set(materialDialogOpen, { type: "InProcMat", inproc: material }),
+    });
+
+    await expect
+      .element(
+        screen.getByText(
+          "This material is part of the current load/unload operation. Complete the operation or cancel it at the machine control before making other changes.",
+        ),
+      )
+      .toBeVisible();
+    await expect
+      .element(screen.getByRole("button", { name: "Cancel Load" }))
+      .not.toBeInTheDocument();
+    await expect
+      .element(screen.getByRole("button", { name: "Quarantine" }))
+      .not.toBeInTheDocument();
+    await expect
+      .element(screen.getByRole("button", { name: /Add To Queue/ }))
+      .not.toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: /Swap/ })).not.toBeInTheDocument();
+    await expect
+      .element(screen.getByRole("button", { name: /Invalidate Cycle/ }))
+      .not.toBeInTheDocument();
+    await expect
+      .element(screen.getByRole("button", { name: /Remove from Queue/ }))
+      .not.toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: "Close" })).toBeVisible();
   });
 
   test("shows the cancellation group and submits its displayed token", async () => {

--- a/client/insight/test/integration/invalidate-cycle.spec.tsx
+++ b/client/insight/test/integration/invalidate-cycle.spec.tsx
@@ -6,6 +6,7 @@ import {
   InvalidateCycleDialogContent,
   type InvalidateCycleState,
 } from "../../src/components/station-monitor/InvalidateCycle.js";
+import { MaterialDialog } from "../../src/components/station-monitor/Material.js";
 import { QuarantineMatButton } from "../../src/components/station-monitor/QuarantineButton.js";
 import { AddToQueueButton } from "../../src/components/station-monitor/QueuesAddMaterial.js";
 import { materialDialogOpen } from "../../src/cell-status/material-details.js";
@@ -38,12 +39,55 @@ function material({
   });
 }
 
-function statusWithMaterial(materials: ReadonlyArray<api.InProcessMaterial>): api.CurrentStatus {
+function statusWithMaterial(
+  materials: ReadonlyArray<api.InProcessMaterial>,
+  jobs: Readonly<Record<string, api.ActiveJob>> = {},
+): api.CurrentStatus {
   return createCurrentStatus({
     material: materials,
+    jobs,
     queues: {
       "Queue A": new api.QueueInfo({ role: api.QueueRole.InProcessTransfer }),
     },
+  });
+}
+
+function quarantinePath(outputQueue: string | undefined): api.ProcPathInfo {
+  return new api.ProcPathInfo({
+    palletNums: [1],
+    load: [],
+    expectedLoadTime: "PT0S",
+    unload: [],
+    expectedUnloadTime: "PT0S",
+    stops: [],
+    simulatedStartingUTC: new Date("2026-04-20T08:00:00Z"),
+    simulatedAverageFlowTime: "PT0S",
+    partsPerPallet: 1,
+    outputQueue,
+  });
+}
+
+function quarantineJob(outputQueue: string | undefined): api.ActiveJob {
+  return new api.ActiveJob({
+    unique: "JOB-1",
+    routeStartUTC: new Date("2026-04-20T08:00:00Z"),
+    routeEndUTC: new Date("2026-05-05T08:00:00Z"),
+    archived: false,
+    partName: "Part",
+    copiedToSystem: true,
+    cycles: 1,
+    procsAndPaths: [
+      new api.ProcessInfo({
+        paths: [quarantinePath(outputQueue)],
+      }),
+      ...(outputQueue === undefined
+        ? [
+            new api.ProcessInfo({
+              paths: [quarantinePath("Queue A")],
+            }),
+          ]
+        : []),
+    ],
   });
 }
 
@@ -216,6 +260,85 @@ describe("cycle invalidation workflow", () => {
     expect(fetch).toHaveBeenCalledWith("/api/v1/log/events/for-material/101", expect.anything());
   });
 
+  test("previews process-zero events for an assignment change", async () => {
+    const selected = material({ materialId: 101 });
+    const localEvents = [
+      logEvent({ counter: 1, process: 0, peerId: 102, peerSerial: "PROCESS-ZERO-PEER" }),
+    ];
+    vi.spyOn(window, "fetch").mockResolvedValue(eventResponse(localEvents));
+    registerNetworkBackend();
+
+    const screen = await renderInsightPage(
+      <Suspense fallback={<div>Loading</div>}>
+        <InvalidateCycleDialogContent
+          st={{
+            process: 1,
+            changeRawMat: "NEW-CASTING",
+            changeJobUnique: null,
+            updating: false,
+            error: null,
+          }}
+          setState={() => {}}
+        />
+      </Suspense>,
+      {
+        currentStatus: statusWithMaterial([selected]),
+        ...dialogData(selected),
+      },
+    );
+
+    await expect.element(screen.getByText("PROCESS-ZERO-PEER")).toBeVisible();
+  });
+
+  test("does not offer quarantine for a basket without a supported exit", async () => {
+    const selected = material({
+      materialId: 201,
+      location: { type: api.LocType.InBasket, basketId: 7, basketSlot: 1 },
+    });
+    const screen = await renderInsightPage(
+      <Suspense fallback={<div>Loading</div>}>
+        <QuarantineMatButton />
+      </Suspense>,
+      {
+        currentStatus: statusWithMaterial([selected], { "JOB-1": quarantineJob(undefined) }),
+        fmsInfo: { quarantineQueue: "Quarantine" },
+        ...dialogData(selected),
+      },
+    );
+
+    await expect
+      .element(screen.getByRole("button", { name: /current automated operation/ }))
+      .not.toBeInTheDocument();
+  });
+
+  test("signals quarantine for a basket with a supported exit", async () => {
+    const selected = material({
+      materialId: 201,
+      location: { type: api.LocType.InBasket, basketId: 7, basketSlot: 1 },
+    });
+    const fetch = vi.spyOn(window, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+    registerNetworkBackend();
+
+    const screen = await renderInsightPage(
+      <Suspense fallback={<div>Loading</div>}>
+        <QuarantineMatButton />
+      </Suspense>,
+      {
+        currentStatus: statusWithMaterial([selected], { "JOB-1": quarantineJob("Queue A") }),
+        fmsInfo: { quarantineQueue: "Quarantine" },
+        ...dialogData(selected),
+      },
+    );
+
+    await screen.getByRole("button", { name: /current automated operation/ }).click();
+    await screen.getByRole("dialog").getByRole("button", { name: "Quarantine" }).click();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/v1/jobs/material/201/signal-quarantine",
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
   test("removes waiting queued material without losing the scanned dialog context", async () => {
     const selected = material({
       materialId: 101,
@@ -231,9 +354,11 @@ describe("cycle invalidation workflow", () => {
       { currentStatus: statusWithMaterial([selected]), ...dialogData(selected) },
     );
 
-    await screen.getByRole("button", { name: "Remove from all queues" }).click();
+    await screen
+      .getByRole("button", { name: "Remove from the current queue so it can be rescanned" })
+      .click();
     const dialog = screen.getByRole("dialog");
-    await dialog.getByRole("button", { name: "Remove from Queues" }).click();
+    await dialog.getByRole("button", { name: "Remove from Queue" }).click();
 
     await expect.element(dialog).not.toBeInTheDocument();
     expect(fetch).toHaveBeenCalledTimes(1);
@@ -261,7 +386,11 @@ describe("cycle invalidation workflow", () => {
 
     await expect.element(screen.getByRole("button", { name: "Move to Quarantine" })).toBeVisible();
     await expect
-      .element(screen.getByRole("button", { name: "Remove from all queues" }))
+      .element(
+        screen.getByRole("button", {
+          name: "Remove from the current queue so it can be rescanned",
+        }),
+      )
       .toBeVisible();
 
     await screen.getByRole("button", { name: "Move to Quarantine" }).click();
@@ -269,7 +398,7 @@ describe("cycle invalidation workflow", () => {
     await dialog.getByRole("button", { name: "Quarantine" }).click();
 
     expect(fetch).toHaveBeenCalledWith(
-      "/api/v1/jobs/material/101/signal-quarantine",
+      "/api/v1/jobs/material/101/quarantine-queued",
       expect.objectContaining({ method: "PUT" }),
     );
   });
@@ -289,12 +418,72 @@ describe("cycle invalidation workflow", () => {
       { currentStatus: statusWithMaterial([selected]), ...dialogData(selected) },
     );
 
-    await screen.getByRole("button", { name: "Remove from all queues" }).click();
+    await screen
+      .getByRole("button", { name: "Remove from the current queue so it can be rescanned" })
+      .click();
     const dialog = screen.getByRole("dialog");
-    await dialog.getByRole("button", { name: "Remove from Queues" }).click();
+    await dialog.getByRole("button", { name: "Remove from Queue" }).click();
 
     await expect.element(dialog).toBeVisible();
     await expect.element(dialog.getByRole("alert")).toHaveTextContent("Queue changed");
+  });
+
+  test("clears quarantine errors and reason when reopened", async () => {
+    const selected = material({
+      materialId: 101,
+      location: { type: api.LocType.InQueue, currentQueue: "Queue A", queuePosition: 0 },
+    });
+    vi.spyOn(window, "fetch").mockResolvedValue(new Response("Queue changed", { status: 409 }));
+    registerNetworkBackend();
+
+    const screen = await renderInsightPage(
+      <Suspense fallback={<div>Loading</div>}>
+        <QuarantineMatButton />
+      </Suspense>,
+      { currentStatus: statusWithMaterial([selected]), ...dialogData(selected) },
+    );
+
+    await screen.getByRole("button", { name: "Remove from queue and treat as scrap" }).click();
+    let dialog = screen.getByRole("dialog");
+    await dialog.getByRole("textbox", { name: "Reason" }).fill("bad material");
+    await dialog.getByRole("button", { name: "Scrap" }).click();
+    await expect.element(dialog.getByRole("alert")).toHaveTextContent("Queue changed");
+
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+    await screen.getByRole("button", { name: "Remove from queue and treat as scrap" }).click();
+    dialog = screen.getByRole("dialog");
+    await expect.element(dialog).not.toHaveTextContent("Queue changed");
+    await expect.element(dialog.getByRole("textbox", { name: "Reason" })).toHaveValue("");
+  });
+
+  test("clears queue-removal errors when reopened", async () => {
+    const selected = material({
+      materialId: 101,
+      location: { type: api.LocType.InQueue, currentQueue: "Queue A", queuePosition: 0 },
+    });
+    vi.spyOn(window, "fetch").mockResolvedValue(new Response("Queue changed", { status: 409 }));
+    registerNetworkBackend();
+
+    const screen = await renderInsightPage(
+      <Suspense fallback={<div>Loading</div>}>
+        <QuarantineMatButton />
+      </Suspense>,
+      { currentStatus: statusWithMaterial([selected]), ...dialogData(selected) },
+    );
+
+    await screen
+      .getByRole("button", { name: "Remove from the current queue so it can be rescanned" })
+      .click();
+    let dialog = screen.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Remove from Queue" }).click();
+    await expect.element(dialog.getByRole("alert")).toHaveTextContent("Queue changed");
+
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+    await screen
+      .getByRole("button", { name: "Remove from the current queue so it can be rescanned" })
+      .click();
+    dialog = screen.getByRole("dialog");
+    await expect.element(dialog).not.toHaveTextContent("Queue changed");
   });
 
   test("retains the dialog context after a successful invalidation", async () => {
@@ -385,6 +574,47 @@ describe("cycle invalidation workflow", () => {
 
     expect(closed).toHaveBeenCalledOnce();
     expect(screen.store.get(materialDialogOpen)).toBeNull();
+  });
+
+  test("allows moving waiting material from one queue to another", async () => {
+    const selected = material({
+      materialId: 101,
+      location: { type: api.LocType.InQueue, currentQueue: "Queue A", queuePosition: 0 },
+    });
+    const fetch = vi.spyOn(window, "fetch").mockImplementation(async (input, init) => {
+      if (init?.method === "GET") return eventResponse([]);
+      if (init?.method === "PUT") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${requestUrl(input)}`);
+    });
+    registerNetworkBackend();
+
+    const screen = await renderInsightPage(
+      <Suspense fallback={<div>Loading</div>}>
+        <MaterialDialog
+          buttons={
+            <AddToQueueButton
+              st={{ toQueue: "Queue B", enteredOperator: null, newMaterialTy: null }}
+              queueNames={["Queue B"]}
+              onClose={() => {}}
+            />
+          }
+        />
+      </Suspense>,
+      { currentStatus: statusWithMaterial([selected]), ...dialogData(selected) },
+    );
+
+    await expect
+      .element(screen.getByRole("button", { name: "Move From Queue A To Queue B" }))
+      .toBeVisible();
+    await screen.getByRole("button", { name: "Move From Queue A To Queue B" }).click();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/v1/jobs/material/101/queue",
+      expect.objectContaining({
+        method: "PUT",
+        body: '{"Queue":"Queue B","Position":-1}',
+      }),
+    );
   });
 
   test("retains queue addition errors in the dialog", async () => {

--- a/client/insight/test/integration/invalidate-cycle.spec.tsx
+++ b/client/insight/test/integration/invalidate-cycle.spec.tsx
@@ -9,6 +9,7 @@ import {
 import { MaterialDialog } from "../../src/components/station-monitor/Material.js";
 import { QuarantineMatButton } from "../../src/components/station-monitor/QuarantineButton.js";
 import { AddToQueueButton } from "../../src/components/station-monitor/QueuesAddMaterial.js";
+import { onLoadCurrentSt } from "../../src/cell-status/loading.js";
 import { materialDialogOpen } from "../../src/cell-status/material-details.js";
 import { registerNetworkBackend, setOtherLogBackends } from "../../src/network/backend.js";
 import * as api from "../../src/network/api.js";
@@ -23,9 +24,11 @@ afterEach(() => {
 function material({
   materialId,
   location = { type: api.LocType.Free },
+  action = { type: api.ActionType.Waiting },
 }: {
   readonly materialId: number;
   readonly location?: api.IInProcessMaterialLocation;
+  readonly action?: api.IInProcessMaterialAction;
 }): api.InProcessMaterial {
   return createMaterial({
     materialID: materialId,
@@ -35,7 +38,7 @@ function material({
     path: 1,
     serial: `SERIAL-${materialId}`,
     location,
-    action: { type: api.ActionType.Waiting },
+    action,
   });
 }
 
@@ -395,6 +398,44 @@ describe("cycle invalidation workflow", () => {
 
     await screen.getByRole("button", { name: "Move to Quarantine" }).click();
     const dialog = screen.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Quarantine" }).click();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/v1/jobs/material/101/quarantine-queued",
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
+  test("preserves the quarantine operation when current status refreshes", async () => {
+    const selected = material({
+      materialId: 101,
+      location: { type: api.LocType.InQueue, currentQueue: "Queue A", queuePosition: 0 },
+    });
+    const refreshed = material({
+      materialId: 101,
+      location: { type: api.LocType.InQueue, currentQueue: "Queue A", queuePosition: 0 },
+      action: { type: api.ActionType.Loading },
+    });
+    const fetch = vi.spyOn(window, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+    registerNetworkBackend();
+
+    const screen = await renderInsightPage(
+      <Suspense fallback={<div>Loading</div>}>
+        <QuarantineMatButton />
+      </Suspense>,
+      {
+        currentStatus: statusWithMaterial([selected]),
+        fmsInfo: { quarantineQueue: "Quarantine" },
+        ...dialogData(selected),
+      },
+    );
+
+    await screen.getByRole("button", { name: "Move to Quarantine" }).click();
+    const dialog = screen.getByRole("dialog");
+    screen.store.set(onLoadCurrentSt, statusWithMaterial([refreshed]));
+
+    await expect.element(dialog).toBeVisible();
+    await expect.element(dialog).toHaveTextContent("Move to Quarantine");
     await dialog.getByRole("button", { name: "Quarantine" }).click();
 
     expect(fetch).toHaveBeenCalledWith(

--- a/client/insight/test/integration/load-station-testkit.ts
+++ b/client/insight/test/integration/load-station-testkit.ts
@@ -27,16 +27,18 @@ export function createCurrentStatus({
   pallets = [],
   baskets = [],
   material = [],
+  jobs = {},
   queues = {},
 }: {
   readonly pallets?: ReadonlyArray<api.PalletStatus>;
   readonly baskets?: ReadonlyArray<api.BasketStatus>;
   readonly material?: ReadonlyArray<api.InProcessMaterial>;
+  readonly jobs?: Readonly<Record<string, api.ActiveJob>>;
   readonly queues?: Readonly<Record<string, api.QueueInfo>>;
 } = {}): api.CurrentStatus {
   return new api.CurrentStatus({
     timeOfCurrentStatusUTC: new Date("2026-04-24T12:00:00Z"),
-    jobs: {},
+    jobs: { ...jobs },
     pallets: Object.fromEntries(pallets.map((p) => [p.palletNum, p])),
     material: Array.from(material),
     alarms: [],

--- a/server/fms-insight-api.json
+++ b/server/fms-insight-api.json
@@ -775,6 +775,12 @@
         "responses": {
           "200": {
             "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
           }
         }
       }
@@ -817,6 +823,61 @@
         },
         "responses": {
           "200": {
+            "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/material/{materialId}/quarantine-queued": {
+      "put": {
+        "tags": ["Jobs"],
+        "operationId": "Jobs_QuarantineQueuedMaterial",
+        "parameters": [
+          {
+            "name": "materialId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "operName",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "reason",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "409": {
             "description": ""
           }
         }
@@ -861,6 +922,15 @@
         },
         "responses": {
           "200": {
+            "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
+          },
+          "500": {
             "description": ""
           }
         }
@@ -932,6 +1002,12 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
           }
         }
       }
@@ -4473,10 +4549,11 @@
       "CancelLoadRequest": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["ExpectedLoadCancellationId", "ExpectedLoadCancellationId"],
+        "required": ["ExpectedLoadCancellationId"],
         "properties": {
           "ExpectedLoadCancellationId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "Reason": {
             "type": "string",

--- a/server/lib/BlackMaple.MachineFramework/api/Material.cs
+++ b/server/lib/BlackMaple.MachineFramework/api/Material.cs
@@ -68,8 +68,12 @@ namespace BlackMaple.MachineFramework
     public string? WorkId { get; init; }
 
     /// <summary>
-    /// Opaque token identifying the currently offered load cancellation. Every material in one
-    /// atomic cancellation unit carries the same token.
+    /// Opaque operation-instance token identifying the currently offered cancellation of one
+    /// complete operator-facing load-station instruction. The instruction may include loading,
+    /// unloading, basket transfers, or unload/reload operations. Every material in one atomic
+    /// cancellation unit carries the same nonblank token; it remains stable while the advertised
+    /// operation is unchanged and changes when the operation's membership or cancellation effects
+    /// change. It is not a reusable slot or operation-category identifier.
     /// </summary>
     public string? LoadCancellationId { get; init; }
 

--- a/server/lib/BlackMaple.MachineFramework/backend/BackendInterfaces.cs
+++ b/server/lib/BlackMaple.MachineFramework/backend/BackendInterfaces.cs
@@ -73,11 +73,23 @@ namespace BlackMaple.MachineFramework
   public interface ILoadCancel<in St>
     where St : ICellState
   {
+    /// <summary>
+    /// Cancels one complete operator-facing load-station instruction.
+    /// </summary>
+    /// <remarks>
+    /// The instruction may include loading, unloading, basket transfers, or unload/reload
+    /// operations. <see cref="JobsAndQueuesFromDb{St}" /> validates the selected material, exact
+    /// cancellation ID, complete group, and duplicate-request state before invoking this method.
+    /// The handler runs while the server change lock is held and must durably record all effects
+    /// before returning. It should be short-running, avoid unnecessary network I/O, and be atomic
+    /// or safely idempotent if external effects can occur before an exception. Throwing means the
+    /// cancellation failed: the ID is not consumed and state recalculation is not requested.
+    /// </remarks>
     void CancelLoad(
       IRepository repository,
       St state,
       InProcessMaterial selectedMaterial,
-      ImmutableList<InProcessMaterial> material,
+      ImmutableList<InProcessMaterial> cancellationGroup,
       string cancellationId,
       string? operatorName,
       string? reason

--- a/server/lib/BlackMaple.MachineFramework/backend/JobsAndQueuesFromDb.cs
+++ b/server/lib/BlackMaple.MachineFramework/backend/JobsAndQueuesFromDb.cs
@@ -34,15 +34,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace BlackMaple.MachineFramework
 {
+  /// <summary>Identifies the exact currently advertised load-station instruction to cancel.</summary>
   public record CancelLoadRequest
   {
-    public required string ExpectedLoadCancellationId { get; init; }
+    /// <summary>
+    /// Opaque operation-instance ID displayed with the load-station instruction. The server
+    /// rejects a missing or blank value as a malformed request.
+    /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    public string ExpectedLoadCancellationId { get; init; } = null!;
+
+    /// <summary>Optional operator context recorded by the backend.</summary>
     public string? Reason { get; init; }
   }
 
@@ -119,14 +128,25 @@ namespace BlackMaple.MachineFramework
       string? operatorName = null
     );
 
-    /// Mark the material for quarantine.  If the material is already in a queue, it is directly moved.
-    /// If the material is still on a pallet, it will be moved after unload completes.
+    /// Record a deferred quarantine intent for automation-controlled material. The backend observes
+    /// this event and decides how to handle the material after it leaves automation control.
     void SignalMaterialForQuarantine(
       long materialId,
       string? operatorName = null,
       string? reason = null
     );
 
+    /// Directly quarantine material which is waiting in a human-controlled queue.
+    void QuarantineQueuedMaterial(
+      long materialId,
+      string? operatorName = null,
+      string? reason = null
+    );
+
+    /// <summary>
+    /// Cancels the complete currently advertised load-station instruction identified by the
+    /// expected operation-instance ID.
+    /// </summary>
     void CancelLoad(
       long materialId,
       string expectedLoadCancellationId,
@@ -134,6 +154,7 @@ namespace BlackMaple.MachineFramework
       string? reason = null
     );
 
+    /// Remove material only from a human-controlled waiting queue.
     void RemoveMaterialFromAllQueues(IList<long> materialIds, string? operatorName = null);
 
     void SwapMaterialOnPallet(
@@ -144,6 +165,7 @@ namespace BlackMaple.MachineFramework
     );
     event EditMaterialInLogDelegate? OnEditMaterialInLog;
 
+    /// Reject a current add-to-queue proposal by invalidating its latest process or all processes.
     MaterialDetails? InvalidatePalletCycle(
       long matId,
       int process,
@@ -163,7 +185,7 @@ namespace BlackMaple.MachineFramework
     private readonly FMSSettings _settings;
     private readonly ISynchronizeCellState<St> _syncState;
     private readonly IEnumerable<IAdditionalCheckJobs> _additionalCheckJobs;
-    private readonly ImmutableList<ILoadCancel<St>> _loadCancelHandlers;
+    private readonly ILoadCancel<St>? _loadCancelHandler;
 
     public event NewCurrentStatus? OnNewCurrentStatus;
 
@@ -173,7 +195,7 @@ namespace BlackMaple.MachineFramework
       FMSSettings settings,
       ISynchronizeCellState<St> syncSt,
       IEnumerable<IAdditionalCheckJobs>? additionalCheckJobs = null,
-      IEnumerable<ILoadCancel<St>>? loadCancelHandlers = null,
+      ILoadCancel<St>? loadCancelHandler = null,
       bool startThread = true
     )
     {
@@ -182,9 +204,7 @@ namespace BlackMaple.MachineFramework
       _serverSettings = serverSt;
       _syncState = syncSt;
       _additionalCheckJobs = additionalCheckJobs ?? Enumerable.Empty<IAdditionalCheckJobs>();
-      _loadCancelHandlers = (
-        loadCancelHandlers ?? Enumerable.Empty<ILoadCancel<St>>()
-      ).ToImmutableList();
+      _loadCancelHandler = loadCancelHandler;
       _syncState.NewCellState += NewCellState;
 
       _thread = new Thread(Thread) { IsBackground = true };
@@ -326,13 +346,21 @@ namespace BlackMaple.MachineFramework
           {
             _newCellState.Reset();
             var st = _syncState.CalculateCellState(db);
+            ValidateLoadCancellationState(st);
             raiseNewCurStatus = raiseNewCurStatus || st.StateUpdated;
             timeUntilNextRefresh = st.TimeUntilNextRefresh;
 
             lock (_curStLock)
             {
               _lastCurrentStatus = st;
-              _consumedLoadCancellationIds = ImmutableHashSet<string>.Empty;
+              var currentlyAdvertisedIds = st
+                .CurrentStatus.Material.Select(m => m.Action.LoadCancellationId)
+                .OfType<string>()
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToImmutableHashSet();
+              _consumedLoadCancellationIds = _consumedLoadCancellationIds.Intersect(
+                currentlyAdvertisedIds
+              );
             }
 
             if (raiseNewCurStatus && Log.IsEnabled(Serilog.Events.LogEventLevel.Verbose))
@@ -408,6 +436,28 @@ namespace BlackMaple.MachineFramework
         {
           OnNewCurrentStatus?.Invoke(GetCurrentStatus());
         }
+      }
+    }
+
+    private void ValidateLoadCancellationState(St state)
+    {
+      var advertisedIds = state
+        .CurrentStatus.Material.Select(material => material.Action.LoadCancellationId)
+        .Where(id => id is not null)
+        .ToImmutableList();
+
+      if (advertisedIds.Any(string.IsNullOrWhiteSpace))
+      {
+        throw new InvalidOperationException(
+          "The backend advertised a blank load cancellation ID. Use null when cancellation is unavailable"
+        );
+      }
+
+      if (advertisedIds.Count > 0 && _loadCancelHandler is null)
+      {
+        throw new InvalidOperationException(
+          "The backend advertised a load cancellation, but no load cancellation handler is configured"
+        );
       }
     }
 
@@ -747,7 +797,6 @@ namespace BlackMaple.MachineFramework
         position
       );
 
-      string? error = null;
       bool requireStateRefresh = false;
 
       using (var ldb = _repo.OpenConnection())
@@ -761,32 +810,37 @@ namespace BlackMaple.MachineFramework
           }
 
           var mat = st?.Material.FirstOrDefault(m => m.MaterialID == materialId);
-          if (mat != null && mat.Location.Type == InProcessMaterialLocation.LocType.OnPallet)
+          var isReorder =
+            mat?.Location.Type == InProcessMaterialLocation.LocType.InQueue
+            && mat.Location.CurrentQueue == queue;
+          if (!isReorder && mat is not null)
           {
-            error = "Material on pallet can not be moved to a queue";
+            var operation = MaterialOperationState.Classify(mat);
+            if (
+              operation
+              is not (
+                MaterialOperationKind.HumanControlledQueuedMaterial
+                or MaterialOperationKind.EligibleAddToQueueProposal
+              )
+            )
+            {
+              throw new ConflictRequestException(
+                "Material is owned by an active operation and cannot be moved to another queue."
+              );
+            }
           }
-          else if (
-            mat != null
-            && mat.Action.Type != InProcessMaterialAction.ActionType.Waiting
-            && mat.Location.CurrentQueue != queue
-          )
-          {
-            error = "Only waiting material can be moved between queues";
-          }
-          else
-          {
-            var nextProc = ldb.NextProcessForQueuedMaterial(materialId);
-            var proc = (nextProc ?? 1) - 1;
-            ldb.RecordAddMaterialToQueue(
-              matID: materialId,
-              process: proc,
-              queue: queue,
-              position: position,
-              operatorName: operatorName,
-              reason: "SetByOperator"
-            );
-            requireStateRefresh = true;
-          }
+
+          var nextProc = ldb.NextProcessForQueuedMaterial(materialId);
+          var proc = (nextProc ?? 1) - 1;
+          ldb.RecordAddMaterialToQueue(
+            matID: materialId,
+            process: proc,
+            queue: queue,
+            position: position,
+            operatorName: operatorName,
+            reason: "SetByOperator"
+          );
+          requireStateRefresh = true;
         }
       }
 
@@ -794,19 +848,11 @@ namespace BlackMaple.MachineFramework
       {
         RecalculateCellState();
       }
-
-      if (error != null)
-      {
-        throw new BadRequestException(error);
-      }
     }
 
     public void RemoveMaterialFromAllQueues(IList<long> materialIds, string? operatorName)
     {
       Log.Debug("Removing {@matId} from all queues", materialIds);
-
-      string? error = null;
-      bool requireStateRefresh = false;
 
       lock (_changeLock)
       {
@@ -820,42 +866,30 @@ namespace BlackMaple.MachineFramework
         foreach (var matId in materialIds)
         {
           var mat = st?.Material.FirstOrDefault(m => m.MaterialID == matId);
-          if (mat != null && mat.Location.Type == InProcessMaterialLocation.LocType.OnPallet)
+          if (mat == null)
           {
-            error = "Material on pallet can not be removed from queues";
-            break;
+            throw new ConflictRequestException("Material not found in the current cell state.");
           }
-          else if (mat != null && mat.Action.Type != InProcessMaterialAction.ActionType.Waiting)
+          else if (
+            MaterialOperationState.Classify(mat)
+            != MaterialOperationKind.HumanControlledQueuedMaterial
+          )
           {
-            error = "Only waiting material can be removed from queues";
-            break;
+            throw new ConflictRequestException(
+              "Material must be waiting in a queue with no active operation."
+            );
           }
         }
 
-        if (error == null)
-        {
-          ldb.BulkRemoveMaterialFromAllQueues(materialIds, operatorName);
-          requireStateRefresh = true;
-        }
+        ldb.BulkRemoveMaterialFromAllQueues(materialIds, operatorName);
       }
 
-      if (requireStateRefresh)
-      {
-        RecalculateCellState();
-      }
-
-      if (error != null)
-      {
-        throw new BadRequestException(error);
-      }
+      RecalculateCellState();
     }
 
     public void SignalMaterialForQuarantine(long materialId, string? operatorName, string? reason)
     {
       Log.Debug("Signaling {matId} for quarantine", materialId);
-
-      string? error = null;
-      bool requireStateRefresh = false;
 
       using (var ldb = _repo.OpenConnection())
       {
@@ -870,132 +904,93 @@ namespace BlackMaple.MachineFramework
           var mat = st?.Material.FirstOrDefault(m => m.MaterialID == materialId);
 
           if (mat == null)
-          {
-            error = "Material not found";
-          }
-          else
-          {
-            switch (mat.Location.Type, mat.Action.Type)
+            throw new ConflictRequestException("Material not found in the current cell state.");
+          if (MaterialOperationState.Classify(mat) != MaterialOperationKind.AutomationControlled)
+            throw new ConflictRequestException(
+              "Material is not eligible for deferred quarantine in its current state."
+            );
+          if (
+            mat.Location.Type
+            is not (
+              InProcessMaterialLocation.LocType.OnPallet
+              or InProcessMaterialLocation.LocType.InBasket
+            )
+          )
+            throw new ConflictRequestException(
+              "Material does not have a supported path out of automation control."
+            );
+
+          var job = st?.Jobs.GetValueOrDefault(mat.JobUnique);
+          if (job == null)
+            throw new ConflictRequestException("Material job is no longer current.");
+          if (
+            mat.Process < 1
+            || mat.Process > job.Processes.Count
+            || mat.Path < 1
+            || mat.Path > job.Processes[mat.Process - 1].Paths.Count
+          )
+            throw new ConflictRequestException("Material routing is no longer current.");
+
+          var path = job.Processes[mat.Process - 1].Paths[mat.Path - 1];
+          if (mat.Process != job.Processes.Count && string.IsNullOrEmpty(path.OutputQueue))
+            throw new ConflictRequestException(
+              "Material does not have a supported path out of automation control."
+            );
+
+          ldb.SignalMaterialForQuarantine(
+            mat: new EventLogMaterial()
             {
-              case (InProcessMaterialLocation.LocType.OnPallet, _):
-                if (mat.Action.Type == InProcessMaterialAction.ActionType.Loading)
-                {
-                  error = "Material on pallet can not be quarantined while loading";
-                }
-                else
-                {
-                  // If the material will eventually stay on the pallet, disallow quarantine
-                  var job = st?.Jobs.GetValueOrDefault(mat.JobUnique);
-                  if (job == null)
-                  {
-                    error = "Job not found";
-                  }
-                  else
-                  {
-                    var path = job.Processes[mat.Process - 1].Paths[mat.Path - 1];
-                    if (
-                      mat.Process != job.Processes.Count
-                      && (path == null || path.OutputQueue == null)
-                    )
-                    {
-                      error =
-                        "Can only signal material for quarantine if the current process and path has an output queue";
-                    }
-                  }
-                }
-                if (error == null)
-                {
-                  ldb.SignalMaterialForQuarantine(
-                    mat: new EventLogMaterial()
-                    {
-                      MaterialID = materialId,
-                      Process = mat.Process,
-                      Face = 0,
-                    },
-                    pallet: mat.Location.PalletNum ?? 0,
-                    queue: _settings.QuarantineQueue ?? "",
-                    timeUTC: null,
-                    operatorName: operatorName,
-                    reason: reason
-                  );
-                  requireStateRefresh = true;
-                }
-                break;
-
-              case (
-                InProcessMaterialLocation.LocType.Free,
-                InProcessMaterialAction.ActionType.Waiting
-              ) when !string.IsNullOrEmpty(_settings.QuarantineQueue):
-              case (
-                InProcessMaterialLocation.LocType.InQueue,
-                InProcessMaterialAction.ActionType.Waiting
-              ) when !string.IsNullOrEmpty(_settings.QuarantineQueue):
-                {
-                  var nextProc = ldb.NextProcessForQueuedMaterial(materialId);
-                  var proc = (nextProc ?? 1) - 1;
-                  if (!string.IsNullOrEmpty(reason))
-                  {
-                    ldb.RecordOperatorNotes(
-                      materialId: materialId,
-                      process: proc,
-                      notes: reason,
-                      operatorName: operatorName
-                    );
-                  }
-                  ldb.RecordAddMaterialToQueue(
-                    matID: materialId,
-                    process: proc,
-                    queue: _settings.QuarantineQueue,
-                    position: -1,
-                    operatorName: operatorName,
-                    reason: "Quarantine"
-                  );
-                  requireStateRefresh = true;
-                }
-                break;
-
-              case (
-                InProcessMaterialLocation.LocType.InQueue,
-                InProcessMaterialAction.ActionType.Waiting
-              ) when string.IsNullOrEmpty(_settings.QuarantineQueue):
-                {
-                  var nextProc = ldb.NextProcessForQueuedMaterial(materialId);
-                  var proc = (nextProc ?? 1) - 1;
-                  if (!string.IsNullOrEmpty(reason))
-                  {
-                    ldb.RecordOperatorNotes(
-                      materialId: materialId,
-                      process: proc,
-                      notes: reason,
-                      operatorName: operatorName
-                    );
-                  }
-                  ldb.BulkRemoveMaterialFromAllQueues(
-                    new[] { materialId },
-                    operatorName: operatorName,
-                    reason: "Quarantine"
-                  );
-                  requireStateRefresh = true;
-                }
-                break;
-
-              default:
-                error = "Invalid material state for quarantine";
-                break;
-            }
-          }
+              MaterialID = materialId,
+              Process = mat.Process,
+              Face = 0,
+            },
+            pallet: mat.Location.Type == InProcessMaterialLocation.LocType.OnPallet
+              ? mat.Location.PalletNum ?? 0
+              : 0,
+            queue: _settings.QuarantineQueue ?? "",
+            timeUTC: null,
+            operatorName: operatorName,
+            reason: reason
+          );
         }
       }
 
-      if (requireStateRefresh)
+      RecalculateCellState();
+    }
+
+    public void QuarantineQueuedMaterial(long materialId, string? operatorName, string? reason)
+    {
+      Log.Debug("Directly quarantining queued material {matId}", materialId);
+
+      lock (_changeLock)
       {
-        RecalculateCellState();
+        CurrentStatus? st;
+        lock (_curStLock)
+        {
+          st = _lastCurrentStatus?.CurrentStatus;
+        }
+
+        var mat = st?.Material.FirstOrDefault(m => m.MaterialID == materialId);
+        if (mat == null)
+          throw new ConflictRequestException("Material not found in the current cell state.");
+        if (
+          MaterialOperationState.Classify(mat)
+          != MaterialOperationKind.HumanControlledQueuedMaterial
+        )
+          throw new ConflictRequestException(
+            "Material must be waiting in a queue with no active operation."
+          );
+
+        using var ldb = _repo.OpenConnection();
+        ldb.QuarantineQueuedMaterial(
+          matId: materialId,
+          quarantineQueue: _settings.QuarantineQueue,
+          operatorName: operatorName,
+          reason: reason
+        );
       }
 
-      if (error != null)
-      {
-        throw new BadRequestException(error);
-      }
+      RecalculateCellState();
     }
 
     public void CancelLoad(
@@ -1030,31 +1025,38 @@ namespace BlackMaple.MachineFramework
             "The displayed load cancellation is no longer current."
           );
 
-        var material = state!
+        if (
+          MaterialOperationState.Classify(selected)
+          != MaterialOperationKind.ActiveLoadStationOperation
+        )
+          throw new ConflictRequestException(
+            "The displayed load cancellation is no longer current."
+          );
+
+        var cancellationGroup = state!
           .CurrentStatus.Material.Where(m =>
             m.Action.LoadCancellationId == expectedLoadCancellationId
           )
           .ToImmutableList();
-        if (material.IsEmpty)
+        if (cancellationGroup.IsEmpty)
           throw new ConflictRequestException(
             "The displayed load cancellation is no longer current."
           );
-        if (_loadCancelHandlers.Count != 1)
+        if (_loadCancelHandler is null)
           throw new InvalidOperationException(
-            "A load cancellation was advertised, but this backend does not have exactly one load cancellation handler."
+            "A load cancellation was advertised, but this backend does not have a load cancellation handler."
           );
 
         using var repository = _repo.OpenConnection();
-        _loadCancelHandlers[0]
-          .CancelLoad(
-            repository,
-            state,
-            selected,
-            material,
-            expectedLoadCancellationId,
-            operatorName,
-            reason
-          );
+        _loadCancelHandler.CancelLoad(
+          repository,
+          state,
+          selected,
+          cancellationGroup,
+          expectedLoadCancellationId,
+          operatorName,
+          reason
+        );
         _consumedLoadCancellationIds = _consumedLoadCancellationIds.Add(expectedLoadCancellationId);
       }
 
@@ -1114,9 +1116,26 @@ namespace BlackMaple.MachineFramework
       {
         using var db = _repo.OpenConnection();
 
+        if (process < 1)
+        {
+          throw new BadRequestException("Process must be at least 1.");
+        }
+
+        if (!string.IsNullOrEmpty(changeCastingTo) && !string.IsNullOrEmpty(changeJobUniqueTo))
+        {
+          throw new BadRequestException("Can not change both casting and job assignment");
+        }
+
+        CurrentStatus? st;
+        lock (_curStLock)
+        {
+          st = _lastCurrentStatus?.CurrentStatus;
+        }
+        ValidateMaterialForInvalidation(st, matId);
+
         if (!string.IsNullOrEmpty(changeCastingTo))
         {
-          if (process > 1)
+          if (process != 1)
           {
             throw new BadRequestException(
               "Can only change casting when invalidating all processes"
@@ -1128,12 +1147,14 @@ namespace BlackMaple.MachineFramework
             changeJobUniqueTo: null,
             changePartNameTo: changeCastingTo,
             changeNumProcessesTo: 1,
-            operatorName: operatorName
+            operatorName: operatorName,
+            validateAffectedMaterials: affected =>
+              ValidateAffectedMaterialsForInvalidation(st, affected)
           );
         }
         else if (!string.IsNullOrEmpty(changeJobUniqueTo))
         {
-          if (process > 1)
+          if (process != 1)
           {
             throw new BadRequestException("Can only change job when invalidating all processes");
           }
@@ -1147,20 +1168,61 @@ namespace BlackMaple.MachineFramework
             changeJobUniqueTo: changeJobUniqueTo,
             changePartNameTo: job.PartName,
             changeNumProcessesTo: job.Processes.Count,
-            operatorName: operatorName
+            operatorName: operatorName,
+            validateAffectedMaterials: affected =>
+              ValidateAffectedMaterialsForInvalidation(st, affected)
           );
         }
         else
         {
-          db.InvalidatePalletCycle(matId: matId, process: process, operatorName: operatorName);
+          db.InvalidatePalletCycle(
+            matId: matId,
+            process: process,
+            operatorName: operatorName,
+            validateAffectedMaterials: affected =>
+              ValidateAffectedMaterialsForInvalidation(st, affected)
+          );
         }
 
         materialDetails = db.GetMaterialDetails(matId);
       }
 
       RecalculateCellState();
-
       return materialDetails;
+    }
+
+    private static void ValidateMaterialForInvalidation(CurrentStatus? state, long materialId)
+    {
+      if (state == null)
+      {
+        throw new ConflictRequestException("Current cell state is unavailable.");
+      }
+
+      var material = state.Material.FirstOrDefault(m => m.MaterialID == materialId);
+      if (material == null)
+      {
+        return;
+      }
+      if (
+        MaterialOperationState.Classify(material)
+        != MaterialOperationKind.EligibleAddToQueueProposal
+      )
+      {
+        throw new ConflictRequestException(
+          "Material is not eligible for cycle invalidation in its current state."
+        );
+      }
+    }
+
+    private static void ValidateAffectedMaterialsForInvalidation(
+      CurrentStatus? state,
+      ImmutableList<EventLogMaterial> affectedMaterials
+    )
+    {
+      foreach (var materialId in affectedMaterials.Select(m => m.MaterialID).Distinct())
+      {
+        ValidateMaterialForInvalidation(state, materialId);
+      }
     }
     #endregion
   }

--- a/server/lib/BlackMaple.MachineFramework/backend/JobsAndQueuesFromDb.cs
+++ b/server/lib/BlackMaple.MachineFramework/backend/JobsAndQueuesFromDb.cs
@@ -1126,6 +1126,16 @@ namespace BlackMaple.MachineFramework
           throw new BadRequestException("Can not change both casting and job assignment");
         }
 
+        if (!string.IsNullOrEmpty(changeCastingTo) && process != 1)
+        {
+          throw new BadRequestException("Can only change casting when invalidating all processes");
+        }
+
+        if (!string.IsNullOrEmpty(changeJobUniqueTo) && process != 1)
+        {
+          throw new BadRequestException("Can only change job when invalidating all processes");
+        }
+
         CurrentStatus? st;
         lock (_curStLock)
         {
@@ -1135,13 +1145,6 @@ namespace BlackMaple.MachineFramework
 
         if (!string.IsNullOrEmpty(changeCastingTo))
         {
-          if (process != 1)
-          {
-            throw new BadRequestException(
-              "Can only change casting when invalidating all processes"
-            );
-          }
-
           db.InvalidateAndChangeAssignment(
             matId: matId,
             changeJobUniqueTo: null,
@@ -1154,10 +1157,6 @@ namespace BlackMaple.MachineFramework
         }
         else if (!string.IsNullOrEmpty(changeJobUniqueTo))
         {
-          if (process != 1)
-          {
-            throw new BadRequestException("Can only change job when invalidating all processes");
-          }
           var job = db.LoadJob(changeJobUniqueTo);
           if (job == null)
           {

--- a/server/lib/BlackMaple.MachineFramework/backend/MaterialOperationState.cs
+++ b/server/lib/BlackMaple.MachineFramework/backend/MaterialOperationState.cs
@@ -1,0 +1,63 @@
+/* Copyright (c) 2026, SeedTactics
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ */
+
+namespace BlackMaple.MachineFramework;
+
+internal enum MaterialOperationKind
+{
+  ActiveLoadStationOperation,
+  AutomationControlled,
+  HumanControlledQueuedMaterial,
+  EligibleAddToQueueProposal,
+}
+
+/// <summary>
+/// Classifies the current owner of material-changing operations. Callers must hold the
+/// <c>JobsAndQueuesFromDb</c> change lock while using the classification with current status.
+/// </summary>
+internal static class MaterialOperationState
+{
+  public static MaterialOperationKind Classify(InProcessMaterial material)
+  {
+    // A cancellation ID is authoritative even when a backend uses an unusual action or location
+    // representation. A non-null blank ID is invalid backend state, but remains protected here so
+    // a direct caller cannot accidentally bypass station-operation exclusivity.
+    if (material.Action.LoadCancellationId is not null || IsLoadStationAction(material.Action.Type))
+      return MaterialOperationKind.ActiveLoadStationOperation;
+
+    if (
+      material.Location.Type == InProcessMaterialLocation.LocType.InQueue
+      && material.Action.Type == InProcessMaterialAction.ActionType.Waiting
+    )
+      return MaterialOperationKind.HumanControlledQueuedMaterial;
+
+    if (
+      material.Location.Type
+        is InProcessMaterialLocation.LocType.OnPallet
+          or InProcessMaterialLocation.LocType.InBasket
+      || material.Action.Type == InProcessMaterialAction.ActionType.Machining
+    )
+      return MaterialOperationKind.AutomationControlled;
+
+    return MaterialOperationKind.EligibleAddToQueueProposal;
+  }
+
+  private static bool IsLoadStationAction(InProcessMaterialAction.ActionType action) =>
+    action
+      is InProcessMaterialAction.ActionType.Loading
+        or InProcessMaterialAction.ActionType.UnloadToInProcess
+        or InProcessMaterialAction.ActionType.UnloadToCompletedMaterial
+        or InProcessMaterialAction.ActionType.LoadingToBasket;
+}

--- a/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/EventLog.cs
@@ -4385,6 +4385,68 @@ namespace BlackMaple.MachineFramework
       });
     }
 
+    public IEnumerable<LogEntry> QuarantineQueuedMaterial(
+      long matId,
+      string quarantineQueue,
+      string operatorName = null,
+      string reason = null,
+      DateTime? timeUTC = null
+    )
+    {
+      return AddEntryInTransaction(trans =>
+      {
+        var time = timeUTC ?? DateTime.UtcNow;
+        var nextProc = NextProcessForQueuedMaterial(trans, matId);
+        var proc = (nextProc ?? 1) - 1;
+        var logs = new List<LogEntry>();
+
+        if (!string.IsNullOrWhiteSpace(reason))
+        {
+          logs.Add(
+            RecordOperatorNotes(
+              trans,
+              materialId: matId,
+              process: proc,
+              notes: reason,
+              operatorName: operatorName,
+              timeUTC: time
+            )
+          );
+        }
+
+        if (string.IsNullOrWhiteSpace(quarantineQueue))
+        {
+          logs.AddRange(
+            RemoveFromAllQueues(
+              trans,
+              matId,
+              proc,
+              operatorName,
+              reason: "Quarantine",
+              timeUTC: time
+            )
+          );
+        }
+        else
+        {
+          logs.AddRange(
+            AddToQueue(
+              trans,
+              matId,
+              proc,
+              quarantineQueue,
+              position: -1,
+              operatorName,
+              time,
+              reason: "Quarantine"
+            )
+          );
+        }
+
+        return logs;
+      });
+    }
+
     public LogEntry SignalMaterialForQuarantine(
       EventLogMaterial mat,
       int pallet,
@@ -4496,24 +4558,56 @@ namespace BlackMaple.MachineFramework
       {
         throw new ArgumentException("Operator notes cannot be empty", nameof(notes));
       }
+      return AddEntryInTransaction(trans =>
+        RecordOperatorNotes(
+          trans,
+          materialId,
+          process,
+          notes,
+          operatorName,
+          timeUtc ?? DateTime.UtcNow
+        )
+      );
+    }
+
+    private LogEntry RecordOperatorNotes(
+      IDbTransaction trans,
+      long materialId,
+      int process,
+      string notes,
+      string operatorName,
+      DateTime timeUTC
+    )
+    {
       var extra = new Dictionary<string, string>();
       extra["note"] = notes;
       if (!string.IsNullOrEmpty(operatorName))
       {
         extra["operator"] = operatorName;
       }
-      return RecordGeneralMessage(
-        mat: new EventLogMaterial()
+      var log = new NewEventLogEntry()
+      {
+        Material = new[]
         {
-          MaterialID = materialId,
-          Process = process,
-          Face = 0,
+          new EventLogMaterial()
+          {
+            MaterialID = materialId,
+            Process = process,
+            Face = 0,
+          },
         },
-        program: "OperatorNotes",
-        result: "Operator Notes",
-        timeUTC: timeUtc,
-        extraData: extra
-      );
+        Pallet = 0,
+        LogType = LogType.GeneralMessage,
+        LocationName = "Message",
+        LocationNum = 1,
+        Program = "OperatorNotes",
+        StartOfCycle = false,
+        EndTimeUTC = timeUTC,
+        Result = "Operator Notes",
+      };
+      foreach (var x in extra)
+        log.ProgramDetails.Add(x.Key, x.Value);
+      return AddLogEntry(trans, log, null, null);
     }
 
     public SwapMaterialResult SwapMaterialInCurrentPalletCycle(
@@ -4810,7 +4904,8 @@ namespace BlackMaple.MachineFramework
       string operatorName,
       DateTime timeUTC,
       SqliteTransaction trans,
-      List<LogEntry> newLogEntries
+      List<LogEntry> newLogEntries,
+      Action<ImmutableList<EventLogMaterial>> validateAffectedMaterials = null
     )
     {
       using var getCycles = _connection.CreateCommand();
@@ -4890,6 +4985,34 @@ namespace BlackMaple.MachineFramework
         }
       }
 
+      if (process is > 1)
+      {
+        using var getLatestProcess = _connection.CreateCommand();
+        getLatestProcess.CommandText =
+          "SELECT MAX(m.Process) FROM stations s "
+          + "JOIN stations_mat m ON s.Counter = m.Counter "
+          + "WHERE m.MaterialID = $matid "
+          + "AND s.StationLoc IN ("
+          + LogTypesToCheckForNextProcess
+          + ") AND NOT EXISTS("
+          + "SELECT 1 FROM program_details d WHERE s.Counter = d.Counter AND d.Key = 'PalletCycleInvalidated'"
+          + ")";
+        getLatestProcess.Parameters.Add("matid", SqliteType.Integer).Value = matId;
+        getLatestProcess.Transaction = trans;
+
+        var latestProcess = getLatestProcess.ExecuteScalar();
+        if (latestProcess is DBNull || latestProcess is null)
+        {
+          throw new ConflictRequestException("No valid process remains to invalidate.");
+        }
+
+        var latestProcessNumber = Convert.ToInt32(latestProcess);
+        if (latestProcessNumber != process.Value)
+        {
+          throw new ConflictRequestException("The requested process is no longer current.");
+        }
+      }
+
       foreach (var affectedMatId in allMatIds.Select(m => m.matId).Distinct())
       {
         checkQueueCmd.Parameters[0].Value = affectedMatId;
@@ -4901,6 +5024,21 @@ namespace BlackMaple.MachineFramework
           );
         }
       }
+
+      if (invalidatedCntrs.Count == 0)
+      {
+        throw new ConflictRequestException("No valid process remains to invalidate.");
+      }
+
+      var affectedMaterials = allMatIds
+        .Select(m => new EventLogMaterial()
+        {
+          MaterialID = m.matId,
+          Process = m.proc,
+          Face = 0,
+        })
+        .ToImmutableList();
+      validateAffectedMaterials?.Invoke(affectedMaterials);
 
       foreach (var cntr in invalidatedCntrs)
       {
@@ -4921,12 +5059,7 @@ namespace BlackMaple.MachineFramework
       // record events
       var newMsg = new NewEventLogEntry()
       {
-        Material = allMatIds.Select(m => new EventLogMaterial()
-        {
-          MaterialID = m.matId,
-          Process = m.proc,
-          Face = 0,
-        }),
+        Material = affectedMaterials,
         Pallet = 0,
         LogType = LogType.InvalidateCycle,
         LocationName = "InvalidateCycle",
@@ -4948,7 +5081,8 @@ namespace BlackMaple.MachineFramework
       long matId,
       int process,
       string operatorName,
-      DateTime? timeUTC = null
+      DateTime? timeUTC = null,
+      Action<ImmutableList<EventLogMaterial>> validateAffectedMaterials = null
     )
     {
       var newLogEntries = new List<LogEntry>();
@@ -4963,7 +5097,8 @@ namespace BlackMaple.MachineFramework
           operatorName: operatorName,
           timeUTC: timeUTC ?? DateTime.UtcNow,
           trans: trans,
-          newLogEntries: newLogEntries
+          newLogEntries: newLogEntries,
+          validateAffectedMaterials: validateAffectedMaterials
         );
 
         trans.Commit();
@@ -4981,7 +5116,8 @@ namespace BlackMaple.MachineFramework
       string changeJobUniqueTo,
       string changePartNameTo,
       int changeNumProcessesTo,
-      DateTime? timeUTC = null
+      DateTime? timeUTC = null,
+      Action<ImmutableList<EventLogMaterial>> validateAffectedMaterials = null
     )
     {
       var newLogEntries = new List<LogEntry>();
@@ -4989,15 +5125,6 @@ namespace BlackMaple.MachineFramework
       lock (_cfg)
       {
         using var trans = _connection.BeginTransaction();
-
-        InvalidatePalletCycle(
-          matId: matId,
-          process: null,
-          operatorName: operatorName,
-          timeUTC: timeUTC ?? DateTime.UtcNow,
-          trans: trans,
-          newLogEntries: newLogEntries
-        );
 
         using var updateMatDetailsCmd = _connection.CreateCommand();
         updateMatDetailsCmd.Transaction = trans;
@@ -5013,6 +5140,19 @@ namespace BlackMaple.MachineFramework
           changeNumProcessesTo;
         updateMatDetailsCmd.Parameters.Add("mid", SqliteType.Integer).Value = matId;
         updateMatDetailsCmd.ExecuteNonQuery();
+
+        // Update the assignment before creating the invalidation event so the event describes the
+        // material's new assignment. Both operations use the same transaction, so a validation
+        // failure during invalidation rolls back the assignment update.
+        InvalidatePalletCycle(
+          matId: matId,
+          process: null,
+          operatorName: operatorName,
+          timeUTC: timeUTC ?? DateTime.UtcNow,
+          trans: trans,
+          newLogEntries: newLogEntries,
+          validateAffectedMaterials: validateAffectedMaterials
+        );
 
         trans.Commit();
       }

--- a/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
+++ b/server/lib/BlackMaple.MachineFramework/db/IRepository.cs
@@ -465,6 +465,13 @@ namespace BlackMaple.MachineFramework
       string reason = null,
       DateTime? timeUTC = null
     );
+    IEnumerable<LogEntry> QuarantineQueuedMaterial(
+      long matId,
+      string quarantineQueue,
+      string operatorName = null,
+      string reason = null,
+      DateTime? timeUTC = null
+    );
     LogEntry RecordGeneralMessage(
       EventLogMaterial mat,
       string program,
@@ -515,7 +522,8 @@ namespace BlackMaple.MachineFramework
       long matId,
       int process,
       string operatorName,
-      DateTime? timeUTC = null
+      DateTime? timeUTC = null,
+      Action<ImmutableList<EventLogMaterial>> validateAffectedMaterials = null
     );
     IEnumerable<LogEntry> InvalidateAndChangeAssignment(
       long matId,
@@ -523,7 +531,8 @@ namespace BlackMaple.MachineFramework
       string changeJobUniqueTo,
       string changePartNameTo,
       int changeNumProcessesTo,
-      DateTime? timeUTC = null
+      DateTime? timeUTC = null,
+      Action<ImmutableList<EventLogMaterial>> validateAffectedMaterials = null
     );
     LogEntry CreateRebooking(
       string bookingId,

--- a/server/lib/BlackMaple.MachineFramework/http/Controllers/JobsController.cs
+++ b/server/lib/BlackMaple.MachineFramework/http/Controllers/JobsController.cs
@@ -228,6 +228,8 @@ namespace BlackMaple.MachineFramework.Controllers
 
     [HttpDelete("material/{materialId}/queue")]
     [ProducesResponseType(typeof(void), 200)]
+    [ProducesResponseType(typeof(void), 400)]
+    [ProducesResponseType(typeof(void), 409)]
     public void RemoveMaterialFromAllQueues(long materialId, [FromQuery] string? operName = null)
     {
       jobAndQueue.RemoveMaterialFromAllQueues(new[] { materialId }, operName);
@@ -235,6 +237,8 @@ namespace BlackMaple.MachineFramework.Controllers
 
     [HttpPut("material/{materialId}/signal-quarantine")]
     [ProducesResponseType(typeof(void), 200)]
+    [ProducesResponseType(typeof(void), 400)]
+    [ProducesResponseType(typeof(void), 409)]
     public void SignalMaterialForQuarantine(
       long materialId,
       [FromQuery] string? operName = null,
@@ -244,8 +248,24 @@ namespace BlackMaple.MachineFramework.Controllers
       jobAndQueue.SignalMaterialForQuarantine(materialId, operatorName: operName, reason: reason);
     }
 
+    [HttpPut("material/{materialId}/quarantine-queued")]
+    [ProducesResponseType(typeof(void), 200)]
+    [ProducesResponseType(typeof(void), 400)]
+    [ProducesResponseType(typeof(void), 409)]
+    public void QuarantineQueuedMaterial(
+      long materialId,
+      [FromQuery] string? operName = null,
+      [FromBody] string? reason = null
+    )
+    {
+      jobAndQueue.QuarantineQueuedMaterial(materialId, operatorName: operName, reason: reason);
+    }
+
     [HttpPut("material/{materialId}/cancel-load")]
     [ProducesResponseType(typeof(void), 200)]
+    [ProducesResponseType(typeof(void), 400)]
+    [ProducesResponseType(typeof(void), 409)]
+    [ProducesResponseType(typeof(void), 500)]
     public void CancelLoad(
       long materialId,
       [FromBody] CancelLoadRequest request,
@@ -261,6 +281,9 @@ namespace BlackMaple.MachineFramework.Controllers
     }
 
     [HttpPut("material/{materialId}/invalidate-process")]
+    [ProducesResponseType(typeof(MaterialDetails), 200)]
+    [ProducesResponseType(typeof(void), 400)]
+    [ProducesResponseType(typeof(void), 409)]
     public MaterialDetails? InvalidatePalletCycle(
       long materialId,
       [FromBody] int process,

--- a/server/test/JobAndQueueSpec.cs
+++ b/server/test/JobAndQueueSpec.cs
@@ -62,7 +62,7 @@ public sealed class JobAndQueueSpec
   private ServerSettings _serverSettings;
   private JobsAndQueuesFromDb<MockCellState> _jq;
   private readonly Fixture _fixture;
-  private ImmutableList<ILoadCancel<MockCellState>> _loadCancelHandlers = [];
+  private ILoadCancel<MockCellState> _loadCancelHandler;
 
   public JobAndQueueSpec()
   {
@@ -119,7 +119,7 @@ public sealed class JobAndQueueSpec
       _serverSettings,
       _settings,
       this,
-      loadCancelHandlers: _loadCancelHandlers,
+      loadCancelHandler: _loadCancelHandler,
       startThread: false
     );
     _jq.OnNewCurrentStatus += OnNewCurrentStatus;
@@ -271,14 +271,21 @@ public sealed class JobAndQueueSpec
 
   private async Task SetCurrentMaterial(ImmutableList<InProcessMaterial> material)
   {
-    await SetCurrentState(
-      stateUpdated: false,
-      executeAction: false,
-      curSt: _curSt.CurrentStatus with
-      {
-        Material = material,
-      }
-    );
+    (await PublishCurrentMaterial(material)).ShouldBe(_curSt.CurrentStatus);
+  }
+
+  private async Task<CurrentStatus> PublishCurrentMaterial(
+    ImmutableList<InProcessMaterial> material
+  )
+  {
+    _curSt = _curSt with
+    {
+      StateUpdated = false,
+      CurrentStatus = _curSt.CurrentStatus with { Material = material },
+    };
+    var task = CreateTaskToWaitForNewStatus();
+    NewCellState?.Invoke();
+    return await task;
   }
 
   private sealed class RecordingLoadCancel : ILoadCancel<MockCellState>
@@ -286,14 +293,14 @@ public sealed class JobAndQueueSpec
     public ImmutableList<long> MaterialIds { get; private set; } = [];
     public string Reason { get; private set; }
     public int Calls { get; private set; }
-    public Action OnCancel { get; init; }
+    public Action OnCancel { get; set; }
     public Exception Failure { get; init; }
 
     public void CancelLoad(
       IRepository repository,
       MockCellState state,
       InProcessMaterial selectedMaterial,
-      ImmutableList<InProcessMaterial> material,
+      ImmutableList<InProcessMaterial> cancellationGroup,
       string cancellationId,
       string operatorName,
       string reason
@@ -305,7 +312,7 @@ public sealed class JobAndQueueSpec
       {
         throw Failure;
       }
-      MaterialIds = material.Select(m => m.MaterialID).ToImmutableList();
+      MaterialIds = cancellationGroup.Select(m => m.MaterialID).ToImmutableList();
       Reason = reason;
     }
   }
@@ -314,7 +321,7 @@ public sealed class JobAndQueueSpec
   public async Task CancelsExactlyTheMaterialWithTheDisplayedCancellationId()
   {
     var handler = new RecordingLoadCancel();
-    _loadCancelHandlers = [handler];
+    _loadCancelHandler = handler;
     await StartSyncThread();
 
     var first = QueuedMat(1, null, "part", 0, 1, "first", "q1", 0) with
@@ -342,7 +349,7 @@ public sealed class JobAndQueueSpec
   public async Task CancelLoadRejectsStaleCancellationIdBeforeCallingTheHandler()
   {
     var handler = new RecordingLoadCancel();
-    _loadCancelHandlers = [handler];
+    _loadCancelHandler = handler;
     await StartSyncThread();
 
     var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
@@ -368,7 +375,7 @@ public sealed class JobAndQueueSpec
   public async Task CancelLoadPassesASingletonCancellationGroupToTheHandler()
   {
     var handler = new RecordingLoadCancel();
-    _loadCancelHandlers = [handler];
+    _loadCancelHandler = handler;
     await StartSyncThread();
 
     var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
@@ -387,6 +394,30 @@ public sealed class JobAndQueueSpec
   }
 
   [Test]
+  public async Task CancelLoadUsesTheAdvertisedIdInsteadOfLocationOrAction()
+  {
+    var handler = new RecordingLoadCancel();
+    _loadCancelHandler = handler;
+    await StartSyncThread();
+
+    var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
+    {
+      Location = new InProcessMaterialLocation() { Type = InProcessMaterialLocation.LocType.Free },
+      Action = new InProcessMaterialAction()
+      {
+        Type = InProcessMaterialAction.ActionType.Waiting,
+        LoadCancellationId = "current",
+      },
+    };
+    await SetCurrentMaterial([material]);
+
+    _jq.CancelLoad(material.MaterialID, "current", null, null);
+
+    handler.Calls.ShouldBe(1);
+    handler.MaterialIds.ShouldBe([material.MaterialID]);
+  }
+
+  [Test]
   public async Task CancelLoadRecalculatesStateAfterSuccessfulHandlerAndMakesPriorTokenStale()
   {
     var handler = new RecordingLoadCancel()
@@ -398,7 +429,7 @@ public sealed class JobAndQueueSpec
           CurrentStatus = _curSt.CurrentStatus with { Material = [] },
         },
     };
-    _loadCancelHandlers = [handler];
+    _loadCancelHandler = handler;
     await StartSyncThread();
 
     var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
@@ -426,7 +457,7 @@ public sealed class JobAndQueueSpec
   public async Task CancelLoadRejectsAConsumedTokenBeforeTheCurrentStateIsReconstructed()
   {
     var handler = new RecordingLoadCancel();
-    _loadCancelHandlers = [handler];
+    _loadCancelHandler = handler;
     await StartSyncThread();
 
     var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
@@ -461,7 +492,7 @@ public sealed class JobAndQueueSpec
       OnCancel = () => _curSt = _curSt with { Uniq = _curSt.Uniq + 1 },
       Failure = new Exception("cancellation failed"),
     };
-    _loadCancelHandlers = [handler];
+    _loadCancelHandler = handler;
     await StartSyncThread();
 
     var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
@@ -495,13 +526,168 @@ public sealed class JobAndQueueSpec
         LoadCancellationId = "current",
       },
     };
+    var status = await PublishCurrentMaterial([material]);
+
+    status.Alarms.ShouldContain(
+      "Error communicating with machines: The backend advertised a load cancellation, but no load cancellation handler is configured. Will try again in a few minutes."
+    );
+  }
+
+  [Test]
+  public async Task SynchronizationRejectsBlankAdvertisedCancellationId()
+  {
+    _loadCancelHandler = new RecordingLoadCancel();
+    await StartSyncThread();
+
+    var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
+    {
+      Action = new InProcessMaterialAction()
+      {
+        Type = InProcessMaterialAction.ActionType.Loading,
+        LoadCancellationId = "  ",
+      },
+    };
+    var status = await PublishCurrentMaterial([material]);
+
+    status.Alarms.ShouldContain(
+      "Error communicating with machines: The backend advertised a blank load cancellation ID. Use null when cancellation is unavailable. Will try again in a few minutes."
+    );
+  }
+
+  [Test]
+  public async Task CancelLoadKeepsConsumedIdUntilOperationDisappears()
+  {
+    var handler = new RecordingLoadCancel();
+    _loadCancelHandler = handler;
+    await StartSyncThread();
+
+    var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
+    {
+      Action = new InProcessMaterialAction()
+      {
+        Type = InProcessMaterialAction.ActionType.Loading,
+        LoadCancellationId = "current",
+      },
+    };
+    await SetCurrentMaterial([material]);
+
+    var newStatusTask = CreateTaskToWaitForNewStatus();
+    _jq.CancelLoad(material.MaterialID, "current", null, null);
+    (await newStatusTask).Material.ShouldBe([material]);
+
+    Should
+      .Throw<ConflictRequestException>(() =>
+        _jq.CancelLoad(material.MaterialID, "current", null, null)
+      )
+      .Message.ShouldContain("no longer current");
+
+    handler.Calls.ShouldBe(1);
+  }
+
+  [Test]
+  public async Task CancelLoadAllowsNewIdAfterThePreviousOperationDisappears()
+  {
+    var handler = new RecordingLoadCancel();
+    _loadCancelHandler = handler;
+    await StartSyncThread();
+
+    var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
+    {
+      Action = new InProcessMaterialAction()
+      {
+        Type = InProcessMaterialAction.ActionType.Loading,
+        LoadCancellationId = "current",
+      },
+    };
+    var replacement = material with
+    {
+      Action = material.Action with { LoadCancellationId = "replacement" },
+    };
+    handler.OnCancel = () =>
+    {
+      if (handler.Calls == 1)
+        _curSt = _curSt with
+        {
+          CurrentStatus = _curSt.CurrentStatus with { Material = [replacement] },
+        };
+    };
+    await SetCurrentMaterial([material]);
+
+    var replacementStatusTask = CreateTaskToWaitForNewStatus();
+    _jq.CancelLoad(material.MaterialID, "current", null, null);
+    (await replacementStatusTask).Material.ShouldBe([replacement]);
+
+    _jq.CancelLoad(material.MaterialID, "replacement", null, null);
+    handler.Calls.ShouldBe(2);
+  }
+
+  [Test]
+  public async Task ActiveCancellationOperationOwnsQueueDisposition()
+  {
+    var handler = new RecordingLoadCancel();
+    _loadCancelHandler = handler;
+    await StartSyncThread();
+
+    var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
+    {
+      Action = new InProcessMaterialAction
+      {
+        Type = InProcessMaterialAction.ActionType.Waiting,
+        LoadCancellationId = "current",
+      },
+    };
     await SetCurrentMaterial([material]);
 
     Should
-      .Throw<InvalidOperationException>(() =>
-        _jq.CancelLoad(material.MaterialID, "current", null, null)
+      .Throw<ConflictRequestException>(() =>
+        _jq.RemoveMaterialFromAllQueues([material.MaterialID], null)
       )
-      .Message.ShouldContain("does not have exactly one load cancellation handler");
+      .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
+    Should
+      .Throw<ConflictRequestException>(() =>
+        _jq.SignalMaterialForQuarantine(material.MaterialID, null, null)
+      )
+      .Message.ShouldBe("Material is not eligible for deferred quarantine in its current state.");
+    Should
+      .Throw<ConflictRequestException>(() =>
+        _jq.QuarantineQueuedMaterial(material.MaterialID, null, null)
+      )
+      .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
+    handler.Calls.ShouldBe(0);
+  }
+
+  [Test]
+  public async Task AutomationControlledMaterialCannotUseHumanQueueDisposition()
+  {
+    await StartSyncThread();
+
+    var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
+    {
+      Location = new InProcessMaterialLocation()
+      {
+        Type = InProcessMaterialLocation.LocType.OnPallet,
+        PalletNum = 1,
+      },
+      Action = new InProcessMaterialAction()
+      {
+        Type = InProcessMaterialAction.ActionType.Machining,
+      },
+    };
+    await SetCurrentMaterial([material]);
+
+    Should
+      .Throw<ConflictRequestException>(() =>
+        _jq.RemoveMaterialFromAllQueues([material.MaterialID], null)
+      )
+      .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
+    Should
+      .Throw<ConflictRequestException>(() =>
+        _jq.QuarantineQueuedMaterial(material.MaterialID, null, null)
+      )
+      .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
+    Should
+      .Throw<ConflictRequestException>(() => _jq.InvalidatePalletCycle(material.MaterialID, 1))
+      .Message.ShouldBe("Material is not eligible for cycle invalidation in its current state.");
   }
 
   #endregion
@@ -898,6 +1084,11 @@ public sealed class JobAndQueueSpec
 
     (await newStatusTask).ShouldBe(_curSt.CurrentStatus);
 
+    await SetCurrentMaterial([
+      QueuedMat(1, null, "c1", 0, 1, "aaa", "q1", 0),
+      QueuedMat(2, null, "c1", 0, 1, "", "q1", 1),
+    ]);
+
     newStatusTask = CreateTaskToWaitForNewStatus();
 
     _jq.RemoveMaterialFromAllQueues(new List<long> { 1 }, "theoper");
@@ -1021,8 +1212,8 @@ public sealed class JobAndQueueSpec
     ]);
 
     Should
-      .Throw<BadRequestException>(() => _jq.RemoveMaterialFromAllQueues([2L], "theoper"))
-      .Message.ShouldBe("Material on pallet can not be removed from queues");
+      .Throw<ConflictRequestException>(() => _jq.RemoveMaterialFromAllQueues([2L], "theoper"))
+      .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
 
     await SetCurrentMaterial([
       expectedMat2 with
@@ -1035,8 +1226,8 @@ public sealed class JobAndQueueSpec
     ]);
 
     Should
-      .Throw<BadRequestException>(() => _jq.RemoveMaterialFromAllQueues([2L], "theoper"))
-      .Message.ShouldBe("Only waiting material can be removed from queues");
+      .Throw<ConflictRequestException>(() => _jq.RemoveMaterialFromAllQueues([2L], "theoper"))
+      .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
 
     db.GetMaterialInAllQueues().ShouldContain(m => m.MaterialID == 2);
   }
@@ -1259,8 +1450,12 @@ public sealed class JobAndQueueSpec
     ]);
 
     Should
-      .Throw<BadRequestException>(() => _jq.SetMaterialInQueue(materialId: 1, "q1", 3, "theoper"))
-      .Message.ShouldBe("Material on pallet can not be moved to a queue");
+      .Throw<ConflictRequestException>(() =>
+        _jq.SetMaterialInQueue(materialId: 1, "q1", 3, "theoper")
+      )
+      .Message.ShouldBe(
+        "Material is owned by an active operation and cannot be moved to another queue."
+      );
 
     await SetCurrentMaterial([
       expectedMat1 with
@@ -1273,11 +1468,98 @@ public sealed class JobAndQueueSpec
     ]);
 
     Should
-      .Throw<BadRequestException>(() => _jq.SetMaterialInQueue(materialId: 1, "q2", 3, "oper"))
-      .Message.ShouldBe("Only waiting material can be moved between queues");
+      .Throw<ConflictRequestException>(() => _jq.SetMaterialInQueue(materialId: 1, "q2", 3, "oper"))
+      .Message.ShouldBe(
+        "Material is owned by an active operation and cannot be moved to another queue."
+      );
 
     // no new events added, already checked them equal to expectedLog above
     db.GetLogForMaterial(materialID: 1).Count().ShouldBe(expectedLog.Length);
+  }
+
+  [Test]
+  public async Task AllowsMovingWaitingMaterialBetweenQueues()
+  {
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var expectedMat = QueuedMat(
+      matId: 1,
+      job: null,
+      part: "c1",
+      proc: 0,
+      path: 1,
+      serial: "aaa",
+      queue: "q1",
+      pos: 0
+    );
+    _jq.AddUnallocatedCastingToQueue(
+        casting: "c1",
+        qty: 1,
+        queue: "q1",
+        serial: ["aaa"],
+        workorder: null,
+        operatorName: "theoper"
+      )
+      .ShouldBe([expectedMat]);
+
+    await SetCurrentMaterial([expectedMat]);
+    var newStatusTask = CreateTaskToWaitForNewStatus();
+
+    _jq.SetMaterialInQueue(materialId: 1, "q2", 0, "oper");
+
+    (await newStatusTask).ShouldBe(_curSt.CurrentStatus);
+    db.GetMaterialInAllQueues().Single().Queue.ShouldBe("q2");
+  }
+
+  [Test]
+  public async Task RejectsMovingMaterialWithLoadCancellationIdBetweenQueues()
+  {
+    _loadCancelHandler = new RecordingLoadCancel();
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var expectedMat = QueuedMat(
+      matId: 1,
+      job: null,
+      part: "c1",
+      proc: 0,
+      path: 1,
+      serial: "aaa",
+      queue: "q1",
+      pos: 0
+    );
+    _jq.AddUnallocatedCastingToQueue(
+        casting: "c1",
+        qty: 1,
+        queue: "q1",
+        serial: ["aaa"],
+        workorder: null,
+        operatorName: "theoper"
+      )
+      .ShouldBe([expectedMat]);
+
+    await SetCurrentMaterial([
+      expectedMat with
+      {
+        Action = new InProcessMaterialAction()
+        {
+          Type = InProcessMaterialAction.ActionType.Waiting,
+          LoadCancellationId = "active-load",
+        },
+      },
+    ]);
+
+    Should
+      .Throw<ConflictRequestException>(() => _jq.SetMaterialInQueue(materialId: 1, "q2", 0, "oper"))
+      .Message.ShouldBe(
+        "Material is owned by an active operation and cannot be moved to another queue."
+      );
+    db.GetMaterialInAllQueues().Single().Queue.ShouldBe("q1");
   }
 
   [Test]
@@ -1340,24 +1622,21 @@ public sealed class JobAndQueueSpec
     db.GetMaterialInAllQueues().Select(m => m.MaterialID).ShouldBe(new[] { 2L, 1L });
 
     Should
-      .Throw<BadRequestException>(() => _jq.SetMaterialInQueue(materialId: 1, "q2", -1, "oper"))
-      .Message.ShouldBe("Only waiting material can be moved between queues");
+      .Throw<ConflictRequestException>(() =>
+        _jq.SetMaterialInQueue(materialId: 1, "q2", -1, "oper")
+      )
+      .Message.ShouldBe(
+        "Material is owned by an active operation and cannot be moved to another queue."
+      );
   }
 
   public record SignalQuarantineTheoryData
   {
-    public enum QuarantineType
-    {
-      Add,
-      Signal,
-      Remove,
-    }
-
     public required InProcessMaterialLocation.LocType LocType { get; set; }
     public required InProcessMaterialAction.ActionType ActionType { get; set; }
     public required string QuarantineQueue { get; set; }
+    public int Pallet { get; set; } = 4;
     public string Error { get; set; } = null;
-    public QuarantineType? QuarantineAction { get; set; } = null;
     public int Process { get; set; } = 0;
     public string JobTransferQeuue { get; set; } = "q1";
   }
@@ -1369,21 +1648,21 @@ public sealed class JobAndQueueSpec
       ActionType = InProcessMaterialAction.ActionType.Waiting,
       LocType = InProcessMaterialLocation.LocType.InQueue,
       QuarantineQueue = "quarqqq",
-      QuarantineAction = SignalQuarantineTheoryData.QuarantineType.Add,
+      Error = "Material is not eligible for deferred quarantine in its current state.",
     },
     new SignalQuarantineTheoryData()
     {
       ActionType = InProcessMaterialAction.ActionType.Waiting,
       LocType = InProcessMaterialLocation.LocType.InQueue,
       QuarantineQueue = null,
-      QuarantineAction = SignalQuarantineTheoryData.QuarantineType.Remove,
+      Error = "Material is not eligible for deferred quarantine in its current state.",
     },
     new SignalQuarantineTheoryData
     {
       ActionType = InProcessMaterialAction.ActionType.Waiting,
       LocType = InProcessMaterialLocation.LocType.Free,
       QuarantineQueue = "quarqqq",
-      QuarantineAction = SignalQuarantineTheoryData.QuarantineType.Add,
+      Error = "Material is not eligible for deferred quarantine in its current state.",
     },
     // Now OnPallet with various tests for transfer queues and proces
     new SignalQuarantineTheoryData
@@ -1393,7 +1672,6 @@ public sealed class JobAndQueueSpec
       QuarantineQueue = "quarqqq",
       Process = 1,
       JobTransferQeuue = "q1",
-      QuarantineAction = SignalQuarantineTheoryData.QuarantineType.Signal,
     },
     new SignalQuarantineTheoryData
     {
@@ -1402,7 +1680,7 @@ public sealed class JobAndQueueSpec
       QuarantineQueue = "quarqqq",
       Process = 1,
       JobTransferQeuue = "q1",
-      QuarantineAction = SignalQuarantineTheoryData.QuarantineType.Signal,
+      Error = "Material is not eligible for deferred quarantine in its current state.",
     },
     new SignalQuarantineTheoryData
     {
@@ -1411,7 +1689,7 @@ public sealed class JobAndQueueSpec
       QuarantineQueue = "quarqqq",
       Process = 1,
       JobTransferQeuue = "q1",
-      Error = "Material on pallet can not be quarantined while loading",
+      Error = "Material is not eligible for deferred quarantine in its current state.",
     },
     new SignalQuarantineTheoryData()
     {
@@ -1420,7 +1698,6 @@ public sealed class JobAndQueueSpec
       QuarantineQueue = null,
       Process = 2,
       JobTransferQeuue = "q1",
-      QuarantineAction = SignalQuarantineTheoryData.QuarantineType.Signal,
     },
     new SignalQuarantineTheoryData
     {
@@ -1429,8 +1706,7 @@ public sealed class JobAndQueueSpec
       QuarantineQueue = "quarqqq",
       Process = 1,
       JobTransferQeuue = null,
-      Error =
-        "Can only signal material for quarantine if the current process and path has an output queue",
+      Error = "Material does not have a supported path out of automation control.",
     },
     new SignalQuarantineTheoryData
     {
@@ -1439,7 +1715,15 @@ public sealed class JobAndQueueSpec
       QuarantineQueue = "quarqqq",
       Process = 2,
       JobTransferQeuue = null,
-      QuarantineAction = SignalQuarantineTheoryData.QuarantineType.Signal,
+    },
+    new SignalQuarantineTheoryData
+    {
+      ActionType = InProcessMaterialAction.ActionType.Waiting,
+      LocType = InProcessMaterialLocation.LocType.InBasket,
+      QuarantineQueue = "quarqqq",
+      Pallet = 0,
+      Process = 1,
+      JobTransferQeuue = "q1",
     },
     // Loading from a queue
     new SignalQuarantineTheoryData()
@@ -1447,14 +1731,14 @@ public sealed class JobAndQueueSpec
       ActionType = InProcessMaterialAction.ActionType.Loading,
       LocType = InProcessMaterialLocation.LocType.InQueue,
       QuarantineQueue = "quarqqq",
-      Error = "Invalid material state for quarantine",
+      Error = "Material is not eligible for deferred quarantine in its current state.",
     },
     new SignalQuarantineTheoryData()
     {
       ActionType = InProcessMaterialAction.ActionType.Loading,
       LocType = InProcessMaterialLocation.LocType.InQueue,
       QuarantineQueue = null,
-      Error = "Invalid material state for quarantine",
+      Error = "Material is not eligible for deferred quarantine in its current state.",
     },
   ];
 
@@ -1558,10 +1842,10 @@ public sealed class JobAndQueueSpec
     }
 
     Should
-      .Throw<BadRequestException>(() =>
+      .Throw<ConflictRequestException>(() =>
         _jq.SignalMaterialForQuarantine(materialId: 1, operatorName: "theoper", reason: "a reason")
       )
-      .Message.ShouldBe("Material not found");
+      .Message.ShouldBe("Material not found in the current cell state.");
 
     var queuedMat = QueuedMat(
       matId: 1,
@@ -1581,7 +1865,8 @@ public sealed class JobAndQueueSpec
         Location = new InProcessMaterialLocation()
         {
           Type = data.LocType,
-          PalletNum = data.LocType == InProcessMaterialLocation.LocType.OnPallet ? 4 : null,
+          PalletNum =
+            data.LocType == InProcessMaterialLocation.LocType.OnPallet ? data.Pallet : null,
         },
       },
     ]);
@@ -1589,7 +1874,7 @@ public sealed class JobAndQueueSpec
     if (data.Error != null)
     {
       Should
-        .Throw<BadRequestException>(() =>
+        .Throw<ConflictRequestException>(() =>
           _jq.SignalMaterialForQuarantine(materialId: 1, "theoper", reason: "a reason")
         )
         .Message.ShouldBe(data.Error);
@@ -1602,65 +1887,18 @@ public sealed class JobAndQueueSpec
 
       (await newStatusTask).ShouldBe(_curSt.CurrentStatus);
 
-      if (data.QuarantineAction == SignalQuarantineTheoryData.QuarantineType.Signal)
-      {
-        expectedLog.Add(
-          SignalQuarantineExpectedEntry(
-            logMat,
-            cntr: expectedLog.Count + 1,
-            pal: 4,
-            queue: data.QuarantineQueue ?? "",
-            operName: "theoper",
-            reason: "signaling reason",
-            timeUTC: now
-          )
-        );
-      }
-      else
-      {
-        expectedLog.Add(
-          OperatorNoteExpectedEntry(
-            logMat,
-            cntr: expectedLog.Count + 1,
-            note: "signaling reason",
-            operName: "theoper",
-            timeUTC: now
-          )
-        );
-
-        if (data.LocType == InProcessMaterialLocation.LocType.InQueue)
-        {
-          expectedLog.Add(
-            RemoveFromQueueExpectedEntry(
-              logMat,
-              cntr: expectedLog.Count + 1,
-              queue: "q1",
-              position: 0,
-              elapsedMin: 0,
-              reason: data.QuarantineAction == SignalQuarantineTheoryData.QuarantineType.Add
-                ? "MovingInQueue"
-                : "Quarantine",
-              operName: "theoper",
-              timeUTC: now
-            )
-          );
-        }
-      }
-
-      if (data.QuarantineAction == SignalQuarantineTheoryData.QuarantineType.Add)
-      {
-        expectedLog.Add(
-          AddToQueueExpectedEntry(
-            logMat,
-            cntr: expectedLog.Count + 1,
-            queue: data.QuarantineQueue,
-            position: 0,
-            reason: "Quarantine",
-            operName: "theoper",
-            timeUTC: now
-          )
-        );
-      }
+      expectedLog.Add(
+        SignalQuarantineExpectedEntry(
+          logMat,
+          cntr: expectedLog.Count + 1,
+          pal: data.Pallet,
+          queue: data.QuarantineQueue ?? "",
+          operName: "theoper",
+          reason: "signaling reason",
+          timeUTC: now
+        )
+      );
+      db.GetMaterialInAllQueues().ShouldBeEmpty();
     }
 
     var mat1Log = db.GetLogForMaterial(materialID: 1).ToList();
@@ -1672,6 +1910,458 @@ public sealed class JobAndQueueSpec
       .Select(e => e with { EndTimeUTC = now, ElapsedTime = TimeSpan.Zero })
       .ToList()
       .ShouldBeEquivalentTo(expectedLog);
+  }
+
+  [Test]
+  public async Task DirectlyQuarantinesQueuedMaterialIntoConfiguredQueue()
+  {
+    _settings = _settings with { QuarantineQueue = "q2" };
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var material = QueuedMat(
+      matId: 1,
+      job: null,
+      part: "c1",
+      proc: 0,
+      path: 1,
+      serial: "serial",
+      queue: "q1",
+      pos: 0
+    );
+    _jq.AddUnallocatedCastingToQueue(
+        casting: "c1",
+        qty: 1,
+        queue: "q1",
+        serial: ["serial"],
+        workorder: null,
+        operatorName: "adder"
+      )
+      .ShouldBe([material]);
+    await SetCurrentMaterial([material]);
+
+    var newStatusTask = CreateTaskToWaitForNewStatus();
+    _jq.QuarantineQueuedMaterial(1, operatorName: "theoper", reason: "direct reason");
+    (await newStatusTask).ShouldBe(_curSt.CurrentStatus);
+
+    db.GetMaterialInAllQueues().ShouldContain(m => m.MaterialID == 1 && m.Queue == "q2");
+    var logs = db.GetLogForMaterial(1).ToList();
+    var note = logs.Single(e => e.Program == "OperatorNotes");
+    note.ProgramDetails.ShouldNotBeNull();
+    note.ProgramDetails["note"].ShouldBe("direct reason");
+    note.ProgramDetails["operator"].ShouldBe("theoper");
+    var quarantineAdd = logs.Single(e => e.LogType == LogType.AddToQueue && e.LocationName == "q2");
+    quarantineAdd.Program.ShouldBe("Quarantine");
+    quarantineAdd.ProgramDetails.ShouldNotBeNull();
+    quarantineAdd.ProgramDetails["operator"].ShouldBe("theoper");
+  }
+
+  [Test]
+  public async Task DirectlyQuarantinesQueuedMaterialWithoutConfiguredQueue()
+  {
+    _settings = _settings with { QuarantineQueue = null };
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var material = QueuedMat(
+      matId: 1,
+      job: null,
+      part: "c1",
+      proc: 0,
+      path: 1,
+      serial: "serial",
+      queue: "q1",
+      pos: 0
+    );
+    _jq.AddUnallocatedCastingToQueue(
+        casting: "c1",
+        qty: 1,
+        queue: "q1",
+        serial: ["serial"],
+        workorder: null,
+        operatorName: "adder"
+      )
+      .ShouldBe([material]);
+    await SetCurrentMaterial([material]);
+
+    var newStatusTask = CreateTaskToWaitForNewStatus();
+    _jq.QuarantineQueuedMaterial(1, operatorName: "theoper", reason: "direct reason");
+    (await newStatusTask).ShouldBe(_curSt.CurrentStatus);
+
+    db.GetMaterialInAllQueues().ShouldBeEmpty();
+    var logs = db.GetLogForMaterial(1).ToList();
+    var note = logs.Single(e => e.Program == "OperatorNotes");
+    note.ProgramDetails.ShouldNotBeNull();
+    note.ProgramDetails["note"].ShouldBe("direct reason");
+    note.ProgramDetails["operator"].ShouldBe("theoper");
+    var quarantineRemove = logs.Single(e => e.LogType == LogType.RemoveFromQueue);
+    quarantineRemove.Program.ShouldBe("Quarantine");
+    quarantineRemove.ProgramDetails.ShouldNotBeNull();
+    quarantineRemove.ProgramDetails["operator"].ShouldBe("theoper");
+  }
+
+  [Test]
+  public async Task DirectQuarantineRejectsMaterialOutsideHumanControlledQueue()
+  {
+    _loadCancelHandler = new RecordingLoadCancel();
+    await StartSyncThread();
+    var queuedMaterial = QueuedMat(1, null, "c1", 0, 1, "serial", "q1", 0);
+    await SetCurrentMaterial([
+      queuedMaterial with
+      {
+        Location = new InProcessMaterialLocation { Type = InProcessMaterialLocation.LocType.Free },
+      },
+    ]);
+
+    Should
+      .Throw<ConflictRequestException>(() => _jq.QuarantineQueuedMaterial(1, null, null))
+      .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
+
+    await SetCurrentMaterial([
+      queuedMaterial with
+      {
+        Action = new InProcessMaterialAction
+        {
+          Type = InProcessMaterialAction.ActionType.Waiting,
+          LoadCancellationId = "active",
+        },
+      },
+    ]);
+
+    Should
+      .Throw<ConflictRequestException>(() => _jq.QuarantineQueuedMaterial(1, null, null))
+      .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
+  }
+
+  [Test]
+  public async Task InvalidationRequiresEligibleAddToQueueProposal()
+  {
+    _loadCancelHandler = new RecordingLoadCancel();
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var materialId = db.AllocateMaterialID("job", "part", 1);
+    db.RecordMachineStart(
+      [
+        new EventLogMaterial
+        {
+          MaterialID = materialId,
+          Process = 1,
+          Face = 1,
+        },
+      ],
+      pallet: 1,
+      statName: "machine",
+      statNum: 1,
+      program: "program",
+      timeUTC: DateTime.UtcNow
+    );
+    var material = QueuedMat(materialId, null, "part", 1, 1, "serial", "q1", 0);
+
+    await SetCurrentMaterial([
+      material with
+      {
+        Location = new InProcessMaterialLocation
+        {
+          Type = InProcessMaterialLocation.LocType.InQueue,
+          CurrentQueue = "q1",
+          QueuePosition = 0,
+        },
+      },
+    ]);
+    Should
+      .Throw<ConflictRequestException>(() => _jq.InvalidatePalletCycle(materialId, 1))
+      .Message.ShouldBe("Material is not eligible for cycle invalidation in its current state.");
+
+    await SetCurrentMaterial([
+      material with
+      {
+        Location = new InProcessMaterialLocation
+        {
+          Type = InProcessMaterialLocation.LocType.OnPallet,
+          PalletNum = 1,
+        },
+      },
+    ]);
+    Should
+      .Throw<ConflictRequestException>(() => _jq.InvalidatePalletCycle(materialId, 1))
+      .Message.ShouldBe("Material is not eligible for cycle invalidation in its current state.");
+
+    await SetCurrentMaterial([
+      material with
+      {
+        Action = new InProcessMaterialAction
+        {
+          Type = InProcessMaterialAction.ActionType.Waiting,
+          LoadCancellationId = "active",
+        },
+      },
+    ]);
+    Should
+      .Throw<ConflictRequestException>(() => _jq.InvalidatePalletCycle(materialId, 1))
+      .Message.ShouldBe("Material is not eligible for cycle invalidation in its current state.");
+  }
+
+  [Test]
+  public async Task InvalidationRejectsAffectedAutomationMaterialBeforeWriting()
+  {
+    _loadCancelHandler = new RecordingLoadCancel();
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var selectedId = db.AllocateMaterialID("selected", "part", 1);
+    var affectedId = db.AllocateMaterialID("affected", "part", 1);
+    db.RecordMachineStart(
+      [
+        new EventLogMaterial
+        {
+          MaterialID = selectedId,
+          Process = 1,
+          Face = 1,
+        },
+        new EventLogMaterial
+        {
+          MaterialID = affectedId,
+          Process = 1,
+          Face = 2,
+        },
+      ],
+      pallet: 1,
+      statName: "machine",
+      statNum: 1,
+      program: "program",
+      timeUTC: DateTime.UtcNow
+    );
+
+    await SetCurrentMaterial([
+      QueuedMat(selectedId, null, "part", 1, 1, "selected", "q1", 0) with
+      {
+        Location = new InProcessMaterialLocation { Type = InProcessMaterialLocation.LocType.Free },
+      },
+      QueuedMat(affectedId, null, "part", 1, 1, "affected", "q1", 0) with
+      {
+        Location = new InProcessMaterialLocation
+        {
+          Type = InProcessMaterialLocation.LocType.OnPallet,
+          PalletNum = 1,
+        },
+        Action = new InProcessMaterialAction
+        {
+          Type = InProcessMaterialAction.ActionType.Waiting,
+          LoadCancellationId = "active",
+        },
+      },
+    ]);
+    var logBefore = db.GetLogForMaterial(selectedId).ToList();
+
+    Should
+      .Throw<ConflictRequestException>(() => _jq.InvalidatePalletCycle(selectedId, 1))
+      .Message.ShouldBe("Material is not eligible for cycle invalidation in its current state.");
+
+    db.GetLogForMaterial(selectedId).EventsShouldBe(logBefore);
+  }
+
+  [Test]
+  public async Task InvalidationAllowsOnlyMostRecentPartialProcess()
+  {
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var materialId = db.AllocateMaterialID("job", "part", 3);
+    for (var process = 1; process <= 3; process++)
+    {
+      db.RecordMachineStart(
+        [
+          new EventLogMaterial
+          {
+            MaterialID = materialId,
+            Process = process,
+            Face = process,
+          },
+        ],
+        pallet: process,
+        statName: "machine",
+        statNum: process,
+        program: "program",
+        timeUTC: DateTime.UtcNow
+      );
+    }
+
+    await SetCurrentMaterial([
+      QueuedMat(materialId, null, "part", 3, 1, "serial", "q1", 0) with
+      {
+        Location = new InProcessMaterialLocation { Type = InProcessMaterialLocation.LocType.Free },
+      },
+    ]);
+
+    Should
+      .Throw<ConflictRequestException>(() => _jq.InvalidatePalletCycle(materialId, 2))
+      .Message.ShouldBe("The requested process is no longer current.");
+
+    var newStatusTask = CreateTaskToWaitForNewStatus();
+    _jq.InvalidatePalletCycle(materialId, 3);
+    (await newStatusTask).ShouldBe(_curSt.CurrentStatus);
+    db.GetLogForMaterial(materialId).ShouldContain(e => e.LogType == LogType.InvalidateCycle);
+  }
+
+  [Test]
+  public async Task InvalidationAllowsHistoricalMaterialAbsentFromCurrentStatus()
+  {
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var oldJob = new Job()
+    {
+      UniqueStr = "old-job",
+      PartName = "old-part",
+      Cycles = 0,
+      Processes =
+      [
+        new ProcessInfo() { Paths = [JobLogTest.EmptyPath] },
+        new ProcessInfo() { Paths = [JobLogTest.EmptyPath] },
+      ],
+      RouteStartUTC = DateTime.MinValue,
+      RouteEndUTC = DateTime.MinValue,
+      Archived = false,
+    };
+    var newJob = oldJob with { UniqueStr = "new-job", PartName = "new-part" };
+    db.AddJobs(
+      new NewJobs() { ScheduleId = "schedule", Jobs = [oldJob, newJob] },
+      null,
+      addAsCopiedToSystem: true
+    );
+
+    var latestMaterialId = db.AllocateMaterialID("old-job", "old-part", 2);
+    for (var process = 1; process <= 2; process++)
+    {
+      db.RecordMachineStart(
+        [
+          new EventLogMaterial()
+          {
+            MaterialID = latestMaterialId,
+            Process = process,
+            Face = 1,
+          },
+        ],
+        pallet: process,
+        statName: "machine",
+        statNum: process,
+        program: "program",
+        timeUTC: DateTime.UtcNow
+      );
+    }
+
+    await SetCurrentMaterial([]);
+    var latestStatusTask = CreateTaskToWaitForNewStatus();
+    _jq.InvalidatePalletCycle(latestMaterialId, 2);
+    (await latestStatusTask).Material.ShouldBeEmpty();
+
+    var reassignedMaterialId = db.AllocateMaterialID("old-job", "old-part", 1);
+    db.RecordMachineStart(
+      [
+        new EventLogMaterial()
+        {
+          MaterialID = reassignedMaterialId,
+          Process = 1,
+          Face = 1,
+        },
+      ],
+      pallet: 2,
+      statName: "machine",
+      statNum: 2,
+      program: "program",
+      timeUTC: DateTime.UtcNow
+    );
+
+    var reassignedStatusTask = CreateTaskToWaitForNewStatus();
+    var details = _jq.InvalidatePalletCycle(reassignedMaterialId, 1, changeJobUniqueTo: "new-job");
+    (await reassignedStatusTask).Material.ShouldBeEmpty();
+    details.JobUnique.ShouldBe("new-job");
+    db.GetLogForMaterial(reassignedMaterialId)
+      .ShouldContain(e => e.LogType == LogType.InvalidateCycle);
+  }
+
+  [Test]
+  public async Task ActiveLoadStationActionsWithoutCancellationIdOwnAllMaterialDisposition()
+  {
+    await StartSyncThread();
+
+    foreach (
+      var actionType in new[]
+      {
+        InProcessMaterialAction.ActionType.Loading,
+        InProcessMaterialAction.ActionType.UnloadToInProcess,
+        InProcessMaterialAction.ActionType.UnloadToCompletedMaterial,
+        InProcessMaterialAction.ActionType.LoadingToBasket,
+      }
+    )
+    {
+      var material = QueuedMat(1, null, "part", 0, 1, "serial", "q1", 0) with
+      {
+        Action = new InProcessMaterialAction() { Type = actionType },
+      };
+      await SetCurrentMaterial([material]);
+
+      Should
+        .Throw<ConflictRequestException>(() =>
+          _jq.SignalMaterialForQuarantine(material.MaterialID, null, null)
+        )
+        .Message.ShouldBe("Material is not eligible for deferred quarantine in its current state.");
+      Should
+        .Throw<ConflictRequestException>(() =>
+          _jq.QuarantineQueuedMaterial(material.MaterialID, null, null)
+        )
+        .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
+      Should
+        .Throw<ConflictRequestException>(() =>
+          _jq.RemoveMaterialFromAllQueues([material.MaterialID], null)
+        )
+        .Message.ShouldBe("Material must be waiting in a queue with no active operation.");
+      Should
+        .Throw<ConflictRequestException>(() => _jq.InvalidatePalletCycle(material.MaterialID, 1))
+        .Message.ShouldBe("Material is not eligible for cycle invalidation in its current state.");
+    }
+  }
+
+  [Test]
+  public async Task InvalidationRejectsMalformedProcessShape()
+  {
+    await StartSyncThread();
+    using var db = _repo.OpenConnection();
+    await SetCurrentState(stateUpdated: false, executeAction: false);
+
+    var materialId = db.AllocateMaterialID("job", "part", 1);
+    await SetCurrentMaterial([
+      QueuedMat(materialId, null, "part", 1, 1, "serial", "q1", 0) with
+      {
+        Location = new InProcessMaterialLocation { Type = InProcessMaterialLocation.LocType.Free },
+      },
+    ]);
+
+    Should
+      .Throw<BadRequestException>(() => _jq.InvalidatePalletCycle(materialId, 0))
+      .Message.ShouldBe("Process must be at least 1.");
+    Should
+      .Throw<BadRequestException>(() =>
+        _jq.InvalidatePalletCycle(materialId, 2, changeCastingTo: "new-casting")
+      )
+      .Message.ShouldBe("Can only change casting when invalidating all processes");
+    Should
+      .Throw<BadRequestException>(() =>
+        _jq.InvalidatePalletCycle(
+          materialId,
+          1,
+          changeCastingTo: "new-casting",
+          changeJobUniqueTo: "new-job"
+        )
+      )
+      .Message.ShouldBe("Can not change both casting and job assignment");
   }
 
   private static LogEntry MarkExpectedEntry(

--- a/server/test/JobAndQueueSpec.cs
+++ b/server/test/JobAndQueueSpec.cs
@@ -2340,7 +2340,15 @@ public sealed class JobAndQueueSpec
     await SetCurrentMaterial([
       QueuedMat(materialId, null, "part", 1, 1, "serial", "q1", 0) with
       {
-        Location = new InProcessMaterialLocation { Type = InProcessMaterialLocation.LocType.Free },
+        Location = new InProcessMaterialLocation
+        {
+          Type = InProcessMaterialLocation.LocType.OnPallet,
+          PalletNum = 1,
+        },
+        Action = new InProcessMaterialAction
+        {
+          Type = InProcessMaterialAction.ActionType.Machining,
+        },
       },
     ]);
 
@@ -2352,6 +2360,11 @@ public sealed class JobAndQueueSpec
         _jq.InvalidatePalletCycle(materialId, 2, changeCastingTo: "new-casting")
       )
       .Message.ShouldBe("Can only change casting when invalidating all processes");
+    Should
+      .Throw<BadRequestException>(() =>
+        _jq.InvalidatePalletCycle(materialId, 2, changeJobUniqueTo: "new-job")
+      )
+      .Message.ShouldBe("Can only change job when invalidating all processes");
     Should
       .Throw<BadRequestException>(() =>
         _jq.InvalidatePalletCycle(

--- a/server/test/JobLogTest.cs
+++ b/server/test/JobLogTest.cs
@@ -38,6 +38,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
 using BlackMaple.MachineFramework;
+using Microsoft.Data.Sqlite;
 using Shouldly;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -3364,6 +3365,70 @@ namespace BlackMaple.FMSInsight.Tests
     }
 
     [Test]
+    public void QuarantineQueuedMaterialRollsBackOperatorNoteWhenQueueMoveFails()
+    {
+      var guid = Guid.NewGuid();
+      using var repositoryConfig = RepositoryConfig.InitializeMemoryDB(null, guid);
+
+      using (
+        var triggerConnection = new SqliteConnection(
+          $"Data Source=file:${guid}?mode=memory&cache=shared"
+        )
+      )
+      {
+        triggerConnection.Open();
+        using var command = triggerConnection.CreateCommand();
+        command.CommandText = """
+          CREATE TRIGGER FailQuarantineQueueInsert
+          BEFORE INSERT ON queues
+          WHEN NEW.Queue = 'broken'
+          BEGIN
+            SELECT RAISE(ABORT, 'quarantine destination unavailable');
+          END;
+          """;
+        command.ExecuteNonQuery();
+      }
+
+      using var repository = repositoryConfig.OpenConnection();
+      var materialId = repository.AllocateMaterialID("job", "part", 1);
+      repository
+        .RecordAddMaterialToQueue(
+          new EventLogMaterial()
+          {
+            MaterialID = materialId,
+            Process = 0,
+            Face = 0,
+          },
+          queue: "source",
+          position: 0,
+          operatorName: null,
+          reason: "Initial"
+        )
+        .ShouldHaveSingleItem();
+
+      Should.Throw<SqliteException>(() =>
+        repository
+          .QuarantineQueuedMaterial(
+            materialId,
+            quarantineQueue: "broken",
+            operatorName: "operator",
+            reason: "direct reason"
+          )
+          .ToList()
+      );
+
+      var queued = repository.GetMaterialInAllQueues().ToList();
+      queued.ShouldHaveSingleItem();
+      queued[0].MaterialID.ShouldBe(materialId);
+      queued[0].Queue.ShouldBe("source");
+
+      var logs = repository.GetLogForMaterial(materialId).ToList();
+      logs.ShouldContain(entry => entry.Program == "Initial");
+      logs.ShouldNotContain(entry => entry.Program == "OperatorNotes");
+      logs.ShouldNotContain(entry => entry.Program == "Quarantine");
+    }
+
+    [Test]
     public void LoadUnloadIntoQueues()
     {
       using var _jobLog = _repoCfg.OpenConnection();
@@ -5383,6 +5448,19 @@ namespace BlackMaple.FMSInsight.Tests
 
       db.GetLogForMaterial(selected.MaterialID).EventsShouldBe(logBefore);
       db.GetMaterialInAllQueues().Single().MaterialID.ShouldBe(selected.MaterialID);
+      db.GetMaterialDetails(selected.MaterialID)
+        .ShouldBeEquivalentTo(
+          new MaterialDetails()
+          {
+            MaterialID = selected.MaterialID,
+            JobUnique = "selected",
+            PartName = "part",
+            NumProcesses = 1,
+            Workorder = null,
+            Serial = null,
+            Paths = null,
+          }
+        );
     }
 
     [Test]
@@ -5567,10 +5645,10 @@ namespace BlackMaple.FMSInsight.Tests
           .Select(proc =>
             MkLogMat.Mk(
               matID: matProc1.MaterialID,
-              uniq: "uniq1",
-              part: "part1",
+              uniq: "",
+              part: "thecasting",
               proc: proc,
-              numProc: 3,
+              numProc: 1,
               serial: "ser1",
               workorder: "",
               face: ""
@@ -5731,10 +5809,10 @@ namespace BlackMaple.FMSInsight.Tests
         {
           MkLogMat.Mk(
             matID: matProc0.MaterialID,
-            uniq: "uniqqq",
-            part: "parttt",
+            uniq: "ZZZuniq",
+            part: "ZZZpart",
             proc: 0,
-            numProc: 3,
+            numProc: 2,
             serial: "ser111",
             workorder: "",
             face: ""

--- a/server/test/JobsControllerSpec.cs
+++ b/server/test/JobsControllerSpec.cs
@@ -1,0 +1,151 @@
+/* Copyright (c) 2026, SeedTactics
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of
+    conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ */
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using BlackMaple.MachineFramework;
+using BlackMaple.MachineFramework.Controllers;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Shouldly;
+
+namespace BlackMaple.FMSInsight.Tests;
+
+public sealed class JobsControllerSpec
+{
+  [Test]
+  public void CancelLoadForwardsTheOperationAndOperatorContext()
+  {
+    var jobAndQueue = Substitute.For<IJobAndQueueControl>();
+    var controller = new JobsController(null!, jobAndQueue);
+
+    controller.CancelLoad(
+      materialId: 17,
+      request: new CancelLoadRequest()
+      {
+        ExpectedLoadCancellationId = "operation-1",
+        Reason = "wrong fixture",
+      },
+      operName: "operator"
+    );
+
+    jobAndQueue.Received(1).CancelLoad(17, "operation-1", "operator", "wrong fixture");
+  }
+
+  [Test]
+  public void SignalMaterialForQuarantineForwardsOperatorAndReason()
+  {
+    var jobAndQueue = Substitute.For<IJobAndQueueControl>();
+    var controller = new JobsController(null!, jobAndQueue);
+
+    controller.SignalMaterialForQuarantine(17, "operator", "wrong fixture");
+
+    jobAndQueue.Received(1).SignalMaterialForQuarantine(17, "operator", "wrong fixture");
+  }
+
+  [Test]
+  public void QuarantineQueuedMaterialForwardsOperatorAndReason()
+  {
+    var jobAndQueue = Substitute.For<IJobAndQueueControl>();
+    var controller = new JobsController(null!, jobAndQueue);
+
+    controller.QuarantineQueuedMaterial(17, "operator", "wrong fixture");
+
+    jobAndQueue.Received(1).QuarantineQueuedMaterial(17, "operator", "wrong fixture");
+  }
+
+  [Test]
+  public void InvalidationReturnsTheBackendMaterialDetails()
+  {
+    var jobAndQueue = Substitute.For<IJobAndQueueControl>();
+    var details = new MaterialDetails()
+    {
+      MaterialID = 17,
+      PartName = "part",
+      NumProcesses = 2,
+    };
+    jobAndQueue.InvalidatePalletCycle(17, 1, "operator", "new-casting", null).Returns(details);
+    var controller = new JobsController(null!, jobAndQueue);
+
+    var result = controller.InvalidatePalletCycle(
+      materialId: 17,
+      process: 1,
+      operName: "operator",
+      changeCastingTo: "new-casting",
+      changeJobUniqueTo: null
+    );
+
+    result.ShouldBe(details);
+    jobAndQueue.Received(1).InvalidatePalletCycle(17, 1, "operator", "new-casting", null);
+  }
+
+  [Test]
+  public async Task BadRequestExceptionsBecomeHttp400()
+  {
+    var jobAndQueue = Substitute.For<IJobAndQueueControl>();
+    jobAndQueue
+      .When(x => x.CancelLoad(17, "operation-1", "operator", "reason"))
+      .Do(_ => throw new BadRequestException("malformed cancellation"));
+    var controller = new JobsController(null!, jobAndQueue);
+
+    var context = await InvokeThroughMiddleware(() =>
+    {
+      controller.CancelLoad(
+        17,
+        new CancelLoadRequest() { ExpectedLoadCancellationId = "operation-1", Reason = "reason" },
+        "operator"
+      );
+      return Task.CompletedTask;
+    });
+
+    context.Response.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+  }
+
+  [Test]
+  public async Task ConflictExceptionsBecomeHttp409()
+  {
+    var jobAndQueue = Substitute.For<IJobAndQueueControl>();
+    jobAndQueue
+      .InvalidatePalletCycle(17, 2, "operator", null, null)
+      .Returns(_ => throw new ConflictRequestException("stale proposal"));
+    var controller = new JobsController(null!, jobAndQueue);
+
+    var context = await InvokeThroughMiddleware(() =>
+    {
+      controller.InvalidatePalletCycle(
+        materialId: 17,
+        process: 2,
+        operName: "operator",
+        changeCastingTo: null,
+        changeJobUniqueTo: null
+      );
+      return Task.CompletedTask;
+    });
+
+    context.Response.StatusCode.ShouldBe(StatusCodes.Status409Conflict);
+  }
+
+  private static async Task<HttpContext> InvokeThroughMiddleware(Func<Task> request)
+  {
+    var context = new DefaultHttpContext();
+    context.Response.Body = new MemoryStream();
+    var middleware = new ErrorHandlingMiddleware(_ => request());
+
+    await middleware.Invoke(context);
+
+    return context;
+  }
+}


### PR DESCRIPTION
# PR 411 Server-Side Follow-Up Plan

## Scope and release assumptions

PR #411 establishes the right overall separation between cycle invalidation, load-station
cancellation, and quarantine handling. This follow-up tightens the server-side contracts before the
final **v17.0.0** release.

Breaking API and backend-interface changes are acceptable in v17. Compatibility shims for the old
`AllowQuarantineToCancelLoad` behavior are not required.

---

## Core design: one authoritative material operation

A useful model is that FMS Insight or the custom backend proposes the next material operation, and
the operator may accept that operation or say, “No, I want to do something else.”

Only one physical or history-changing operation should be authoritative for a piece of material at a
time.

- **Add-to-queue proposal**: A scanned or otherwise identified material is outside active cell flow
  and FMS Insight (client) proposes adding it to a queue for a specific process. The allowed
  commands are to accept the queue addition, or reject the proposal through cycle
  invalidation/reassignment. FMS Insight responsibility.

- **Load-station operation**: Material participates in an advertised load-station instruction. The
  allowed commands are to proceed with the proposed operation, `CancelLoad` if allowed, or reorder
  the queue. They are all handled entirely by the custom backend, to ensure the entire operation is
  canceled or adjusted correctly.

- **Automated production flow**: Material is under automation control and is not part of a
  cancellable load-station operation. The allowed command is `SignalMaterialForQuarantine`. FMS
  Insight records the intent; the custom backend acts on it later.

- **Human-controlled queue state**: Material is waiting in a queue with no active operation. The
  allowed commands are queue reordering or to directly quarantine it or remove it from queues. This
  is responsibility of FMS Insight.

The above views this from the state. The same thing but viewed from the perspective of the
operations is:

- **Cycle invalidation** can occur when the operator scans a part and the system proposes to add it
  to a queue to run a process. The operator may indicate "I do not wish to do that." It edits
  historical production events and may optionally change a material’s assignment.
- **Cancel Load** can occur when the system proposes an operation or collection of operations at the
  load station. The operator can retract a currently advertised operator instruction at a load
  station while the backend can still safely cancel and recalculate that instruction.
- **Signal for Quarantine** can occur when a piece of material is under automation control. It
  records that material already committed to automated production flow should be handled differently
  when it eventually returns to operator-controlled flow.
- **Direct Quarantine/Removal** can occur for material in a queue with no active operations. The
  material is either removed or moved directly to a quarantine queue depending on the configuration.
- **Queue Reordering** can occur at any time. The queue order is one input into the next operation
  calculation, and if several pieces of material are valid, queue reordering may change the
  operation. (It may also not change if only one piece of material is currently acceptable.) FMS
  Insight handles the queue reordering, but the load/unload operation calculation is handled
  entirely by the backend.

### Load/Unload Precedence Rule

If a material is part of a load/unload operation, that takes precedence over the other flows.

While a material belongs to an advertised load-station operation:

- If material is involved in a load operation but no `CancellationId` is present, it means the
  backend does not support cancellation of this material from the UI and the operation must be
  completed. (Some systems might offer an out-of-band cancellation such as a button on the shop
  floor.)
- If `CancellationId` is present, then `CancelLoad` is allowed. The backend may then change its
  location, assignment, historical processing state, or disposition.
- Cycle invalidation must be rejected (even if cancellation id is not present).
- Deferred quarantine signaling must be rejected.
- Direct queued-material quarantine or removal must be rejected.
- Queue reordering is allowed (but the backend may choose or not to change the operation).
- The custom cancellation handler may choose to requeue, quarantine, remove, or otherwise alter the
  affected material, but it is responsible for performing all required state transitions atomically.

Metadata-only actions that do not change material ownership or production history may remain
available such as adding notes, but all material-mutating commands should be audited during
implementation.

---

## 1. Centralize operation eligibility in `JobsAndQueuesFromDb`

`JobsAndQueuesFromDb` already owns the central change lock and current reconstructed state. It
should also be the authoritative place for deciding which class of material operation is currently
valid.

Add a small internal classification or validation helper used by cancellation, quarantine,
queued-material disposition, and invalidation. The exact type name is not important, but the logic
should distinguish:

1. **Active load-station operation**

   - Part of a load/unload operation.

2. **Automation-controlled material**

   - The material is on a pallet, in a backend-controlled basket or carrier, or otherwise
     represented as under automation control.
   - No load/unload action is currently active.

3. **Human-controlled queued material**

   - Location is `InQueue`.
   - Action is `Waiting`.
   - No load/unload action is currently active.

4. **Eligible add-to-queue proposal**

   - The material is not queued and not under automation control.
   - No load/unload action is currently active.
   - Repository history supports the proposed next-process operation.

Perform these checks while `_changeLock` is held so synchronization, queue changes, and operator
commands cannot interleave with the decision.

Use:

- `400 Bad Request` for malformed commands or unsupported request shapes.
- `409 Conflict` when the command was valid when displayed but no longer matches current material
  state.

Do not make `CancelLoad` depend on a particular `ActionType`, material location, or pallet-location
enum. The custom backend is authoritative about whether a complete load-station instruction remains
safely retractable.

---

## 2. Finalize the Cancel Load extension contract

### Retain established terminology

FMS Insight already uses “load” as the umbrella term for operator work at a load station, including
loading, unloading, basket transfers, and unload/reload operations.

Retain:

- `LoadCancellationId`
- `ILoadCancel<St>`
- `CancelLoad`
- The Cancel Load API command

Document that a “load cancellation” means cancellation of one complete operator-facing load-station
instruction, not only an `ActionType.Loading` action.

Suggested summary:

> A load cancellation represents cancellation of an operator-facing load-station instruction. The
> instruction may include loading, unloading, basket transfers, or unload/reload operations.

### Accept one optional handler

Change the `JobsAndQueuesFromDb` constructor from an enumerable of handlers to one optional handler:

```csharp
ILoadCancel<St>? loadCancelHandler = null
```

Store it as a single nullable field.

Valid configurations are:

- No handler and no advertised cancellation IDs.
- One handler and zero or more advertised cancellation groups.

If reconstructed state advertises any cancellation ID while no handler is configured, treat that as
a backend configuration error during synchronization rather than waiting for an operator request to
produce a runtime 500.

### Require valid advertised IDs

`LoadCancellationId` must be either:

- `null`, meaning no cancellation capability; or
- A nonempty, non-whitespace opaque token.

A blank advertised token is a backend bug. Validate this while accepting reconstructed state.

The HTTP request must still reject a missing or blank expected ID with `400 Bad Request`.

### Operation-instance identity

A cancellation ID identifies one specific currently advertised atomic operation, not a reusable slot
or operation category.

All material belonging to the same atomic cancellation operation must carry the same ID.

The ID must:

- Remain stable while the advertised operation is unchanged.
- Change whenever group membership or cancellation behavior changes.
- Be opaque outside the backend that constructs it.
- Not be reused for a different operation while an old client request could still contain it.

The general rule is:

> If two requests would cause materially different cancellation effects, they must have different
> cancellation IDs.

### Custom-backend token construction

Replace static identifiers such as:

```text
basket-lul-cancel:load:load-slot2
```

with operation-instance identifiers such as:

```text
basket-lul-cancel:v1:load:load-slot2:{operation-hash}
```

Build the hash from a canonical, deterministic representation of every input that affects the
handler’s behavior.

For material loaded from a queue, include at least:

- Material ID.
- The `AddToQueue` event counter establishing the current queue admission.
- Load slot or station-operation identity.
- Pallet, basket, queue, face, or position where relevant.
- Any other value that would change cancellation effects.

For unload or unload/reload material, use the durable event or instruction identity that establishes
the current unloadable or reloadable state.

Sort grouped material and other unordered inputs before hashing.

Do not use only the maximum event counter for a group. Group membership can change while the maximum
counter remains unchanged.

Avoid a global `MAX(Counter)` unless no causally specific durable identity exists; unrelated cell
activity should not churn otherwise unchanged cancellation IDs.

### Consumed-token lifecycle

Duplicate protection remains in `JobsAndQueuesFromDb`.

After a handler returns successfully:

- Add the ID to `_consumedLoadCancellationIds`.
- Reject another request with the same ID before invoking the handler.
- Keep the ID consumed while reconstructed state still advertises it.
- Remove it only after it disappears from reconstructed state.

Conceptually, after each successful reconstruction:

```csharp
var currentlyAdvertisedIds = st.CurrentStatus.Material
  .Select(m => m.Action.LoadCancellationId)
  .Where(id => !string.IsNullOrWhiteSpace(id))
  .ToImmutableHashSet();

_consumedLoadCancellationIds =
  _consumedLoadCancellationIds.Intersect(currentlyAdvertisedIds);
```

A new operation in the same logical slot must have a new operation-instance ID and is therefore
immediately cancellable.

### Handler execution contract

Document on `ILoadCancel<St>` that:

- `JobsAndQueuesFromDb` validates the selected material, expected ID, complete group, and
  consumed-ID state before invocation.
- The handler runs while `_changeLock` is held.
- The handler receives the selected material and the complete atomic cancellation group.
- The handler must durably record all cancellation effects before returning.
- The handler should be short-running and avoid unnecessary blocking or network I/O.
- The handler must be atomic or safely idempotent if external effects can occur before an exception.
- Throwing means failure: the ID is not consumed and automatic state recalculation is not requested.
- The backend must stop advertising the old ID after cancellation, or continue to tolerate it being
  rejected as consumed until reconstructed state catches up.

Rename the collection parameter from `material` to `materials` or `cancellationGroup`.

---

## 3. Split deferred quarantine signaling from direct queue disposition

The current `SignalMaterialForQuarantine` path combines two different operations. Separate them.

### Deferred signal for automation-controlled material

`SignalMaterialForQuarantine` should apply only when:

- The material is under automation control.
- It is not part of an advertised load-station operation.
- The material can eventually leave automation control through a supported path.

The command records a durable quarantine intent. It does not immediately move or remove material.

The custom backend is responsible for observing the event and changing later automation behavior so
the material is:

- Sent to the configured quarantine queue;
- Removed from normal production flow; or
- Otherwise handled according to backend-specific rules.

Reject with `409 Conflict` when:

- `LoadCancellationId` is present;
- The material is part of a load/unload operation;
- The material is currently waiting in a queue;
- The material is otherwise not under automation control; or
- The current operation no longer supports deferred quarantine.

### Direct quarantine for human-controlled queued material

Add or expose a distinct server command for direct queued-material quarantine, preferably named
`QuarantineQueuedMaterial`.

It is valid only when:

- Location is `InQueue`.
- Action is `Waiting`.
- `LoadCancellationId` is absent.
- No other active material operation owns the material.

Behavior:

- If a quarantine queue is configured, move the material directly to that queue.
- If no quarantine queue is configured, remove the material from all queues.
- Preserve operator and reason audit information.
- Recalculate current state after success.

This operation is generic FMS Insight behavior and does not call the custom load-cancellation
handler.

Keep explicit `RemoveMaterialFromAllQueues` as a separate human-controlled queue action. It must use
the same eligibility rule and reject material participating in a load-station operation.

`SignalMaterialForQuarantine` should no longer directly move free or queued material.

### Interaction with Cancel Load

When `CancelLoad` is invoked, the custom backend may decide that the correct result is effectively
quarantine, removal, requeueing, or a different station plan. That is intentionally backend-owned.

The generic server must not attempt to perform a second quarantine or removal operation alongside
the handler.

---

## 4. Restrict invalidation to rejecting an add-to-queue proposal

Cycle invalidation should no longer be treated as a general historical editing command.

Its intended use is:

1. FMS Insight identifies or scans material.
2. Based on current history, FMS Insight proposes adding it to a queue to run a specific process.
3. The operator rejects that proposal because the recorded history or assignment is wrong.
4. The operator either:

   - Invalidates the most recent process; or
   - Invalidates all processes and optionally changes the job or casting assignment.

The server does not need to know that the request originated from a scanner. It must verify that the
material is still in the same state as a valid add-to-queue proposal.

### Allowed invalidation shapes

Allow only:

1. **Invalidate the most recent process**

   - No job or casting reassignment.
   - The requested process must equal the most recent non-invalidated process represented by the
     invalidatable history.

2. **Invalidate all processes**

   - Use the canonical value `process == 1`.
   - May optionally change the job or casting assignment.

Reject:

- Arbitrary invalidation beginning at an older middle process.
- Reassignment combined with anything other than all-process invalidation.
- Process values less than 1.
- Requests where no currently valid process remains to invalidate.

### Eligibility rules

Before mutation, verify the selected material and every material affected through shared cycle
events:

- Has no active load/unload operation or `LoadCancellationId`.
- Is not in a queue.
- Is not on a pallet, in an automated basket or carrier, or otherwise under automation control.
- Is not participating in another active material operation.
- Still has the history expected by the requested invalidation shape.

A request that was previously valid but is now stale should return `409 Conflict`.

A malformed or unsupported invalidation shape should return `400 Bad Request`.

### Calculate and validate the complete affected set before mutation

Refactor the repository invalidation implementation so it:

1. Calculates all counters to invalidate.
2. Calculates every affected `(materialId, process)` pair.
3. Validates the complete affected set against queue and operation-ownership constraints.
4. Performs event invalidation and path-detail deletion.
5. Writes the single invalidation event.
6. Commits once.

No event, path detail, assignment, or queue state may be partially changed when validation fails.

`JobsAndQueuesFromDb` owns current-state and operation validation under `_changeLock`. `EventLog`
owns transactional event and queue validation. Arrange the API so the complete affected set is
checked by both layers before mutation without maintaining two different definitions of that set.

---

## 5. Restore assignment-first event semantics

`InvalidateAndChangeAssignment` should create an invalidation event describing the material’s new
assignment. This was accidentally changed during PR 411 and should go back to the previous behavior.

Inside the existing database transaction:

1. Update `matdetails` to the new job or casting.
2. Calculate, validate, and invalidate all affected cycles.
3. Write the invalidation event.
4. Commit.
5. Publish `OnNewLogEntry` callbacks after commit.

If queue or operation validation throws, disposal of the uncommitted transaction rolls back the
assignment update and all other writes.

Add this comment near the ordering:

> Update the assignment before creating the invalidation event so the event describes the material’s
> new assignment. Both operations use the same transaction, so a validation failure during
> invalidation rolls back the assignment update.

The returned event, live callback event, and historically reloaded event must all contain the same
new job or casting metadata. Prior events already preserve the old assignment.

Keep request-shape validation in `JobsAndQueuesFromDb`:

- `process == 1` is required when changing job or casting.
- Partial invalidation cannot change assignment.
- Do not add a process parameter to `InvalidateAndChangeAssignment`; the repository method is
  inherently an all-process operation.

---

## 6. HTTP, OpenAPI, and migration updates

### Cancel Load

Document:

- `200 OK`: cancellation succeeded.
- `400 Bad Request`: expected cancellation ID is missing or blank.
- `409 Conflict`: material, group, or ID is no longer current, or the ID has already been consumed.
- `500 Internal Server Error`: backend configuration is invalid or the handler fails unexpectedly.

### Deferred quarantine signal

Document:

- `200 OK`: quarantine intent recorded.
- `400 Bad Request`: malformed request.
- `409 Conflict`: material is part of a load-station operation, is not automation-controlled, or is
  no longer eligible for deferred quarantine.

### Direct queued-material quarantine or removal

Document:

- `200 OK`: material was moved to the quarantine queue or removed.
- `400 Bad Request`: malformed request.
- `409 Conflict`: material is not waiting in a queue, participates in a load-station operation, or
  has otherwise changed state.

### Invalidation

Document:

- `200 OK`: requested invalidation completed.
- `400 Bad Request`: invalid process value or unsupported invalidation/reassignment shape.
- `409 Conflict`: proposal is stale, material ownership changed, or selected or affected material is
  in an active operation.

Add appropriate `ProducesResponseType` declarations and regenerate:

- `server/fms-insight-api.json`
- The generated TypeScript API client

Investigate duplicated names in generated OpenAPI `required` arrays, including
`ExpectedLoadCancellationId`. Fix the generation issue if practical; at minimum, ensure the
checked-in schema passes the project’s generation and validation tooling.

---

## 7. Server and backend test plan

### Operation exclusivity

Add a state-matrix test suite proving:

- Material with `LoadCancellationId` can be cancelled.
- The same material cannot be invalidated.
- The same material cannot be signaled for quarantine.
- The same material cannot be directly quarantined or removed from queues.
- Automation-controlled material without a cancellation ID can be signaled for quarantine but cannot
  use direct queue disposition or invalidation.
- Waiting queued material without a cancellation ID can be directly quarantined or removed but
  cannot use deferred quarantine signaling or invalidation.
- Eligible add-to-queue proposal material can use only the supported invalidation shapes.
- Material may be reordered in the queue.

You may not need to add new tests, instead adjust existing tests so that they cover this behavior.
If one flow is not covered, only then should a new test be added.

### Cancellation tokens

Private-backend tests should prove:

- The same unchanged operation produces the same ID.
- Removing and re-adding the same material changes the ID because the causal queue-admission event
  changes.
- Replacing any member of a group changes the ID.
- Reordering the same group does not change the ID.
- Changing slot, operation type, pallet, basket, face, queue, or another behavior-defining input
  changes the ID.
- Unload/reload groups use the durable identities that establish their current station work.
- Loading, unloading, and unload/reload actions may share one ID when they form one atomic station
  instruction.
- No ID is advertised after the instruction is partially completed or no longer retractable.

Framework tests should prove:

- Blank advertised IDs are rejected as backend state errors.
- Advertising an ID without a configured handler is rejected as a backend configuration error.
- A successful cancellation consumes the ID.
- Reconstructing state with the same ID keeps it consumed.
- A duplicate request does not invoke the handler twice.
- The ID is forgotten after it disappears from reconstructed state.
- A later operation with a new ID in the same logical slot succeeds.
- The handler receives the selected material, complete group, exact ID, operator, reason, state, and
  repository.
- A handler exception does not consume the ID and permits a later retry.
- Recalculation is requested only after success.

### Quarantine

Add tests proving:

- Deferred quarantine records an event for eligible automation-controlled material.
- Deferred quarantine performs no immediate queue move or removal.
- Material with a cancellation ID is rejected.
- Waiting queued material is rejected by the deferred-signal command.
- Direct queued quarantine moves material to the configured quarantine queue.
- Without a configured quarantine queue, direct quarantine removes material from all queues.
- Explicit queue removal uses the same eligibility checks.
- Operator and reason information are preserved.
- The custom backend can later observe and act on the deferred quarantine event.

### Invalidation

Add tests proving:

- Only the most recent process can be partially invalidated.
- An arbitrary older process is rejected.
- `process == 1` invalidates all processes.
- Job and casting changes require `process == 1`.
- A stale process proposal returns conflict.
- Selected or peer affected material in a queue blocks the operation.
- Selected or peer affected material under automation control blocks the operation.
- Selected or peer affected material with a cancellation ID blocks the operation.
- Validation failure leaves events, path details, assignments, and queue state unchanged.
- Shared pallet and basket events invalidate all affected material consistently.
- Normal invalidation without reassignment still works for the most recent process.

### Assignment and event consistency

Add tests proving:

- A rejected reassignment rolls back the original job or casting and process count.
- No invalidation event is written after rejection.
- Queue membership and existing logs remain unchanged after rejection.
- The returned invalidation event contains the new assignment.
- `OnNewLogEntry` receives the new assignment.
- Reloading the event through `GetLogForMaterial` returns the same assignment.
- Both job reassignment and casting reassignment are covered.

### HTTP behavior

Add controller or integration tests for the documented 200, 400, and 409 outcomes of:

- Cancel Load.
- Deferred quarantine signal.
- Direct queued-material quarantine or removal.
- Invalidation and reassignment.

Verify operator name and reason forwarding where supported.

---

## Server Acceptance criteria

The server-side follow-up is complete when:

- Every material-changing command covered by this plan has one unambiguous operation owner.
- A nonblank `LoadCancellationId` makes Cancel Load the exclusive physical or history-changing
  command for the advertised station operation.
- Cancellation IDs identify operation instances and cannot collide with later work.
- Duplicate cancellation requests cannot invoke the handler twice.
- Only one optional cancellation handler can be configured.
- Deferred quarantine is limited to automation-controlled material and records intent without
  immediate queue mutation.
- Direct quarantine or removal is limited to waiting queued material with no active operation.
- Invalidation is limited to rejecting a current add-to-queue proposal: most recent process or all
  processes only.
- Every material affected by shared events is validated before invalidation.
- Reassignment updates occur before invalidation-event creation inside one transaction.
- Returned, live, and reloaded invalidation events agree on the new assignment.
- Expected 400 and 409 outcomes are documented and tested.
- Existing tests cover the new flow and there are no longer any old outdated, low-quality tests.

# Client

The UI should expose familiar operator intentions rather than the distinction between server
endpoints:

- **Cancel Load** — reject an active load-station instruction.
- **Quarantine** or **Scrap** — change the eventual disposition of material.
- **Remove from Queue** — clear queued state so the material can be rescanned, corrected, and
  re-added.
- **Invalidate Cycle** — reject the history or assignment behind a proposed add-to-queue operation.
- **Queue reordering** — change which eligible queued material the backend considers first.

The client should never show commands that compete for ownership of the same material operation.

---

## 1. Add one shared client-side operation policy

Create a small pure TypeScript module, for example:

```text
client/insight/src/data/material-operation-policy.ts
```

The policy should classify a live `IInProcessMaterial` into one of these states:

```typescript
type MaterialOperationState =
  | {
      kind: "ActiveLoadStationOperation";
      cancellationId: string | null;
    }
  | {
      kind: "AutomationControlled";
    }
  | {
      kind: "HumanControlledQueue";
    }
  | {
      kind: "AddToQueueProposal";
    };
```

Should conceptually match the equivalent rules added to the server in PR 412.

### Classification rules

#### Active load-station operation

Classify as active load-station work when either:

- `LoadCancellationId` is nonblank; or
- The action is:

  - `Loading`
  - `UnloadToInProcess`
  - `UnloadToCompletedMaterial`
  - `LoadingToBasket`

A cancellation ID means the operation can be cancelled through Insight.

A load-station action without a cancellation ID means the operation is active but cannot be
cancelled through Insight. This includes systems such as Mazak, where the operator may need to use
an out-of-band control such as NoSet.

#### Human-controlled queue

Classify as human-controlled queued material only when:

- Location is `InQueue`.
- Action is `Waiting`.
- No active load-station operation exists.

#### Automation-controlled

Classify as automation-controlled when no load-station operation is active and the material is:

- `OnPallet`;
- `InBasket`; or
- Machining.

#### Add-to-queue proposal

Everything else that is eligible for the scan/add workflow is an add-to-queue proposal, normally:

- Historical material absent from current status; or
- Free, waiting material not involved in another operation.

Do not treat absence from `CurrentStatus.Material` as an error. Historical material opened through
barcode or serial lookup is the primary invalidation use case.

### Helper functions

Expose focused helpers rather than duplicating conditions in components:

```typescript
isActiveLoadStationOperation(material);
canCancelLoad(material);
canSignalQuarantine(material);
canDirectlyQuarantine(material);
canRemoveFromQueue(material);
canInvalidateMaterial(materialOrNull);
canAddMaterialToQueue(materialOrNull);
```

Unit-test this policy exhaustively. The client policy should mirror the server policy closely enough
that normal UI usage does not rely on a `409` response to discover command eligibility.

The server remains authoritative, so stale-state conflicts must still be handled.

---

## 2. Preserve Cancel Load as the active-operation exception

Keep `CancelLoadButton` largely as implemented.

Continue to:

- Show the button only when the selected material has a nonblank cancellation ID.
- Snapshot the selected material, cancellation ID, and complete cancellation group when the
  confirmation dialog opens.
- Submit the snapshotted ID rather than a subsequently refreshed ID.
- Keep the dialog open and show the server response when cancellation fails.
- Clear prior errors whenever the dialog is newly opened.
- List every material sharing the displayed cancellation ID.

Use the shared operation policy to confirm that the material belongs to an active load-station
operation.

### Active operation without UI cancellation

When an active load-station operation has no cancellation ID:

- Do not show Cancel Load.
- Do not show Quarantine, Scrap, Remove from Queue, Add to Queue, Swap Material, or Invalidate
  Cycle.
- Keep metadata and informational actions such as notes, printing, workorder metadata, inspections,
  and instructions where otherwise valid.
- Show a small informational message in the material dialog rather than a disabled button:

> This material is part of the current load/unload operation. Complete the operation or cancel it at
> the machine control before making other changes.

This explains the Mazak/NoSet case without presenting an action that Insight cannot perform.

Avoid mentioning Mazak specifically in the generic UI text.

---

## 3. Keep one Quarantine flow with state-specific behavior

Refactor `QuarantineMatButton` so the operator still sees one conceptual Quarantine/Scrap workflow.
Internally, dispatch to the correct endpoint based on the shared operation policy.

### Automation-controlled material

For eligible pallet or basket material:

- Show **Quarantine**.
- Call `SignalMaterialForQuarantine`.
- Explain that the current automated operation will continue.
- Explain that the material will be diverted when it returns to operator control.

Suggested dialog wording when a quarantine queue exists:

> The current automated operation will continue. When the material leaves automation control, it
> will be sent to **{quarantine queue}**.

Without a quarantine queue:

> The current automated operation will continue. When the material leaves automation control, it
> will be removed from normal production flow as scrap.

Use wording such as “leaves automation control” rather than always saying “after unload,” because
the material may currently be in a basket.

If `quarantineAfterUnload` is already set:

- Do not offer the command again.
- Show a compact status such as **Quarantine requested** in the material details.
- Do not open another confirmation dialog.

### Waiting material in a normal queue

For waiting queued material with no active operation:

- Continue to show a **Quarantine** button when a quarantine queue is configured.
- Call `QuarantineQueuedMaterial`.
- Describe the immediate move to the configured quarantine queue.

Without a configured quarantine queue:

- Label the button **Scrap** rather than Quarantine.
- Call `QuarantineQueuedMaterial`.
- Explain that the material will be removed from the queue and treated as scrap.

The direct and deferred server endpoints should not result in separate top-level UI concepts.

### Material already in a quarantine queue

Retain the existing **Remove from System** behavior:

- Show **Remove** or **Remove from System**.
- Call `RemoveMaterialFromAllQueues`.
- Do not offer another Quarantine action.

### Active load-station operation

Return no Quarantine/Scrap action whenever a load-station action is active, regardless of whether a
cancellation ID is present.

### Free material

Do not show Quarantine or Scrap for free material.

Free or historical material belongs to the add-to-queue proposal workflow. It can be assigned and
added, or its history can be invalidated where applicable.

---

## 4. Preserve Remove from Queue as the recovery path

Keep **Remove from Queue** separate from Quarantine because it represents a different operator
intention.

Its purpose is:

> Clear the current queued state so the material can be rescanned, corrected, and added again.

Show it only when:

- The material is waiting in a normal production queue.
- No load-station operation is active.
- The queue is not already classified as a quarantine queue.

The confirmation dialog should say:

> Remove this material from its current queue. Its production history will remain available. You can
> scan it again to correct its history or assignment and then add it back to a queue.

After success:

- Close the material dialog or return to a summary.
- Let the refreshed current status remove the material from the queue display.
- Do not automatically open invalidation.
- The operator can rescan the physical part and begin again.

This keeps the recovery sequence explicit and dependable:

1. Remove from Queue.
2. Rescan the part.
3. Invalidate or change assignment when necessary.
4. Add it back to the correct queue.

Do not combine this action with Quarantine merely because both initially remove material from its
current queue.

---

## 5. Restrict and simplify the invalidation UI

Invalidation should appear only as an alternative to accepting an add-to-queue proposal.

### Eligibility

Show `InvalidateCycleDialogButton` only when:

- Material history has been identified through a barcode, serial, or material lookup.
- The material is absent from current status, or is explicitly classified as an add-to-queue
  proposal.
- The material has at least one valid completed process or can be reassigned to a proposed
  casting/job.
- The relevant existing FMS setting permits invalidation on that page.

Do not show invalidation for:

- Waiting queued material.
- Pallet or basket material.
- Active load/unload material.
- Material with a cancellation ID.
- Machining material.

This naturally enforces the remove → rescan → invalidate → re-add workflow.

### Allowed selections

The current selector should no longer list every process from 1 through the last process.

Offer only:

1. **Invalidate Process N**

   - `N` is the most recently completed process.
   - Sends `process = N`.

2. **Invalidate All Processes**

   - Show when more than one process has been completed.
   - Sends `process = 1`.

3. **Invalidate Everything and Change to {casting}**

   - Sends `process = 1` with `changeCastingTo`.

4. **Invalidate Everything and Change to Job {job}**

   - Sends `process = 1` with `changeJobUniqueTo`.

Do not offer arbitrary middle-process invalidation.

When only process 1 exists, avoid displaying separate “latest process” and “all processes” entries
that perform the same operation.

### After success

Keep the material dialog open on the returned material details.

Reset the invalidation state and let the normal Add to Queue controls become available. This allows
an operator who has already rescanned the part to proceed directly from correction to re-adding it.

On `409 Conflict`:

- Keep the dialog open.
- Show the server message.
- Do not silently change the selected operation.
- Allow current-status refresh to update the available choices.

---

## 6. Apply the operation policy to every mutating button

The policy must gate more than Quarantine and Invalidation.

Audit all material-dialog surfaces and hide conflicting physical or history-changing commands while
a load-station operation is active.

At minimum, update:

- `QuarantineMatButton`
- `CancelLoadButton`
- `InvalidateCycleDialogButton`
- Queue-page `AddToQueueButton`
- Load-station `AddMatButton`
- `SwapMaterialButtons`
- `RemoveFromQueuesButton`

The current Add to Queue checks should be replaced with the shared policy rather than checking only
`OnPallet`, `Loading`, and `LoadingToBasket`.

Keep available where otherwise permitted:

- Instructions
- Print Label
- Add Note
- Inspection signals
- Workorder metadata
- Other clearly metadata-only actions

Use the same policy on:

- Queue material dialogs.
- Load-station material dialogs.
- System overview dialogs.
- All Material dialogs.
- Inspection and closeout material dialogs.

This avoids page-specific discrepancies where the same material offers different commands depending
on which screen opened it.

---

## 7. Leave queue reordering independent

Do not disable queue drag-and-drop merely because one queued material participates in an active load
operation.

Queue ordering remains an input into future operation calculation:

- The operator may move a physically selected serial to the top.
- The client updates queue order as it does today.
- The backend recalculates proposed loading.
- The backend decides whether the already active operation changes.

Queue reordering should not be presented inside the material exception dialog and should not be
described as cancellation.

Add documentation explaining that queue order can influence the next proposal but cannot directly
override an already authoritative backend operation.

---

## 8. Update client network wrappers and hooks

PR 412 generates `JobsClient.quarantineQueuedMaterial`, but the handwritten `JobAPI` abstraction and
hooks must expose it.

Add to `JobAPI`:

```typescript
quarantineQueuedMaterial(
  materialId: number,
  operatorName: string | null,
  reason: string | undefined,
): Promise<void>;
```

Update:

- `backend.ts`
- `backend-mock.ts`
- Test substitutes and fake implementations

Add a hook such as:

```typescript
useQuarantineQueuedMaterial();
```

Retain:

- `useSignalForQuarantine()` for automation-controlled material.
- `useRemoveFromQueue()` for the correction/recovery path.

The quarantine component should select the proper hook from operation state; components outside the
quarantine flow should not select endpoints directly.

Consider renaming `useSignalForQuarantine` to `useSignalQuarantineAfterAutomation` only if that
improves clarity without creating excessive churn.

---

## 9. Normalize dialog error behavior

For Cancel Load, Quarantine, Scrap, Remove from Queue, and Invalidation:

- Clear the previous error whenever a dialog is newly opened.
- Clear the error after a successful operation.
- Keep the dialog open after a server failure.
- Display the server’s 400 or 409 response body.
- Disable only the submitting action while a request is running.
- Do not lose the operator-entered reason after a failed submission.
- Reset the reason after success or when starting a fresh operation.

When current status changes while a confirmation dialog is open:

- Preserve the snapshot used for submission.
- Let the server reject stale commands.
- Do not silently retarget the command to different material or a new operation.

---

## 10. Client test plan

### Pure operation-policy tests

Cover every action and location combination:

- Loading with cancellation ID.
- Loading without cancellation ID.
- Unload to in-process without cancellation ID.
- Unload to completed without cancellation ID.
- Loading to basket without cancellation ID.
- An unusual action carrying a cancellation ID.
- Waiting material in a queue.
- Waiting material on a pallet.
- Waiting material in a basket.
- Machining material.
- Free waiting material.
- Historical material absent from current status.

Verify the exact available commands for every state.

### Material-dialog integration tests

#### Active and cancellable load operation

Verify:

- Cancel Load is shown.
- Quarantine, Scrap, Remove from Queue, Add to Queue, Swap, and Invalidate are absent.
- Metadata actions remain as configured.

#### Active but not UI-cancellable operation

For every load/unload action without an ID, verify:

- Cancel Load is absent.
- Other mutating commands are absent.
- The machine-control informational message is visible.

Include an explicit Mazak-style unload case.

#### Automation-controlled material

Verify:

- Pallet material calls `signal-quarantine`.
- Basket material calls `signal-quarantine`.
- Dialog language describes deferred handling.
- Already-signaled material does not submit a duplicate request.
- Active unload material does not show the action.

#### Human-controlled queued material

Verify:

- Quarantine calls `quarantine-queued`.
- Scrap without a configured quarantine queue calls `quarantine-queued`.
- Remove from Queue calls the queue-removal endpoint instead.
- Material in a quarantine queue offers Remove from System, not Quarantine.
- Loading material in a queue offers neither queue disposition command.

#### Invalidation

Verify:

- Only the latest process and all-process choices are shown.
- Middle-process choices are absent.
- Assignment changes always send `process = 1`.
- Historical material absent from current status can invalidate.
- Queued, automated, and active-load material cannot.
- Successful invalidation leaves the material available for Add to Queue.
- A stale `409` remains visible in the dialog.

### Recovery-flow integration test

Add one end-to-end client test for the preferred operator recovery workflow:

1. Open waiting queued material.
2. Remove it from the queue.
3. Refresh current status without that material.
4. Rescan the same serial.
5. Select latest-process or all-process invalidation.
6. Submit invalidation.
7. Add the corrected material back to a queue.

This test should protect the simple “remove everything and try again” experience from future
refactoring.

### Queue-reordering regression test

Verify that:

- Waiting queued material remains draggable.
- Material participating in a load proposal remains draggable where it is currently shown in a
  sortable queue.
- Reordering does not reveal Quarantine, Remove, or Invalidation controls for active load work.

---

## Client Acceptance criteria

The client work is complete when:

- Active load-station work owns the material regardless of whether cancellation is available.
- Cancel Load is the only material-changing command shown for a cancellable active operation.
- No material-changing command is shown for an uncancellable active operation.
- Queue and automated quarantine use different endpoints but remain one recognizable operator flow.
- Remove from Queue remains a distinct correction/recovery action.
- Invalidation is available only as part of an add-to-queue proposal.
- The invalidation UI offers latest-process, all-process, and all-process-with-reassignment
  operations only.
- Queue reordering remains available and independent.
- Every material-dialog surface applies the same command policy.
- Stale server responses are shown clearly without silently changing the requested operation.
- The remove → rescan → invalidate → re-add workflow has an integration test.